### PR TITLE
Added dynamic grids 

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
@@ -42,6 +42,7 @@ class BrowserPreferences(
   val showProgressBar = preferenceStore.getBoolean("show_progress_bar", true)
   val centerGridTitles = preferenceStore.getBoolean("center_grid_titles", true)
   val mediaLayoutMode = preferenceStore.getEnum("media_layout_mode", MediaLayoutMode.LIST)
+  val manualGridColumnsEnabled = preferenceStore.getBoolean("manual_grid_columns_enabled", false)
 
   // Visibility preferences for folder card chips
   val showTotalVideosChip = preferenceStore.getBoolean("show_total_videos_chip", true)

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
@@ -2,6 +2,12 @@ package app.gyrolet.mpvrx.preferences
 
 import app.gyrolet.mpvrx.preferences.preference.PreferenceStore
 import app.gyrolet.mpvrx.preferences.preference.getEnum
+import app.gyrolet.mpvrx.preferences.preference.Preference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 /**
  * Preferences for the video browser (folder and video lists)
@@ -21,11 +27,19 @@ class BrowserPreferences(
   val folderViewMode = preferenceStore.getEnum("folder_view_mode", FolderViewMode.AlbumView)
 
   private val isTablet = context.resources.configuration.smallestScreenWidthDp >= 600
-  val folderGridColumnsPortrait = preferenceStore.getInt("folder_grid_columns_portrait", if (isTablet) 4 else 3)
-  val folderGridColumnsLandscape = preferenceStore.getInt("folder_grid_columns_landscape", 5)
+  val maxColumns = if (isTablet) 8 else 4
 
-  val videoGridColumnsPortrait = preferenceStore.getInt("video_grid_columns_portrait", if (isTablet) 4 else 2)
-  val videoGridColumnsLandscape = preferenceStore.getInt("video_grid_columns_landscape", 4)
+  private val _folderGridColumnsPortrait = preferenceStore.getInt("folder_grid_columns_portrait", if (isTablet) 4 else 3)
+  private val _folderGridColumnsLandscape = preferenceStore.getInt("folder_grid_columns_landscape", 5)
+
+  private val _videoGridColumnsPortrait = preferenceStore.getInt("video_grid_columns_portrait", if (isTablet) 4 else 2)
+  private val _videoGridColumnsLandscape = preferenceStore.getInt("video_grid_columns_landscape", 4)
+
+  val folderGridColumnsPortrait: Preference<Int> = CoercedPreference(_folderGridColumnsPortrait, maxColumns)
+  val folderGridColumnsLandscape: Preference<Int> = CoercedPreference(_folderGridColumnsLandscape, 8)
+
+  val videoGridColumnsPortrait: Preference<Int> = CoercedPreference(_videoGridColumnsPortrait, maxColumns)
+  val videoGridColumnsLandscape: Preference<Int> = CoercedPreference(_videoGridColumnsLandscape, 8)
 
   val showExtensionField = preferenceStore.getBoolean("show_extension_field", false)
   val showDurationField = preferenceStore.getBoolean("show_duration_field", true)
@@ -157,4 +171,22 @@ enum class ThumbnailMode {
         FrameAtPosition -> "Frame position"
         EmbeddedThumbnail -> "Embedded thumbnail"
       }
+}
+
+internal class CoercedPreference(
+  private val delegate: Preference<Int>,
+  private val maxVal: Int,
+) : Preference<Int> {
+  override fun key(): String = delegate.key()
+  override fun get(): Int = delegate.get().coerceIn(1, maxVal)
+  override fun set(value: Int) = delegate.set(value.coerceIn(1, maxVal))
+  override fun isSet(): Boolean = delegate.isSet()
+  override fun delete() = delegate.delete()
+  override fun defaultValue(): Int = delegate.defaultValue().coerceIn(1, maxVal)
+
+  override fun changes(): Flow<Int> =
+    delegate.changes().map { it.coerceIn(1, maxVal) }
+
+  override fun stateIn(scope: kotlinx.coroutines.CoroutineScope): StateFlow<Int> =
+    changes().stateIn(scope, SharingStarted.Eagerly, get())
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/FolderCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/FolderCard.kt
@@ -2,6 +2,7 @@ package app.gyrolet.mpvrx.ui.browser.cards
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -78,29 +79,39 @@ fun FolderCard(
   val showFolderPath by browserPreferences.showFolderPath.collectAsState()
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
   val showFolderThumbnails by browserPreferences.showFolderThumbnails.collectAsState()
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
   val context = androidx.compose.ui.platform.LocalContext.current
   val density = LocalDensity.current
   val thumbnailRepository = koinInject<ThumbnailRepository>()
   var folderThumbnail by remember(folder.bucketId) { mutableStateOf<android.graphics.Bitmap?>(null) }
 
-  LaunchedEffect(folder.bucketId, showFolderThumbnails, isGridMode) {
+  LaunchedEffect(folder.bucketId, showFolderThumbnails, isGridMode, manualGridColumnsEnabled, folderGridColumnsPortrait, folderGridColumnsLandscape) {
     if (isGridMode && showFolderThumbnails) {
       withContext(Dispatchers.IO) {
         val videos = app.gyrolet.mpvrx.repository.MediaFileRepository.getVideosInFolder(context, folder.bucketId)
         if (videos.isNotEmpty()) {
           val configuration = context.resources.configuration
           val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-          val folderGridColumnsPortraitVal = browserPreferences.folderGridColumnsPortrait.get()
-          val folderGridColumnsLandscapeVal = browserPreferences.folderGridColumnsLandscape.get()
-          val folderGridColumns = if (isLandscape) folderGridColumnsLandscapeVal else folderGridColumnsPortraitVal
           val screenWidthDp = configuration.screenWidthDp.dp
+          val contentHorizontalPadding = 8.dp
+          val itemSpacing = 2.dp
+          val usableWidth = screenWidthDp - (contentHorizontalPadding * 2) - itemSpacing
+          val folderMinWidth = 100.dp
+          val folderGridColumnsPref = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+          val folderGridColumns = if (manualGridColumnsEnabled) {
+            folderGridColumnsPref.coerceAtLeast(1)
+          } else {
+            (usableWidth / folderMinWidth).toInt().coerceAtLeast(1)
+          }
           val horizontalPadding = 32.dp
           val spacing = 8.dp
           val thumbWidthDp = if (folderGridColumns > 1) {
             val totalSpacing = spacing * (folderGridColumns - 1)
             ((screenWidthDp - horizontalPadding - totalSpacing) / folderGridColumns).coerceAtLeast(120.dp)
           } else {
-            160.dp
+            (screenWidthDp - horizontalPadding).coerceAtLeast(160.dp)
           }
           val aspect = 16f / 9f
           val thumbWidthPx = with(density) { thumbWidthDp.roundToPx() }
@@ -112,6 +123,8 @@ fun FolderCard(
           }
         }
       }
+    } else {
+      folderThumbnail = null
     }
   }
 
@@ -173,19 +186,34 @@ fun FolderCard(
       }
 
       if (isGridMode) {
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+        val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
+        val contentHorizontalPadding = 8.dp
+        val itemSpacing = 2.dp
+        val usableWidth = screenWidthDp - (contentHorizontalPadding * 2) - itemSpacing
+        val folderMinWidth = 100.dp
+        val folderGridColumnsPref = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+        val folderGridColumns = if (manualGridColumnsEnabled) {
+          folderGridColumnsPref.coerceAtLeast(1)
+        } else {
+          (usableWidth / folderMinWidth).toInt().coerceAtLeast(1)
+        }
+        val isSingleColumn = folderGridColumns == 1
+
+        val horizontalAlignment = if (isSingleColumn) {
+          Alignment.Start
+        } else {
+          if (centerGridTitles) Alignment.CenterHorizontally else Alignment.Start
+        }
+
         // GRID LAYOUT - Vertical arrangement
         Column(
           modifier = Modifier
             .fillMaxWidth()
             .padding(12.dp),
-          horizontalAlignment = if (centerGridTitles) Alignment.CenterHorizontally else Alignment.Start,
+          horizontalAlignment = horizontalAlignment,
         ) {
-          val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-          val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-          val configuration = LocalConfiguration.current
-          val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-          val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
-          val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
           val horizontalPadding = 32.dp
           val spacing = 8.dp
 
@@ -195,15 +223,21 @@ fun FolderCard(
             ((screenWidthDp - horizontalPadding - totalSpacing) / folderGridColumns).coerceAtLeast(120.dp)
           } else {
             // single column fallback
-            160.dp
+            (screenWidthDp - horizontalPadding).coerceAtLeast(160.dp)
           }
           val aspect = 16f / 9f
           val thumbHeightDp = thumbWidthDp / aspect
 
           Box(
-            modifier = Modifier
-              .width(thumbWidthDp)
-              .height(thumbHeightDp)
+            modifier = (if (isSingleColumn) {
+              Modifier
+                .fillMaxWidth()
+                .aspectRatio(aspect)
+            } else {
+              Modifier
+                .width(thumbWidthDp)
+                .height(thumbHeightDp)
+            })
               .clip(AppShapeScale.medium)
               .background(MaterialTheme.colorScheme.surfaceContainerHigh)
               .combinedClickable(
@@ -212,7 +246,9 @@ fun FolderCard(
               ),
             contentAlignment = Alignment.Center,
           ) {
-            val resolvedThumbnail = thumbnail ?: folderThumbnail?.asImageBitmap()
+            val resolvedThumbnail = if (showFolderThumbnails) {
+              thumbnail ?: folderThumbnail?.asImageBitmap()
+            } else null
             if (resolvedThumbnail != null) {
               androidx.compose.foundation.Image(
                 bitmap = resolvedThumbnail,
@@ -280,11 +316,11 @@ fun FolderCard(
 
           Text(
             folder.name,
-            style = MaterialTheme.typography.titleSmall,
+            style = if (isSingleColumn) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleSmall,
             color = if (isRecentlyPlayed) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurface,
             maxLines = maxLines,
             overflow = TextOverflow.Ellipsis,
-            textAlign = if (centerGridTitles) androidx.compose.ui.text.style.TextAlign.Center else androidx.compose.ui.text.style.TextAlign.Start,
+            textAlign = if (isSingleColumn) androidx.compose.ui.text.style.TextAlign.Start else (if (centerGridTitles) androidx.compose.ui.text.style.TextAlign.Center else androidx.compose.ui.text.style.TextAlign.Start),
           )
 
           if (showTotalVideosChip && folder.videoCount > 0) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
@@ -35,6 +35,7 @@ fun FolderSortDialog(
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
   val folderViewMode by browserPreferences.folderViewMode.collectAsState()
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
   val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
   val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
   val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
@@ -46,20 +47,20 @@ fun FolderSortDialog(
   val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
   val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
 
-  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
-      label = "Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = folderGridColumns,
+      label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
+      currentValue = folderGridColumns.coerceAtLeast(1),
       onValueChange = {
         if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
         else browserPreferences.folderGridColumnsPortrait.set(it)
       },
-      valueRange = if (isLandscape) 3f..5f else 2f..4f,
-      steps = if (isLandscape) 1 else 1,
+      valueRange = 1f..10f,
+      steps = 8,
     )
   } else null
 
-  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
       currentValue = videoGridColumns,
@@ -67,8 +68,8 @@ fun FolderSortDialog(
         if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
         else browserPreferences.videoGridColumnsPortrait.set(it)
       },
-      valueRange = if (isLandscape) 3f..5f else 1f..3f,
-      steps = if (isLandscape) 1 else 1,
+      valueRange = 1f..10f,
+      steps = 8,
     )
   } else null
 
@@ -189,6 +190,13 @@ fun FolderSortDialog(
       if (mediaLayoutMode == MediaLayoutMode.GRID) {
         add(
           VisibilityToggle(
+            label = "Manual Grid Columns",
+            checked = manualGridColumnsEnabled,
+            onCheckedChange = { browserPreferences.manualGridColumnsEnabled.set(it) },
+          )
+        )
+        add(
+          VisibilityToggle(
             label = "Folder Thumbnails",
             checked = showFolderThumbnails,
             onCheckedChange = { browserPreferences.showFolderThumbnails.set(it) },
@@ -218,16 +226,6 @@ fun VideoSortDialog(
   onSortOrderChange: (SortOrder) -> Unit,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
-  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
-  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
-  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-
-  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
-  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
   val appearancePreferences = koinInject<AppearancePreferences>()
   val showThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
   val showSizeChip by browserPreferences.showSizeChip.collectAsState()
@@ -242,30 +240,41 @@ fun VideoSortDialog(
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
   val folderViewMode by browserPreferences.folderViewMode.collectAsState()
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
 
-  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+
+  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = folderGridColumns,
+      currentValue = folderGridColumns.coerceAtLeast(1),
       onValueChange = {
         if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
         else browserPreferences.folderGridColumnsPortrait.set(it)
       },
-      valueRange = if (isLandscape) 3f..5f else 2f..4f,
-      steps = if (isLandscape) 1 else 1,
+      valueRange = 1f..10f,
+      steps = 8,
     )
   } else null
 
-  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
-      label = "Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
+      label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
       currentValue = videoGridColumns,
       onValueChange = {
         if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
         else browserPreferences.videoGridColumnsPortrait.set(it)
       },
-      valueRange = if (isLandscape) 3f..5f else 1f..3f,
-      steps = if (isLandscape) 1 else 1,
+      valueRange = 1f..10f,
+      steps = 8,
     )
   } else null
 
@@ -412,7 +421,14 @@ fun VideoSortDialog(
             onCheckedChange = { browserPreferences.showProgressBar.set(it) },
           )
         )
-        if (mediaLayoutMode == MediaLayoutMode.GRID && videoGridColumns > 1) {
+        if (mediaLayoutMode == MediaLayoutMode.GRID) {
+          add(
+            VisibilityToggle(
+              label = "Manual Grid Columns",
+              checked = manualGridColumnsEnabled,
+              onCheckedChange = { browserPreferences.manualGridColumnsEnabled.set(it) },
+            )
+          )
           add(
             VisibilityToggle(
               label = "Center Titles",
@@ -450,6 +466,44 @@ fun FileSystemSortDialog(
   val showExtensionField by browserPreferences.showExtensionField.collectAsState()
   val showDurationField by browserPreferences.showDurationField.collectAsState()
   val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+
+  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+
+  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
+    GridColumnSelector(
+      label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
+      currentValue = folderGridColumns.coerceAtLeast(1),
+      onValueChange = {
+        if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
+        else browserPreferences.folderGridColumnsPortrait.set(it)
+      },
+      valueRange = 1f..10f,
+      steps = 8,
+    )
+  } else null
+
+  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
+    GridColumnSelector(
+      label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
+      currentValue = videoGridColumns,
+      onValueChange = {
+        if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
+        else browserPreferences.videoGridColumnsPortrait.set(it)
+      },
+      valueRange = 1f..10f,
+      steps = 8,
+    )
+  } else null
 
   SortDialog(
     isOpen = isOpen,
@@ -516,74 +570,111 @@ fun FileSystemSortDialog(
       secondOptionLabel = "Grid",
       firstOptionIcon = Icons.Filled.ViewList,
       secondOptionIcon = Icons.Filled.GridView,
-      isFirstOptionSelected = true, // Always list mode
-      onViewModeChange = { /* Disabled - do nothing */ },
+      isFirstOptionSelected = mediaLayoutMode == MediaLayoutMode.LIST,
+      onViewModeChange = { isFirstOption ->
+        browserPreferences.mediaLayoutMode.set(
+          if (isFirstOption) MediaLayoutMode.LIST else MediaLayoutMode.GRID
+        )
+      },
     ),
-    folderGridColumnSelector = null,
-    videoGridColumnSelector = null,
+    folderGridColumnSelector = folderGridColumnSelector,
+    videoGridColumnSelector = videoGridColumnSelector,
     enableViewModeOptions = isAtRoot,
-    enableLayoutModeOptions = false, // Disabled/grayed out
-    visibilityToggles = listOf(
-      VisibilityToggle(
-        label = "Video Thumbnails",
-        checked = showVideoThumbnails,
-        onCheckedChange = { browserPreferences.showVideoThumbnails.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Full Name",
-        checked = unlimitedNameLines,
-        onCheckedChange = { appearancePreferences.unlimitedNameLines.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Extension",
-        checked = showExtensionField,
-        onCheckedChange = { browserPreferences.showExtensionField.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Duration",
-        checked = showDurationField,
-        onCheckedChange = { browserPreferences.showDurationField.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Path",
-        checked = showFolderPath,
-        onCheckedChange = { browserPreferences.showFolderPath.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Total Videos",
-        checked = showTotalVideosChip,
-        onCheckedChange = { browserPreferences.showTotalVideosChip.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Folder Size",
-        checked = showTotalSizeChip,
-        onCheckedChange = { browserPreferences.showTotalSizeChip.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Size",
-        checked = showSizeChip,
-        onCheckedChange = { browserPreferences.showSizeChip.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Resolution",
-        checked = showResolutionChip,
-        onCheckedChange = { browserPreferences.showResolutionChip.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Framerate",
-        checked = showFramerateInResolution,
-        onCheckedChange = { browserPreferences.showFramerateInResolution.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Subtitle",
-        checked = showSubtitleIndicator,
-        onCheckedChange = { browserPreferences.showSubtitleIndicator.set(it) },
-      ),
-      VisibilityToggle(
-        label = "Progress Bar",
-        checked = showProgressBar,
-        onCheckedChange = { browserPreferences.showProgressBar.set(it) },
-      ),
-    )
+    enableLayoutModeOptions = true, // Enabled layout selection
+    visibilityToggles = buildList {
+      add(
+        VisibilityToggle(
+          label = "Video Thumbnails",
+          checked = showVideoThumbnails,
+          onCheckedChange = { browserPreferences.showVideoThumbnails.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Full Name",
+          checked = unlimitedNameLines,
+          onCheckedChange = { appearancePreferences.unlimitedNameLines.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Extension",
+          checked = showExtensionField,
+          onCheckedChange = { browserPreferences.showExtensionField.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Duration",
+          checked = showDurationField,
+          onCheckedChange = { browserPreferences.showDurationField.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Path",
+          checked = showFolderPath,
+          onCheckedChange = { browserPreferences.showFolderPath.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Total Videos",
+          checked = showTotalVideosChip,
+          onCheckedChange = { browserPreferences.showTotalVideosChip.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Folder Size",
+          checked = showTotalSizeChip,
+          onCheckedChange = { browserPreferences.showTotalSizeChip.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Size",
+          checked = showSizeChip,
+          onCheckedChange = { browserPreferences.showSizeChip.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Resolution",
+          checked = showResolutionChip,
+          onCheckedChange = { browserPreferences.showResolutionChip.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Framerate",
+          checked = showFramerateInResolution,
+          onCheckedChange = { browserPreferences.showFramerateInResolution.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Subtitle",
+          checked = showSubtitleIndicator,
+          onCheckedChange = { browserPreferences.showSubtitleIndicator.set(it) },
+        )
+      )
+      add(
+        VisibilityToggle(
+          label = "Progress Bar",
+          checked = showProgressBar,
+          onCheckedChange = { browserPreferences.showProgressBar.set(it) },
+        )
+      )
+      if (mediaLayoutMode == MediaLayoutMode.GRID) {
+        add(
+          VisibilityToggle(
+            label = "Manual Grid Columns",
+            checked = manualGridColumnsEnabled,
+            onCheckedChange = { browserPreferences.manualGridColumnsEnabled.set(it) },
+          )
+        )
+      }
+    }
   )
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
@@ -3,6 +3,7 @@ package app.gyrolet.mpvrx.ui.browser.dialogs
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.dp
 import app.gyrolet.mpvrx.preferences.AppearancePreferences
 import app.gyrolet.mpvrx.preferences.BrowserPreferences
 import app.gyrolet.mpvrx.preferences.FolderSortType
@@ -43,33 +44,44 @@ fun FolderSortDialog(
 
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val isTablet = configuration.smallestScreenWidthDp >= 600
+  val maxColumns = if (isTablet || isLandscape) 8 else 4
 
   val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
   val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
 
+  val screenWidthDp = configuration.screenWidthDp.dp
+  val contentHorizontalPadding = 8.dp
+  val itemSpacing = 2.dp
+  val usableWidth = screenWidthDp - (contentHorizontalPadding * 2) - itemSpacing
+  val folderMinWidth = 100.dp
+  val videoMinWidth = 130.dp
+  val dynamicFolderColumns = (usableWidth / folderMinWidth).toInt().coerceIn(1, maxColumns)
+  val dynamicVideoColumns = (usableWidth / videoMinWidth).toInt().coerceIn(1, maxColumns)
+
   val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = folderGridColumns.coerceAtLeast(1),
+      currentValue = folderGridColumns.coerceIn(1, maxColumns),
       onValueChange = {
         if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
         else browserPreferences.folderGridColumnsPortrait.set(it)
       },
-      valueRange = 1f..10f,
-      steps = 8,
+      valueRange = 1f..maxColumns.toFloat(),
+      steps = maxColumns - 2,
     )
   } else null
 
   val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = videoGridColumns,
+      currentValue = videoGridColumns.coerceIn(1, maxColumns),
       onValueChange = {
         if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
         else browserPreferences.videoGridColumnsPortrait.set(it)
       },
-      valueRange = 1f..10f,
-      steps = 8,
+      valueRange = 1f..maxColumns.toFloat(),
+      steps = maxColumns - 2,
     )
   } else null
 
@@ -192,7 +204,18 @@ fun FolderSortDialog(
           VisibilityToggle(
             label = "Manual Grid Columns",
             checked = manualGridColumnsEnabled,
-            onCheckedChange = { browserPreferences.manualGridColumnsEnabled.set(it) },
+            onCheckedChange = { enabled ->
+              if (enabled) {
+                if (isLandscape) {
+                  browserPreferences.folderGridColumnsLandscape.set(dynamicFolderColumns)
+                  browserPreferences.videoGridColumnsLandscape.set(dynamicVideoColumns)
+                } else {
+                  browserPreferences.folderGridColumnsPortrait.set(dynamicFolderColumns)
+                  browserPreferences.videoGridColumnsPortrait.set(dynamicVideoColumns)
+                }
+              }
+              browserPreferences.manualGridColumnsEnabled.set(enabled)
+            },
           )
         )
         add(
@@ -248,33 +271,44 @@ fun VideoSortDialog(
 
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val isTablet = configuration.smallestScreenWidthDp >= 600
+  val maxColumns = if (isTablet || isLandscape) 8 else 4
 
   val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
   val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
 
+  val screenWidthDp = configuration.screenWidthDp.dp
+  val contentHorizontalPadding = 8.dp
+  val itemSpacing = 2.dp
+  val usableWidth = screenWidthDp - (contentHorizontalPadding * 2) - itemSpacing
+  val folderMinWidth = 100.dp
+  val videoMinWidth = 130.dp
+  val dynamicFolderColumns = (usableWidth / folderMinWidth).toInt().coerceIn(1, maxColumns)
+  val dynamicVideoColumns = (usableWidth / videoMinWidth).toInt().coerceIn(1, maxColumns)
+
   val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = folderGridColumns.coerceAtLeast(1),
+      currentValue = folderGridColumns.coerceIn(1, maxColumns),
       onValueChange = {
         if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
         else browserPreferences.folderGridColumnsPortrait.set(it)
       },
-      valueRange = 1f..10f,
-      steps = 8,
+      valueRange = 1f..maxColumns.toFloat(),
+      steps = maxColumns - 2,
     )
   } else null
 
   val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = videoGridColumns,
+      currentValue = videoGridColumns.coerceIn(1, maxColumns),
       onValueChange = {
         if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
         else browserPreferences.videoGridColumnsPortrait.set(it)
       },
-      valueRange = 1f..10f,
-      steps = 8,
+      valueRange = 1f..maxColumns.toFloat(),
+      steps = maxColumns - 2,
     )
   } else null
 
@@ -426,7 +460,18 @@ fun VideoSortDialog(
             VisibilityToggle(
               label = "Manual Grid Columns",
               checked = manualGridColumnsEnabled,
-              onCheckedChange = { browserPreferences.manualGridColumnsEnabled.set(it) },
+              onCheckedChange = { enabled ->
+                if (enabled) {
+                  if (isLandscape) {
+                    browserPreferences.folderGridColumnsLandscape.set(dynamicFolderColumns)
+                    browserPreferences.videoGridColumnsLandscape.set(dynamicVideoColumns)
+                  } else {
+                    browserPreferences.folderGridColumnsPortrait.set(dynamicFolderColumns)
+                    browserPreferences.videoGridColumnsPortrait.set(dynamicVideoColumns)
+                  }
+                }
+                browserPreferences.manualGridColumnsEnabled.set(enabled)
+              },
             )
           )
           add(
@@ -475,33 +520,44 @@ fun FileSystemSortDialog(
 
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val isTablet = configuration.smallestScreenWidthDp >= 600
+  val maxColumns = if (isTablet || isLandscape) 8 else 4
 
   val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
   val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
 
+  val screenWidthDp = configuration.screenWidthDp.dp
+  val contentHorizontalPadding = 8.dp
+  val itemSpacing = 2.dp
+  val usableWidth = screenWidthDp - (contentHorizontalPadding * 2) - itemSpacing
+  val folderMinWidth = 100.dp
+  val videoMinWidth = 130.dp
+  val dynamicFolderColumns = (usableWidth / folderMinWidth).toInt().coerceIn(1, maxColumns)
+  val dynamicVideoColumns = (usableWidth / videoMinWidth).toInt().coerceIn(1, maxColumns)
+
   val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = folderGridColumns.coerceAtLeast(1),
+      currentValue = folderGridColumns.coerceIn(1, maxColumns),
       onValueChange = {
         if (isLandscape) browserPreferences.folderGridColumnsLandscape.set(it)
         else browserPreferences.folderGridColumnsPortrait.set(it)
       },
-      valueRange = 1f..10f,
-      steps = 8,
+      valueRange = 1f..maxColumns.toFloat(),
+      steps = maxColumns - 2,
     )
   } else null
 
   val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
-      currentValue = videoGridColumns,
+      currentValue = videoGridColumns.coerceIn(1, maxColumns),
       onValueChange = {
         if (isLandscape) browserPreferences.videoGridColumnsLandscape.set(it)
         else browserPreferences.videoGridColumnsPortrait.set(it)
       },
-      valueRange = 1f..10f,
-      steps = 8,
+      valueRange = 1f..maxColumns.toFloat(),
+      steps = maxColumns - 2,
     )
   } else null
 
@@ -671,7 +727,18 @@ fun FileSystemSortDialog(
           VisibilityToggle(
             label = "Manual Grid Columns",
             checked = manualGridColumnsEnabled,
-            onCheckedChange = { browserPreferences.manualGridColumnsEnabled.set(it) },
+            onCheckedChange = { enabled ->
+              if (enabled) {
+                if (isLandscape) {
+                  browserPreferences.folderGridColumnsLandscape.set(dynamicFolderColumns)
+                  browserPreferences.videoGridColumnsLandscape.set(dynamicVideoColumns)
+                } else {
+                  browserPreferences.folderGridColumnsPortrait.set(dynamicFolderColumns)
+                  browserPreferences.videoGridColumnsPortrait.set(dynamicVideoColumns)
+                }
+              }
+              browserPreferences.manualGridColumnsEnabled.set(enabled)
+            },
           )
         )
       }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
@@ -1,6 +1,8 @@
 package app.gyrolet.mpvrx.ui.browser.dialogs
 
 import kotlin.math.roundToInt
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -385,12 +387,14 @@ private fun GridColumnsNextSection(
   HorizontalDivider(modifier = Modifier.padding(top = 10.dp))
   DialogSectionTitle(text = "Grid Columns")
 
-  Column(
+  val haptic = LocalHapticFeedback.current
+
+  Row(
     modifier = Modifier.fillMaxWidth(),
-    verticalArrangement = Arrangement.spacedBy(12.dp),
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     if (folderGridColumnSelector != null) {
-      Column(modifier = Modifier.fillMaxWidth()) {
+      Column(modifier = Modifier.weight(1f)) {
         Row(
           modifier = Modifier.fillMaxWidth(),
           horizontalArrangement = Arrangement.SpaceBetween,
@@ -410,7 +414,13 @@ private fun GridColumnsNextSection(
         }
         Slider(
           value = folderGridColumnSelector.currentValue.toFloat(),
-          onValueChange = { folderGridColumnSelector.onValueChange(it.roundToInt()) },
+          onValueChange = {
+            val newValue = it.roundToInt()
+            if (newValue != folderGridColumnSelector.currentValue) {
+              folderGridColumnSelector.onValueChange(newValue)
+              haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+          },
           valueRange = folderGridColumnSelector.valueRange,
           steps = folderGridColumnSelector.steps,
           modifier = Modifier.fillMaxWidth(),
@@ -419,7 +429,7 @@ private fun GridColumnsNextSection(
     }
 
     if (videoGridColumnSelector != null) {
-      Column(modifier = Modifier.fillMaxWidth()) {
+      Column(modifier = Modifier.weight(1f)) {
         Row(
           modifier = Modifier.fillMaxWidth(),
           horizontalArrangement = Arrangement.SpaceBetween,
@@ -439,7 +449,13 @@ private fun GridColumnsNextSection(
         }
         Slider(
           value = videoGridColumnSelector.currentValue.toFloat(),
-          onValueChange = { videoGridColumnSelector.onValueChange(it.roundToInt()) },
+          onValueChange = {
+            val newValue = it.roundToInt()
+            if (newValue != videoGridColumnSelector.currentValue) {
+              videoGridColumnSelector.onValueChange(newValue)
+              haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+          },
           valueRange = videoGridColumnSelector.valueRange,
           steps = videoGridColumnSelector.steps,
           modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
@@ -1,5 +1,6 @@
 package app.gyrolet.mpvrx.ui.browser.dialogs
 
+import kotlin.math.roundToInt
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -409,7 +410,7 @@ private fun GridColumnsNextSection(
         }
         Slider(
           value = folderGridColumnSelector.currentValue.toFloat(),
-          onValueChange = { folderGridColumnSelector.onValueChange(it.toInt()) },
+          onValueChange = { folderGridColumnSelector.onValueChange(it.roundToInt()) },
           valueRange = folderGridColumnSelector.valueRange,
           steps = folderGridColumnSelector.steps,
           modifier = Modifier.fillMaxWidth(),
@@ -438,7 +439,7 @@ private fun GridColumnsNextSection(
         }
         Slider(
           value = videoGridColumnSelector.currentValue.toFloat(),
-          onValueChange = { videoGridColumnSelector.onValueChange(it.toInt()) },
+          onValueChange = { videoGridColumnSelector.onValueChange(it.roundToInt()) },
           valueRange = videoGridColumnSelector.valueRange,
           steps = videoGridColumnSelector.steps,
           modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
@@ -384,13 +384,12 @@ private fun GridColumnsNextSection(
   HorizontalDivider(modifier = Modifier.padding(top = 10.dp))
   DialogSectionTitle(text = "Grid Columns")
 
-  Row(
+  Column(
     modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.spacedBy(16.dp),
-    verticalAlignment = Alignment.Top,
+    verticalArrangement = Arrangement.spacedBy(12.dp),
   ) {
     if (folderGridColumnSelector != null) {
-      Column(modifier = Modifier.weight(1f)) {
+      Column(modifier = Modifier.fillMaxWidth()) {
         Row(
           modifier = Modifier.fillMaxWidth(),
           horizontalArrangement = Arrangement.SpaceBetween,
@@ -419,7 +418,7 @@ private fun GridColumnsNextSection(
     }
 
     if (videoGridColumnSelector != null) {
-      Column(modifier = Modifier.weight(1f)) {
+      Column(modifier = Modifier.fillMaxWidth()) {
         Row(
           modifier = Modifier.fillMaxWidth(),
           horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -27,6 +27,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.layout.BoxWithConstraints
+import app.gyrolet.mpvrx.ui.utils.calculateResponsiveGridSpans
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -175,7 +183,9 @@ fun FileSystemBrowserScreen(path: String? = null) {
   val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
 
   // Use standalone local states instead of CompositionLocal to avoid scroll issues with predictive back gesture
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
   val listState = remember { LazyListState() }
+  val gridState = rememberLazyGridState()
   
   // UI state
   val isRefreshing = remember { mutableStateOf(false) }
@@ -452,7 +462,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
   // Track scroll for FAB visibility
   app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper.trackScrollForFabVisibility(
     listState = listState,
-    gridState = null,
+    gridState = if (mediaLayoutMode == app.gyrolet.mpvrx.preferences.MediaLayoutMode.GRID) gridState else null,
     isFabVisible = isFabVisible,
     expanded = isFabExpanded.value,
     onExpandedChange = { isFabExpanded.value = it },
@@ -676,6 +686,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
               // Show search results
               FileSystemSearchContent(
                 listState = listState, // Use the main listState for FAB tracking
+                gridState = gridState,
                 searchQuery = searchQuery,
                 searchResults = searchResults,
                 isLoading = isSearchLoading,
@@ -698,6 +709,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
             } else {
               FileSystemBrowserContent(
                 listState = listState,
+                gridState = gridState,
                 items = items,
                 videoFilesWithPlayback = videoFilesWithPlayback,
                 newVideoIds = newVideoIds,
@@ -1124,6 +1136,7 @@ private fun playVideosAsPlaylist(
 @Composable
 private fun FileSystemBrowserContent(
   listState: LazyListState,
+  gridState: LazyGridState,
   items: List<FileSystemItem>,
   videoFilesWithPlayback: Map<Long, Float>,
   newVideoIds: Set<Long>,
@@ -1281,6 +1294,9 @@ private fun FileSystemBrowserContent(
         label = "scrollbarAlpha",
       )
 
+      val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+      val isGridMode = mediaLayoutMode == app.gyrolet.mpvrx.preferences.MediaLayoutMode.GRID
+
       PullRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = onRefresh,
@@ -1290,105 +1306,220 @@ private fun FileSystemBrowserContent(
         Box(
           modifier = Modifier.fillMaxSize()
         ) {
-          LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-              start = 8.dp,
-              end = 8.dp,
-              bottom = navigationBarHeight
-            ),
-          ) {
-            // Breadcrumb navigation (if not at root)
-            if (!isAtRoot && breadcrumbs.isNotEmpty()) {
-              item {
-                app.gyrolet.mpvrx.ui.browser.filesystem.BreadcrumbNavigation(
-                  breadcrumbs = breadcrumbs,
-                  onBreadcrumbClick = onBreadcrumbClick,
+          if (isGridMode) {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+              val spansInfo = calculateResponsiveGridSpans(
+                maxWidth = maxWidth,
+                isGridMode = true
+              )
+
+              LazyVerticalGrid(
+                state = gridState,
+                columns = GridCells.Fixed(spansInfo.spans),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                  start = 8.dp,
+                  end = 8.dp,
+                  bottom = navigationBarHeight
+                ),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+              ) {
+                // Breadcrumb navigation (if not at root)
+                if (!isAtRoot && breadcrumbs.isNotEmpty()) {
+                  item(span = { GridItemSpan(maxLineSpan) }) {
+                    app.gyrolet.mpvrx.ui.browser.filesystem.BreadcrumbNavigation(
+                      breadcrumbs = breadcrumbs,
+                      onBreadcrumbClick = onBreadcrumbClick,
+                    )
+                  }
+                }
+
+                // Folders first
+                items(
+                  items = items.filterIsInstance<FileSystemItem.Folder>(),
+                  key = { it.path },
+                  span = { GridItemSpan(spansInfo.folderSpan) }
+                ) { folder ->
+                  val folderModel = app.gyrolet.mpvrx.domain.media.model.VideoFolder(
+                    bucketId = folder.path,
+                    name = folder.name,
+                    path = folder.path,
+                    videoCount = folder.videoCount,
+                    totalSize = folder.totalSize,
+                    totalDuration = folder.totalDuration,
+                    lastModified = folder.lastModified / 1000,
+                  )
+
+                  FolderCard(
+                    folder = folderModel,
+                    isSelected = selectionManager.isSelected(folder),
+                    isRecentlyPlayed = false,
+                    onClick = { onFolderClick(folder) },
+                    onLongClick = { onFolderLongClick(folder) },
+                    onThumbClick = if (tapThumbnailToSelect) {
+                      { selectionManager.toggle(folder) }
+                    } else {
+                      { onFolderClick(folder) }
+                    },
+                    newVideoCount = folder.newCount,
+                    isGridMode = true,
+                  )
+                }
+
+                // Videos second
+                items(
+                  items = items.filterIsInstance<FileSystemItem.VideoFile>(),
+                  key = { "${it.video.id}_${it.video.path}" },
+                  span = { GridItemSpan(spansInfo.videoSpan) }
+                ) { videoFile ->
+                  VideoCard(
+                    video = videoFile.video,
+                    progressPercentage = videoFilesWithPlayback[videoFile.video.id],
+                    isRecentlyPlayed = false,
+                    isSelected = selectionManager.isSelected(videoFile),
+                    onClick = { onVideoClick(videoFile) },
+                    onLongClick = { onVideoLongClick(videoFile) },
+                    onThumbClick = if (tapThumbnailToSelect) {
+                      { selectionManager.toggle(videoFile) }
+                    } else {
+                      { onVideoClick(videoFile) }
+                    },
+                    isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
+                    isGridMode = true,
+                    showSubtitleIndicator = showSubtitleIndicator,
+                    overrideShowSizeChip = null,
+                    overrideShowResolutionChip = null,
+                    useFolderNameStyle = false,
+                    uiConfig = videoCardUiConfig,
+                  )
+                }
+              }
+
+              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                val scrollbarLabels =
+                  remember(items, isAtRoot, breadcrumbs) {
+                    buildList<String?> {
+                      if (!isAtRoot && breadcrumbs.isNotEmpty()) add(null)
+                      items.filterIsInstance<FileSystemItem.Folder>().forEach { add(it.name) }
+                      items.filterIsInstance<FileSystemItem.VideoFile>().forEach { add(it.video.displayName) }
+                    }
+                  }
+
+                ExpressiveScrollBar(
+                  gridState = gridState,
+                  dragLabelProvider = { index ->
+                    fastScrollGlyph(scrollbarLabels.getOrNull(index))
+                  },
+                  modifier =
+                    Modifier
+                      .align(Alignment.CenterEnd)
+                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
+                      .graphicsLayer { alpha = scrollbarAlpha },
+                )
+              }
+            }
+          } else {
+            LazyColumn(
+              state = listState,
+              modifier = Modifier.fillMaxSize(),
+              contentPadding = PaddingValues(
+                start = 8.dp,
+                end = 8.dp,
+                bottom = navigationBarHeight
+              ),
+            ) {
+              // Breadcrumb navigation (if not at root)
+              if (!isAtRoot && breadcrumbs.isNotEmpty()) {
+                item {
+                  app.gyrolet.mpvrx.ui.browser.filesystem.BreadcrumbNavigation(
+                    breadcrumbs = breadcrumbs,
+                    onBreadcrumbClick = onBreadcrumbClick,
+                  )
+                }
+              }
+
+              // Folders first
+              items(
+                items = items.filterIsInstance<FileSystemItem.Folder>(),
+                key = { it.path },
+              ) { folder ->
+                val folderModel = app.gyrolet.mpvrx.domain.media.model.VideoFolder(
+                  bucketId = folder.path,
+                  name = folder.name,
+                  path = folder.path,
+                  videoCount = folder.videoCount,
+                  totalSize = folder.totalSize,
+                  totalDuration = folder.totalDuration,
+                  lastModified = folder.lastModified / 1000,
+                )
+
+                FolderCard(
+                  folder = folderModel,
+                  isSelected = selectionManager.isSelected(folder),
+                  isRecentlyPlayed = false,
+                  onClick = { onFolderClick(folder) },
+                  onLongClick = { onFolderLongClick(folder) },
+                  onThumbClick = if (tapThumbnailToSelect) {
+                    { selectionManager.toggle(folder) }
+                  } else {
+                    { onFolderClick(folder) }
+                  },
+                  newVideoCount = folder.newCount,
+                  isGridMode = false,
+                )
+              }
+
+              // Videos second
+              items(
+                items = items.filterIsInstance<FileSystemItem.VideoFile>(),
+                key = { "${it.video.id}_${it.video.path}" },
+              ) { videoFile ->
+                VideoCard(
+                  video = videoFile.video,
+                  progressPercentage = videoFilesWithPlayback[videoFile.video.id],
+                  isRecentlyPlayed = false,
+                  isSelected = selectionManager.isSelected(videoFile),
+                  onClick = { onVideoClick(videoFile) },
+                  onLongClick = { onVideoLongClick(videoFile) },
+                  onThumbClick = if (tapThumbnailToSelect) {
+                    { selectionManager.toggle(videoFile) }
+                  } else {
+                    { onVideoClick(videoFile) }
+                  },
+                  isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
+                  isGridMode = false,
+                  showSubtitleIndicator = showSubtitleIndicator,
+                  overrideShowSizeChip = null,
+                  overrideShowResolutionChip = null,
+                  useFolderNameStyle = false,
+                  uiConfig = videoCardUiConfig,
                 )
               }
             }
 
-            // Folders first
-            items(
-              items = items.filterIsInstance<FileSystemItem.Folder>(),
-              key = { it.path },
-            ) { folder ->
-              val folderModel = app.gyrolet.mpvrx.domain.media.model.VideoFolder(
-                bucketId = folder.path,
-                name = folder.name,
-                path = folder.path,
-                videoCount = folder.videoCount,
-                totalSize = folder.totalSize,
-                totalDuration = folder.totalDuration,
-                lastModified = folder.lastModified / 1000,
-              )
-
-              FolderCard(
-                folder = folderModel,
-                isSelected = selectionManager.isSelected(folder),
-                isRecentlyPlayed = false,
-                onClick = { onFolderClick(folder) },
-                onLongClick = { onFolderLongClick(folder) },
-                onThumbClick = if (tapThumbnailToSelect) {
-                  { selectionManager.toggle(folder) }
-                } else {
-                  { onFolderClick(folder) }
-                },
-                newVideoCount = folder.newCount,
-                isGridMode = false,
-              )
-            }
-
-            // Videos second
-            items(
-              items = items.filterIsInstance<FileSystemItem.VideoFile>(),
-              key = { "${it.video.id}_${it.video.path}" },
-            ) { videoFile ->
-              VideoCard(
-                video = videoFile.video,
-                progressPercentage = videoFilesWithPlayback[videoFile.video.id],
-                isRecentlyPlayed = false,
-                isSelected = selectionManager.isSelected(videoFile),
-                onClick = { onVideoClick(videoFile) },
-                onLongClick = { onVideoLongClick(videoFile) },
-                onThumbClick = if (tapThumbnailToSelect) {
-                  { selectionManager.toggle(videoFile) }
-                } else {
-                  { onVideoClick(videoFile) }
-                },
-                isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
-                isGridMode = false,
-                showSubtitleIndicator = showSubtitleIndicator,
-                overrideShowSizeChip = null,
-                overrideShowResolutionChip = null,
-                useFolderNameStyle = false,
-                uiConfig = videoCardUiConfig,
-              )
-            }
-          }
-          
-          if (hasEnoughItems && scrollbarAlpha > 0.01f) {
-            val scrollbarLabels =
-              remember(items, isAtRoot, breadcrumbs) {
-                buildList<String?> {
-                  if (!isAtRoot && breadcrumbs.isNotEmpty()) add(null)
-                  items.filterIsInstance<FileSystemItem.Folder>().forEach { add(it.name) }
-                  items.filterIsInstance<FileSystemItem.VideoFile>().forEach { add(it.video.displayName) }
+            if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+              val scrollbarLabels =
+                remember(items, isAtRoot, breadcrumbs) {
+                  buildList<String?> {
+                    if (!isAtRoot && breadcrumbs.isNotEmpty()) add(null)
+                    items.filterIsInstance<FileSystemItem.Folder>().forEach { add(it.name) }
+                    items.filterIsInstance<FileSystemItem.VideoFile>().forEach { add(it.video.displayName) }
+                  }
                 }
-              }
 
-            ExpressiveScrollBar(
-              listState = listState,
-              dragLabelProvider = { index ->
-                fastScrollGlyph(scrollbarLabels.getOrNull(index))
-              },
-              modifier =
-                Modifier
-                  .align(Alignment.CenterEnd)
-                  .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
-                  .graphicsLayer { alpha = scrollbarAlpha },
-            )
+              ExpressiveScrollBar(
+                listState = listState,
+                dragLabelProvider = { index ->
+                  fastScrollGlyph(scrollbarLabels.getOrNull(index))
+                },
+                modifier =
+                  Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
+                    .graphicsLayer { alpha = scrollbarAlpha },
+              )
+            }
           }
         }
       }
@@ -1399,6 +1530,7 @@ private fun FileSystemBrowserContent(
 @Composable
 private fun FileSystemSearchContent(
   listState: LazyListState,
+  gridState: LazyGridState,
   searchQuery: String,
   searchResults: List<FileSystemItem>,
   isLoading: Boolean,
@@ -1456,13 +1588,19 @@ private fun FileSystemSearchContent(
       )
     }
 
+  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val isGridMode = mediaLayoutMode == app.gyrolet.mpvrx.preferences.MediaLayoutMode.GRID
+
   // Track scroll for FAB visibility in search mode with proper scroll direction detection
   val previousIndex = remember { mutableIntStateOf(0) }
   val previousOffset = remember { mutableIntStateOf(0) }
+
+  val firstVisibleItemIndex = if (isGridMode) gridState.firstVisibleItemIndex else listState.firstVisibleItemIndex
+  val firstVisibleItemScrollOffset = if (isGridMode) gridState.firstVisibleItemScrollOffset else listState.firstVisibleItemScrollOffset
   
-  LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-    val currentIndex = listState.firstVisibleItemIndex
-    val currentOffset = listState.firstVisibleItemScrollOffset
+  LaunchedEffect(firstVisibleItemIndex, firstVisibleItemScrollOffset) {
+    val currentIndex = firstVisibleItemIndex
+    val currentOffset = firstVisibleItemScrollOffset
     
     // Show FAB when at the top
     if (currentIndex == 0 && currentOffset == 0) {
@@ -1526,91 +1664,191 @@ private fun FileSystemSearchContent(
         Box(
           modifier = Modifier.fillMaxSize()
         ) {
-          // Content extends full height for transparency
-          LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-              start = 8.dp,
-              end = 8.dp,
-              top = 12.dp,
-              bottom = navigationBarHeight
-            ),
-          ) {
-            // Separate folders and videos for proper ordering and deduplicate
-            val folders = searchResults.filterIsInstance<FileSystemItem.Folder>().distinctBy { it.path }
-            val videos = searchResults.filterIsInstance<FileSystemItem.VideoFile>().distinctBy { it.video.id }
-            
-            // Folders first
-            items(
-              items = folders,
-              key = { "search_folder_${it.path}_${it.hashCode()}" },
-            ) { folder ->
-              val folderModel = app.gyrolet.mpvrx.domain.media.model.VideoFolder(
-                bucketId = folder.path,
-                name = folder.name,
-                path = folder.path,
-                videoCount = folder.videoCount,
-                totalSize = folder.totalSize,
-                totalDuration = folder.totalDuration,
-                lastModified = folder.lastModified / 1000,
+          if (isGridMode) {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+              val spansInfo = calculateResponsiveGridSpans(
+                maxWidth = maxWidth,
+                isGridMode = true
               )
 
-              FolderCard(
-                folder = folderModel,
-                isSelected = false,
-                isRecentlyPlayed = false,
-                onClick = { onFolderClick(folder) },
-                onLongClick = { },
-                onThumbClick = { onFolderClick(folder) },
-                newVideoCount = folder.newCount,
-                isGridMode = false,
-              )
-            }
-            
-            // Videos second
-            items(
-              items = videos,
-              key = { "search_video_${it.video.id}_${it.video.path}_${it.hashCode()}" },
-            ) { videoFile ->
-              VideoCard(
-                video = videoFile.video,
-                progressPercentage = videoFilesWithPlayback[videoFile.video.id],
-                isRecentlyPlayed = false,
-                isSelected = false,
-                onClick = { onVideoClick(videoFile.video) },
-                onLongClick = { },
-                onThumbClick = { onVideoClick(videoFile.video) },
-                isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
-                isGridMode = false,
-                showSubtitleIndicator = showSubtitleIndicator,
-                overrideShowSizeChip = null,
-                overrideShowResolutionChip = null,
-                useFolderNameStyle = false,
-                uiConfig = videoCardUiConfig,
-              )
-            }
-          }
-          
-          if (searchResults.size > 20) {
-            val scrollbarLabels =
-              remember(searchResults) {
-                buildList<String?> {
-                  searchResults.filterIsInstance<FileSystemItem.Folder>().forEach { add(it.name) }
-                  searchResults.filterIsInstance<FileSystemItem.VideoFile>().forEach { add(it.video.displayName) }
+              LazyVerticalGrid(
+                state = gridState,
+                columns = GridCells.Fixed(spansInfo.spans),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                  start = 8.dp,
+                  end = 8.dp,
+                  top = 12.dp,
+                  bottom = navigationBarHeight
+                ),
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+              ) {
+                // Separate folders and videos for proper ordering and deduplicate
+                val folders = searchResults.filterIsInstance<FileSystemItem.Folder>().distinctBy { it.path }
+                val videos = searchResults.filterIsInstance<FileSystemItem.VideoFile>().distinctBy { it.video.id }
+
+                // Folders first
+                items(
+                  items = folders,
+                  key = { "search_folder_${it.path}_${it.hashCode()}" },
+                  span = { GridItemSpan(spansInfo.folderSpan) }
+                ) { folder ->
+                  val folderModel = app.gyrolet.mpvrx.domain.media.model.VideoFolder(
+                    bucketId = folder.path,
+                    name = folder.name,
+                    path = folder.path,
+                    videoCount = folder.videoCount,
+                    totalSize = folder.totalSize,
+                    totalDuration = folder.totalDuration,
+                    lastModified = folder.lastModified / 1000,
+                  )
+
+                  FolderCard(
+                    folder = folderModel,
+                    isSelected = false,
+                    isRecentlyPlayed = false,
+                    onClick = { onFolderClick(folder) },
+                    onLongClick = { },
+                    onThumbClick = { onFolderClick(folder) },
+                    newVideoCount = folder.newCount,
+                    isGridMode = true,
+                  )
+                }
+
+                // Videos second
+                items(
+                  items = videos,
+                  key = { "search_video_${it.video.id}_${it.video.path}_${it.hashCode()}" },
+                  span = { GridItemSpan(spansInfo.videoSpan) }
+                ) { videoFile ->
+                  VideoCard(
+                    video = videoFile.video,
+                    progressPercentage = videoFilesWithPlayback[videoFile.video.id],
+                    isRecentlyPlayed = false,
+                    isSelected = false,
+                    onClick = { onVideoClick(videoFile.video) },
+                    onLongClick = { },
+                    onThumbClick = { onVideoClick(videoFile.video) },
+                    isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
+                    isGridMode = true,
+                    showSubtitleIndicator = showSubtitleIndicator,
+                    overrideShowSizeChip = null,
+                    overrideShowResolutionChip = null,
+                    useFolderNameStyle = false,
+                    uiConfig = videoCardUiConfig,
+                  )
                 }
               }
 
-            ExpressiveScrollBar(
-              listState = listState,
-              dragLabelProvider = { index ->
-                fastScrollGlyph(scrollbarLabels.getOrNull(index))
-              },
-              modifier =
-                Modifier
-                  .align(Alignment.CenterEnd)
-                  .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp),
-            )
+              if (searchResults.size > 20) {
+                val scrollbarLabels =
+                  remember(searchResults) {
+                    buildList<String?> {
+                      searchResults.filterIsInstance<FileSystemItem.Folder>().forEach { add(it.name) }
+                      searchResults.filterIsInstance<FileSystemItem.VideoFile>().forEach { add(it.video.displayName) }
+                    }
+                  }
+
+                ExpressiveScrollBar(
+                  gridState = gridState,
+                  dragLabelProvider = { index ->
+                    fastScrollGlyph(scrollbarLabels.getOrNull(index))
+                  },
+                  modifier =
+                    Modifier
+                      .align(Alignment.CenterEnd)
+                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp),
+                )
+              }
+            }
+          } else {
+            // Content extends full height for transparency
+            LazyColumn(
+              state = listState,
+              modifier = Modifier.fillMaxSize(),
+              contentPadding = PaddingValues(
+                start = 8.dp,
+                end = 8.dp,
+                top = 12.dp,
+                bottom = navigationBarHeight
+              ),
+            ) {
+              // Separate folders and videos for proper ordering and deduplicate
+              val folders = searchResults.filterIsInstance<FileSystemItem.Folder>().distinctBy { it.path }
+              val videos = searchResults.filterIsInstance<FileSystemItem.VideoFile>().distinctBy { it.video.id }
+              
+              // Folders first
+              items(
+                items = folders,
+                key = { "search_folder_${it.path}_${it.hashCode()}" },
+              ) { folder ->
+                val folderModel = app.gyrolet.mpvrx.domain.media.model.VideoFolder(
+                  bucketId = folder.path,
+                  name = folder.name,
+                  path = folder.path,
+                  videoCount = folder.videoCount,
+                  totalSize = folder.totalSize,
+                  totalDuration = folder.totalDuration,
+                  lastModified = folder.lastModified / 1000,
+                )
+
+                FolderCard(
+                  folder = folderModel,
+                  isSelected = false,
+                  isRecentlyPlayed = false,
+                  onClick = { onFolderClick(folder) },
+                  onLongClick = { },
+                  onThumbClick = { onFolderClick(folder) },
+                  newVideoCount = folder.newCount,
+                  isGridMode = false,
+                )
+              }
+              
+              // Videos second
+              items(
+                items = videos,
+                key = { "search_video_${it.video.id}_${it.video.path}_${it.hashCode()}" },
+              ) { videoFile ->
+                VideoCard(
+                  video = videoFile.video,
+                  progressPercentage = videoFilesWithPlayback[videoFile.video.id],
+                  isRecentlyPlayed = false,
+                  isSelected = false,
+                  onClick = { onVideoClick(videoFile.video) },
+                  onLongClick = { },
+                  onThumbClick = { onVideoClick(videoFile.video) },
+                  isOldAndUnplayed = newVideoIds.contains(videoFile.video.id),
+                  isGridMode = false,
+                  showSubtitleIndicator = showSubtitleIndicator,
+                  overrideShowSizeChip = null,
+                  overrideShowResolutionChip = null,
+                  useFolderNameStyle = false,
+                  uiConfig = videoCardUiConfig,
+                )
+              }
+            }
+            
+            if (searchResults.size > 20) {
+              val scrollbarLabels =
+                remember(searchResults) {
+                  buildList<String?> {
+                    searchResults.filterIsInstance<FileSystemItem.Folder>().forEach { add(it.name) }
+                    searchResults.filterIsInstance<FileSystemItem.VideoFile>().forEach { add(it.video.displayName) }
+                  }
+                }
+
+              ExpressiveScrollBar(
+                listState = listState,
+                dragLabelProvider = { index ->
+                  fastScrollGlyph(scrollbarLabels.getOrNull(index))
+                },
+                modifier =
+                  Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp),
+              )
+            }
           }
         }
       }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
@@ -21,6 +21,9 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.layout.BoxWithConstraints
+import app.gyrolet.mpvrx.ui.utils.calculateResponsiveGridSpans
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -49,6 +52,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -162,11 +166,6 @@ object FolderListScreen : Screen {
 
     // Preferences
     val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-    val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
     val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
     val folderSortType by browserPreferences.folderSortType.collectAsState()
     val folderSortOrder by browserPreferences.folderSortOrder.collectAsState()
@@ -606,7 +605,6 @@ object FolderListScreen : Screen {
                       MediaUtils.playFile(video, context)
                     },
                     mediaLayoutMode = mediaLayoutMode,
-                    folderGridColumns = folderGridColumns,
                   )
                 }
               }
@@ -621,7 +619,6 @@ object FolderListScreen : Screen {
                 hasCompletedInitialLoad = hasCompletedInitialLoad,
                 foldersWereDeleted = foldersWereDeleted,
                 mediaLayoutMode = mediaLayoutMode,
-                folderGridColumns = folderGridColumns,
                 tapThumbnailToSelect = tapThumbnailToSelect,
                 navigationBarHeight = navigationBarHeight,
                 listState = listState,
@@ -839,7 +836,6 @@ private fun FolderListContent(
   hasCompletedInitialLoad: Boolean,
   foldersWereDeleted: Boolean,
   mediaLayoutMode: MediaLayoutMode,
-  folderGridColumns: Int,
   tapThumbnailToSelect: Boolean,
   navigationBarHeight: androidx.compose.ui.unit.Dp,
   listState: LazyListState,
@@ -897,7 +893,6 @@ private fun FolderListContent(
           foldersWithNewCount = foldersWithNewCount,
           pinnedFolderPaths = pinnedFolderPaths,
           recentlyPlayedFilePath = recentlyPlayedFilePath,
-          folderGridColumns = folderGridColumns,
           tapThumbnailToSelect = tapThumbnailToSelect,
           navigationBarHeight = navigationBarHeight,
           gridState = gridState,
@@ -933,7 +928,6 @@ private fun GridContent(
   foldersWithNewCount: List<app.gyrolet.mpvrx.ui.browser.folderlist.FolderWithNewCount>,
   pinnedFolderPaths: Set<String>,
   recentlyPlayedFilePath: String?,
-  folderGridColumns: Int,
   tapThumbnailToSelect: Boolean,
   navigationBarHeight: androidx.compose.ui.unit.Dp,
   gridState: androidx.compose.foundation.lazy.grid.LazyGridState,
@@ -943,9 +937,28 @@ private fun GridContent(
   onFolderLongClick: (VideoFolder) -> Unit,
   onTogglePin: (VideoFolder) -> Unit,
 ) {
-  Box(modifier = Modifier.fillMaxSize()) {
+  BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    val browserPreferences = org.koin.compose.koinInject<app.gyrolet.mpvrx.preferences.BrowserPreferences>()
+    val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+    val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+    val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
+
+    val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+    val folderGridColumnsPref = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+
+    val computedColumns = if (manualGridColumnsEnabled) {
+      folderGridColumnsPref.coerceAtLeast(1)
+    } else {
+      val contentHorizontalPadding = 8.dp
+      val itemSpacing = 2.dp
+      val usableWidth = maxWidth - (contentHorizontalPadding * 2) - itemSpacing
+      val folderMinWidth = 100.dp
+      (usableWidth / folderMinWidth).toInt().coerceAtLeast(1)
+    }
+
     LazyVerticalGrid(
-      columns = GridCells.Fixed(folderGridColumns),
+      columns = GridCells.Fixed(computedColumns),
       state = gridState,
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(
@@ -1115,7 +1128,6 @@ private fun SearchResultsContent(
   onFolderClick: (app.gyrolet.mpvrx.domain.media.model.VideoFolder) -> Unit,
   onVideoClick: (app.gyrolet.mpvrx.domain.media.model.Video) -> Unit,
   mediaLayoutMode: app.gyrolet.mpvrx.preferences.MediaLayoutMode,
-  folderGridColumns: Int,
 ) {
   val folders = searchResults.filterIsInstance<FileSystemItem.Folder>().map { folder ->
     app.gyrolet.mpvrx.domain.media.model.VideoFolder(
@@ -1176,44 +1188,58 @@ private fun SearchResultsContent(
   
   Box(modifier = Modifier.fillMaxSize()) {
     if (isGridMode) {
-      LazyVerticalGrid(
-        columns = GridCells.Fixed(folderGridColumns),
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(
-          start = 8.dp,
-          end = 8.dp,
-          top = 8.dp,
-          bottom = navigationBarHeight + 8.dp
-        ),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-      ) {
-        items(count = folders.size, key = { index -> folders[index].bucketId }) { index ->
-          val folder = folders[index]
-          FolderCard(
-            folder = folder,
-            isSelected = false,
-            isRecentlyPlayed = false,
-            onClick = { onFolderClick(folder) },
-            onLongClick = {},
-            onThumbClick = { onFolderClick(folder) },
-            newVideoCount = 0,
-            isGridMode = true,
-          )
-        }
-        
-        items(count = videos.size, key = { index -> videos[index].id }) { index ->
-          val video = videos[index]
-          VideoCard(
-            video = video,
-            isSelected = false,
-            onClick = { onVideoClick(video) },
-            onLongClick = {},
-            onThumbClick = { onVideoClick(video) },
-            isGridMode = true,
-            showSubtitleIndicator = showSubtitleIndicator,
-            uiConfig = videoCardUiConfig,
-          )
+      BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val spansInfo = calculateResponsiveGridSpans(
+          maxWidth = maxWidth,
+          isGridMode = true
+        )
+        LazyVerticalGrid(
+          columns = GridCells.Fixed(spansInfo.spans),
+          modifier = Modifier.fillMaxSize(),
+          contentPadding = PaddingValues(
+            start = 8.dp,
+            end = 8.dp,
+            top = 8.dp,
+            bottom = navigationBarHeight + 8.dp
+          ),
+          horizontalArrangement = Arrangement.spacedBy(4.dp),
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+          items(
+            count = folders.size,
+            key = { index -> folders[index].bucketId },
+            span = { GridItemSpan(spansInfo.folderSpan) }
+          ) { index ->
+            val folder = folders[index]
+            FolderCard(
+              folder = folder,
+              isSelected = false,
+              isRecentlyPlayed = false,
+              onClick = { onFolderClick(folder) },
+              onLongClick = {},
+              onThumbClick = { onFolderClick(folder) },
+              newVideoCount = 0,
+              isGridMode = true,
+            )
+          }
+          
+          items(
+            count = videos.size,
+            key = { index -> videos[index].id },
+            span = { GridItemSpan(spansInfo.videoSpan) }
+          ) { index ->
+            val video = videos[index]
+            VideoCard(
+              video = video,
+              isSelected = false,
+              onClick = { onVideoClick(video) },
+              onLongClick = {},
+              onThumbClick = { onVideoClick(video) },
+              isGridMode = true,
+              showSubtitleIndicator = showSubtitleIndicator,
+              uiConfig = videoCardUiConfig,
+            )
+          }
         }
       }
     } else {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistScreen.kt
@@ -6,6 +6,7 @@ import app.gyrolet.mpvrx.ui.icons.Icons
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -43,6 +44,7 @@ import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -388,11 +390,9 @@ object PlaylistScreen : Screen {
   ) {
     val browserPreferences = koinInject<app.gyrolet.mpvrx.preferences.BrowserPreferences>()
     val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+    val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
     val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+    val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
 
     val isGridMode = mediaLayoutMode == MediaLayoutMode.GRID
 
@@ -418,11 +418,24 @@ object PlaylistScreen : Screen {
       if (isGridMode) {
         // Grid layout
         val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
-        Box(
+        BoxWithConstraints(
           modifier = Modifier
             .fillMaxSize()
             .padding(bottom = navigationBarHeight)
         ) {
+          val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+          val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+          val folderGridColumnsPref = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+          val folderGridColumns = if (manualGridColumnsEnabled) {
+            folderGridColumnsPref.coerceAtLeast(1)
+          } else {
+            val contentHorizontalPadding = 8.dp
+            val itemSpacing = 8.dp
+            val usableWidth = maxWidth - (contentHorizontalPadding * 2) - itemSpacing
+            val folderMinWidth = 100.dp
+            (usableWidth / folderMinWidth).toInt().coerceAtLeast(1)
+          }
+
           LazyVerticalGrid(
             columns = GridCells.Fixed(folderGridColumns),
             state = gridState,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.layout.BoxWithConstraints
+import app.gyrolet.mpvrx.ui.utils.calculateResponsiveGridSpans
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -39,6 +42,7 @@ import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -452,19 +456,24 @@ private fun RecentItemsContent(
   val showUnplayedOldVideoLabel by appearancePreferences.showUnplayedOldVideoLabel.collectAsState()
   val unplayedOldVideoDays by appearancePreferences.unplayedOldVideoDays.collectAsState()
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
-  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
-  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
-  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
   val showExtensionField by browserPreferences.showExtensionField.collectAsState()
   val showDurationField by browserPreferences.showDurationField.collectAsState()
-
-
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-
-  val folderGridColumns = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
-  val videoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+  val screenWidthDp = configuration.screenWidthDp.dp
+  val contentHorizontalPadding = 8.dp
+  val itemSpacing = 2.dp
+  val usableWidth = screenWidthDp - (contentHorizontalPadding * 2) - itemSpacing
+  val videoMinWidth = 130.dp
+  val videoGridColumnsPref = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+  val computedVideoColumns = if (manualGridColumnsEnabled) {
+    videoGridColumnsPref.coerceAtLeast(1)
+  } else {
+    (usableWidth / videoMinWidth).toInt().coerceAtLeast(1)
+  }
 
   val isGridMode = mediaLayoutMode == MediaLayoutMode.GRID
 
@@ -472,7 +481,7 @@ private fun RecentItemsContent(
   val isRefreshing = remember { mutableStateOf(false) }
 
   val thumbWidthDp = if (isGridMode) {
-    (360.dp / videoGridColumns)
+    (screenWidthDp / computedVideoColumns)
   } else {
     160.dp
   }
@@ -549,13 +558,17 @@ private fun RecentItemsContent(
   ) {
     if (isGridMode) {
       val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
-      Box(
+      BoxWithConstraints(
         modifier = Modifier
           .fillMaxSize()
           .padding(bottom = navigationBarHeight)
       ) {
+        val spansInfo = calculateResponsiveGridSpans(
+          maxWidth = maxWidth,
+          isGridMode = true
+        )
         LazyVerticalGrid(
-          columns = GridCells.Fixed(videoGridColumns),
+          columns = GridCells.Fixed(spansInfo.spans),
           state = gridState,
           modifier = Modifier.fillMaxSize(),
           contentPadding = PaddingValues(
@@ -574,6 +587,14 @@ private fun RecentItemsContent(
                 is RecentlyPlayedItem.PlaylistItem -> "playlist_${item.playlist.id}_${item.timestamp}"
               }
             },
+            span = { index ->
+              val item = recentItems[index]
+              val itemSpan = when (item) {
+                is RecentlyPlayedItem.PlaylistItem -> spansInfo.folderSpan
+                is RecentlyPlayedItem.VideoItem -> spansInfo.videoSpan
+              }
+              GridItemSpan(itemSpan)
+            }
           ) { index ->
             when (val item = recentItems[index]) {
               is RecentlyPlayedItem.VideoItem -> {
@@ -601,7 +622,7 @@ private fun RecentItemsContent(
                     }
                   },
                   isGridMode = true,
-                  gridColumns = videoGridColumns,
+                  gridColumns = spansInfo.spans,
                   showSubtitleIndicator = showSubtitleIndicator,
                   uiConfig = videoCardUiConfig,
                 )

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.slideOutVertically
 import app.gyrolet.mpvrx.ui.theme.AppMotion
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -47,6 +48,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -610,21 +612,11 @@ internal fun VideoListContent(
   val browserPreferences = koinInject<BrowserPreferences>()
   val appearancePreferences = koinInject<AppearancePreferences>()
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
-  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
-  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
   val isTablet = configuration.smallestScreenWidthDp >= 600
   val bottomPadding = if (showFloatingBottomBar) {
     if (isTablet) 108.dp else 88.dp
   } else 16.dp
-  val preferredVideoGridColumns = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
-  val videoGridColumns = remember(configuration.screenWidthDp, preferredVideoGridColumns) {
-    responsiveVideoGridColumns(
-      availableWidthDp = configuration.screenWidthDp,
-      preferredColumns = preferredVideoGridColumns,
-    )
-  }
   val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
   val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
   val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
@@ -638,14 +630,13 @@ internal fun VideoListContent(
   val unplayedOldVideoDays by appearancePreferences.unplayedOldVideoDays.collectAsState()
   val showExtensionField by browserPreferences.showExtensionField.collectAsState()
   val showDurationField by browserPreferences.showDurationField.collectAsState()
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
   val density = LocalDensity.current
   val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
-  // Must match the thumbnail size logic inside `VideoCard` for this screen,
-  // otherwise the cache keys won't line up and the UI won't receive updates.
-  val thumbWidthDp = if (mediaLayoutMode == MediaLayoutMode.GRID) 160.dp else 128.dp
   val aspect = 16f / 9f
-  val thumbWidthPx = with(density) { thumbWidthDp.roundToPx() }
-  val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+
   val videoCardUiConfig =
     remember(
       unlimitedNameLines,
@@ -704,285 +695,309 @@ internal fun VideoListContent(
     }
 
     else -> {
-      val rememberedListIndex = rememberSaveable { mutableIntStateOf(0) }
-      val rememberedListOffset = rememberSaveable { mutableIntStateOf(0) }
-      val rememberedGridIndex = rememberSaveable { mutableIntStateOf(0) }
-      val rememberedGridOffset = rememberSaveable { mutableIntStateOf(0) }
-      
-      val initialListIndex = if (rememberedListIndex.intValue > 0) {
-          rememberedListIndex.intValue
-      } else if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && videosWithInfo.isNotEmpty()) {
-          var foundIndex = 0
-          for (i in videosWithInfo.indices) {
-              if (videosWithInfo[i].video.path == recentlyPlayedFilePath) {
-                  foundIndex = i
-                  break
-              }
-          }
-          foundIndex
-      } else 0
-      
-      val initialGridIndex = if (rememberedGridIndex.intValue > 0) {
-          rememberedGridIndex.intValue
-      } else if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && videosWithInfo.isNotEmpty()) {
-          var foundIndex = 0
-          for (i in videosWithInfo.indices) {
-              if (videosWithInfo[i].video.path == recentlyPlayedFilePath) {
-                  foundIndex = i
-                  break
-              }
-          }
-          foundIndex
-      } else 0
-      
-      val listState = rememberLazyListState(
-          initialFirstVisibleItemIndex = initialListIndex,
-          initialFirstVisibleItemScrollOffset = rememberedListOffset.intValue
-      )
-      
-      val gridState = rememberLazyGridState(
-          initialFirstVisibleItemIndex = initialGridIndex,
-          initialFirstVisibleItemScrollOffset = rememberedGridOffset.intValue
-      )
-      
-      LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-          rememberedListIndex.intValue = listState.firstVisibleItemIndex
-          rememberedListOffset.intValue = listState.firstVisibleItemScrollOffset
-      }
-      
-      LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset) {
-          rememberedGridIndex.intValue = gridState.firstVisibleItemIndex
-          rememberedGridOffset.intValue = gridState.firstVisibleItemScrollOffset
-      }
-
-      val latestVideosWithInfo by rememberUpdatedState(videosWithInfo)
-      val thumbnailListKey = remember(videosWithInfo) {
-        buildString {
-          append(videosWithInfo.size)
-          append('|')
-          append(videosWithInfo.firstOrNull()?.video?.path.orEmpty())
-          append('|')
-          append(videosWithInfo.lastOrNull()?.video?.path.orEmpty())
-        }
-      }
-
-      LaunchedEffect(
-        folderId,
-        showVideoThumbnails,
-        thumbWidthPx,
-        thumbHeightPx,
-        mediaLayoutMode,
-        thumbnailListKey,
-        videoGridColumns,
-      ) {
-        if (!showVideoThumbnails || latestVideosWithInfo.isEmpty()) return@LaunchedEffect
-
-        snapshotFlow {
-          val itemCount = latestVideosWithInfo.size
-          val visibleIndices =
-            if (mediaLayoutMode == MediaLayoutMode.GRID) {
-              gridState.layoutInfo.visibleItemsInfo.map { it.index }
-            } else {
-              listState.layoutInfo.visibleItemsInfo.map { it.index }
-            }
-
-          if (visibleIndices.isEmpty()) {
-            val firstIndex =
-              if (mediaLayoutMode == MediaLayoutMode.GRID) {
-                gridState.firstVisibleItemIndex
-              } else {
-                listState.firstVisibleItemIndex
-              }
-            visibleVideoWindow(
-              firstVisibleIndex = firstIndex,
-              lastVisibleIndex = firstIndex,
-              itemCount = itemCount,
-              columns = videoGridColumns,
-            )
-          } else {
-            visibleVideoWindow(
-              firstVisibleIndex = visibleIndices.minOrNull() ?: 0,
-              lastVisibleIndex = visibleIndices.maxOrNull() ?: 0,
-              itemCount = itemCount,
-              columns = videoGridColumns,
-            )
-          }
-        }
-          .distinctUntilChanged()
-          .map { indices ->
-            val currentVideos = latestVideosWithInfo
-            indices.mapNotNull { index -> currentVideos.getOrNull(index)?.video }
-          }
-          .collectLatest { visibleVideos ->
-            thumbnailRepository.startFolderThumbnailGeneration(
-              folderId = "$folderId:${mediaLayoutMode.name}",
-              videos = visibleVideos,
-              widthPx = thumbWidthPx,
-              heightPx = thumbHeightPx,
-            )
-          }
-      }
-
-      FabScrollHelper.trackScrollForFabVisibility(
-        listState = listState,
-        gridState = if (mediaLayoutMode == MediaLayoutMode.GRID) gridState else null,
-        isFabVisible = isFabVisible,
-        expanded = false,
-        onExpandedChange = {},
-      )
-      
-      val coroutineScope = rememberCoroutineScope()
-
-      val hasEnoughItems = videosWithInfo.size > 10
-
-      val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
-        targetValue = if (hasEnoughItems) 1f else 0f,
-        animationSpec = androidx.compose.animation.core.spring(
-          dampingRatio = app.gyrolet.mpvrx.ui.theme.AppMotion.Effect.Alpha.dampingRatio,
-          stiffness = app.gyrolet.mpvrx.ui.theme.AppMotion.Effect.Alpha.stiffness,
-        ),
-        label = "scrollbarAlpha",
-      )
-
-      PullRefreshBox(
-        isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
-        listState = listState,
-        modifier = modifier.fillMaxSize(),
-      ) {
-
-        val columns = when (mediaLayoutMode) {
-          MediaLayoutMode.LIST -> 1
-          MediaLayoutMode.GRID -> videoGridColumns
-        }
-
-        if (mediaLayoutMode == MediaLayoutMode.GRID) {
-          Box(
-            modifier =
-              Modifier
-                .fillMaxSize()
-                .padding(bottom = if (selectionManager.isInSelectionMode) 0.dp else navigationBarHeight),
-          ) {
-            LazyVerticalGrid(
-              columns = GridCells.Fixed(columns),
-              state = gridState,
-              modifier = Modifier.fillMaxSize(),
-              contentPadding = PaddingValues(
-                start = 8.dp,
-                end = 8.dp,
-                bottom = bottomPadding,
-              ),
-              horizontalArrangement = Arrangement.spacedBy(4.dp),
-              verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-              items(
-                count = videosWithInfo.size,
-                key = { index -> "${videosWithInfo[index].video.id}_${videosWithInfo[index].video.path}" },
-              ) { index ->
-                val videoWithInfo = videosWithInfo[index]
-                val isRecentlyPlayed = recentlyPlayedFilePath?.let { videoWithInfo.video.path == it } ?: false
-
-                VideoCard(
-                  video = videoWithInfo.video,
-                  progressPercentage = videoWithInfo.progressPercentage,
-                  isRecentlyPlayed = isRecentlyPlayed,
-                  isSelected = selectionManager.isSelected(videoWithInfo.video),
-                  isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
-                  isWatched = videoWithInfo.isWatched,
-                  onClick = { onVideoClick(videoWithInfo.video) },
-                  onLongClick = { onVideoLongClick(videoWithInfo.video) },
-                  onThumbClick = if (tapThumbnailToSelect) {
-                    { selectionManager.toggle(videoWithInfo.video) }
-                  } else {
-                    { onVideoClick(videoWithInfo.video) }
-                  },
-                  isGridMode = mediaLayoutMode == MediaLayoutMode.GRID,
-                  gridColumns = videoGridColumns,
-                  showSubtitleIndicator = showSubtitleIndicator,
-                  allowThumbnailGeneration = false,
-                  uiConfig = videoCardUiConfig,
-                )
-              }
-            }
-
-            if (hasEnoughItems && scrollbarAlpha > 0.01f) {
-              ExpressiveScrollBar(
-                gridState = gridState,
-                dragLabelProvider = { index ->
-                  fastScrollGlyph(videosWithInfo.getOrNull(index)?.video?.displayName)
-                },
-                modifier =
-                  Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(vertical = 6.dp)
-                    .graphicsLayer { alpha = scrollbarAlpha },
-              )
-            }
-          }
+      BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+        val videoGridColumnsPref = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+        val contentHorizontalPadding = 8.dp
+        val itemSpacing = 4.dp
+        val usableWidth = maxWidth - (contentHorizontalPadding * 2) - itemSpacing
+        val videoGridColumns = if (manualGridColumnsEnabled) {
+          videoGridColumnsPref.coerceAtLeast(1)
         } else {
-          Box(
-            modifier =
-              Modifier
-                .fillMaxSize()
-                .padding(bottom = if (selectionManager.isInSelectionMode) 0.dp else navigationBarHeight),
-          ) {
-            LazyColumn(
-              state = listState,
-              modifier = Modifier.fillMaxSize(),
-              contentPadding = PaddingValues(
-                start = 8.dp,
-                end = 8.dp,
-                bottom = bottomPadding,
-              ),
-            ) {
-              items(
-                count = videosWithInfo.size,
-                key = { index -> "${videosWithInfo[index].video.id}_${videosWithInfo[index].video.path}" },
-              ) { index ->
-                val videoWithInfo = videosWithInfo[index]
-                val isRecentlyPlayed = recentlyPlayedFilePath?.let { videoWithInfo.video.path == it } ?: false
+          val videoMinWidth = 130.dp
+          (usableWidth / videoMinWidth).toInt().coerceAtLeast(1)
+        }
 
-                VideoCard(
-                  video = videoWithInfo.video,
-                  progressPercentage = videoWithInfo.progressPercentage,
-                  isRecentlyPlayed = isRecentlyPlayed,
-                  isSelected = selectionManager.isSelected(videoWithInfo.video),
-                  isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
-                  isWatched = videoWithInfo.isWatched,
-                  onClick = { onVideoClick(videoWithInfo.video) },
-                  onLongClick = { onVideoLongClick(videoWithInfo.video) },
-                  onThumbClick = if (tapThumbnailToSelect) {
-                    { selectionManager.toggle(videoWithInfo.video) }
-                  } else {
-                    { onVideoClick(videoWithInfo.video) }
-                  },
-                  isGridMode = false,
-                  showSubtitleIndicator = showSubtitleIndicator,
-                  allowThumbnailGeneration = false,
-                  uiConfig = videoCardUiConfig,
-                )
-              }
+        // Must match the thumbnail size logic inside `VideoCard` for this screen,
+        // otherwise the cache keys won't line up and the UI won't receive updates.
+        val thumbWidthDp = if (mediaLayoutMode == MediaLayoutMode.GRID) {
+          (usableWidth / videoGridColumns)
+        } else {
+          128.dp
+        }
+        val thumbWidthPx = with(density) { thumbWidthDp.roundToPx() }
+        val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+
+        val rememberedListIndex = rememberSaveable { mutableIntStateOf(0) }
+        val rememberedListOffset = rememberSaveable { mutableIntStateOf(0) }
+        val rememberedGridIndex = rememberSaveable { mutableIntStateOf(0) }
+        val rememberedGridOffset = rememberSaveable { mutableIntStateOf(0) }
+        
+        val initialListIndex = if (rememberedListIndex.intValue > 0) {
+            rememberedListIndex.intValue
+        } else if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && videosWithInfo.isNotEmpty()) {
+            var foundIndex = 0
+            for (i in videosWithInfo.indices) {
+                if (videosWithInfo[i].video.path == recentlyPlayedFilePath) {
+                    foundIndex = i
+                    break
+                }
             }
+            foundIndex
+        } else 0
+        
+        val initialGridIndex = if (rememberedGridIndex.intValue > 0) {
+            rememberedGridIndex.intValue
+        } else if (autoScrollToLastPlayed && recentlyPlayedFilePath != null && videosWithInfo.isNotEmpty()) {
+            var foundIndex = 0
+            for (i in videosWithInfo.indices) {
+                if (videosWithInfo[i].video.path == recentlyPlayedFilePath) {
+                    foundIndex = i
+                    break
+                }
+            }
+            foundIndex
+        } else 0
+        
+        val listState = rememberLazyListState(
+            initialFirstVisibleItemIndex = initialListIndex,
+            initialFirstVisibleItemScrollOffset = rememberedListOffset.intValue
+        )
+        
+        val gridState = rememberLazyGridState(
+            initialFirstVisibleItemIndex = initialGridIndex,
+            initialFirstVisibleItemScrollOffset = rememberedGridOffset.intValue
+        )
+        
+        LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
+            rememberedListIndex.intValue = listState.firstVisibleItemIndex
+            rememberedListOffset.intValue = listState.firstVisibleItemScrollOffset
+        }
+        
+        LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset) {
+            rememberedGridIndex.intValue = gridState.firstVisibleItemIndex
+            rememberedGridOffset.intValue = gridState.firstVisibleItemScrollOffset
+        }
 
-            if (hasEnoughItems && scrollbarAlpha > 0.01f) {
-              ExpressiveScrollBar(
-                listState = listState,
-                dragLabelProvider = { index ->
-                  fastScrollGlyph(videosWithInfo.getOrNull(index)?.video?.displayName)
-                },
-                modifier =
-                  Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(vertical = 6.dp)
-                    .graphicsLayer { alpha = scrollbarAlpha },
+        val latestVideosWithInfo by rememberUpdatedState(videosWithInfo)
+        val thumbnailListKey = remember(videosWithInfo) {
+          buildString {
+            append(videosWithInfo.size)
+            append('|')
+            append(videosWithInfo.firstOrNull()?.video?.path.orEmpty())
+            append('|')
+            append(videosWithInfo.lastOrNull()?.video?.path.orEmpty())
+          }
+        }
+
+        LaunchedEffect(
+          folderId,
+          showVideoThumbnails,
+          thumbWidthPx,
+          thumbHeightPx,
+          mediaLayoutMode,
+          thumbnailListKey,
+          videoGridColumns,
+        ) {
+          if (!showVideoThumbnails || latestVideosWithInfo.isEmpty()) return@LaunchedEffect
+
+          snapshotFlow {
+            val itemCount = latestVideosWithInfo.size
+            val visibleIndices =
+              if (mediaLayoutMode == MediaLayoutMode.GRID) {
+                gridState.layoutInfo.visibleItemsInfo.map { it.index }
+              } else {
+                listState.layoutInfo.visibleItemsInfo.map { it.index }
+              }
+
+            if (visibleIndices.isEmpty()) {
+              val firstIndex =
+                if (mediaLayoutMode == MediaLayoutMode.GRID) {
+                  gridState.firstVisibleItemIndex
+                } else {
+                  listState.firstVisibleItemIndex
+                }
+              visibleVideoWindow(
+                firstVisibleIndex = firstIndex,
+                lastVisibleIndex = firstIndex,
+                itemCount = itemCount,
+                columns = videoGridColumns,
+              )
+            } else {
+              visibleVideoWindow(
+                firstVisibleIndex = visibleIndices.minOrNull() ?: 0,
+                lastVisibleIndex = visibleIndices.maxOrNull() ?: 0,
+                itemCount = itemCount,
+                columns = videoGridColumns,
               )
             }
           }
+            .distinctUntilChanged()
+            .map { indices ->
+              val currentVideos = latestVideosWithInfo
+              indices.mapNotNull { index -> currentVideos.getOrNull(index)?.video }
+            }
+            .collectLatest { visibleVideos ->
+              thumbnailRepository.startFolderThumbnailGeneration(
+                folderId = "$folderId:${mediaLayoutMode.name}",
+                videos = visibleVideos,
+                widthPx = thumbWidthPx,
+                heightPx = thumbHeightPx,
+              )
+            }
         }
-      }
+
+        FabScrollHelper.trackScrollForFabVisibility(
+          listState = listState,
+          gridState = if (mediaLayoutMode == MediaLayoutMode.GRID) gridState else null,
+          isFabVisible = isFabVisible,
+          expanded = false,
+          onExpandedChange = {},
+        )
+        
+        val coroutineScope = rememberCoroutineScope()
+
+        val hasEnoughItems = videosWithInfo.size > 10
+
+        val scrollbarAlpha by androidx.compose.animation.core.animateFloatAsState(
+          targetValue = if (hasEnoughItems) 1f else 0f,
+          animationSpec = androidx.compose.animation.core.spring(
+            dampingRatio = app.gyrolet.mpvrx.ui.theme.AppMotion.Effect.Alpha.dampingRatio,
+            stiffness = app.gyrolet.mpvrx.ui.theme.AppMotion.Effect.Alpha.stiffness,
+          ),
+          label = "scrollbarAlpha",
+        )
+
+        PullRefreshBox(
+          isRefreshing = isRefreshing,
+          onRefresh = onRefresh,
+          listState = listState,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+
+          val columns = when (mediaLayoutMode) {
+            MediaLayoutMode.LIST -> 1
+            MediaLayoutMode.GRID -> videoGridColumns
+          }
+
+          if (mediaLayoutMode == MediaLayoutMode.GRID) {
+            Box(
+              modifier =
+                Modifier
+                  .fillMaxSize()
+                  .padding(bottom = if (selectionManager.isInSelectionMode) 0.dp else navigationBarHeight),
+            ) {
+              LazyVerticalGrid(
+                columns = GridCells.Fixed(columns),
+                state = gridState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                  start = 8.dp,
+                  end = 8.dp,
+                  bottom = bottomPadding,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+              ) {
+                items(
+                  count = videosWithInfo.size,
+                  key = { index -> "${videosWithInfo[index].video.id}_${videosWithInfo[index].video.path}" },
+                ) { index ->
+                  val videoWithInfo = videosWithInfo[index]
+                  val isRecentlyPlayed = recentlyPlayedFilePath?.let { videoWithInfo.video.path == it } ?: false
+
+                  VideoCard(
+                    video = videoWithInfo.video,
+                    progressPercentage = videoWithInfo.progressPercentage,
+                    isRecentlyPlayed = isRecentlyPlayed,
+                    isSelected = selectionManager.isSelected(videoWithInfo.video),
+                    isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
+                    isWatched = videoWithInfo.isWatched,
+                    onClick = { onVideoClick(videoWithInfo.video) },
+                    onLongClick = { onVideoLongClick(videoWithInfo.video) },
+                    onThumbClick = if (tapThumbnailToSelect) {
+                      { selectionManager.toggle(videoWithInfo.video) }
+                    } else {
+                      { onVideoClick(videoWithInfo.video) }
+                    },
+                    isGridMode = mediaLayoutMode == MediaLayoutMode.GRID,
+                    gridColumns = columns,
+                    showSubtitleIndicator = showSubtitleIndicator,
+                    allowThumbnailGeneration = false,
+                    uiConfig = videoCardUiConfig,
+                  )
+                }
+              }
+
+              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                ExpressiveScrollBar(
+                  gridState = gridState,
+                  dragLabelProvider = { index ->
+                    fastScrollGlyph(videosWithInfo.getOrNull(index)?.video?.displayName)
+                  },
+                  modifier =
+                    Modifier
+                      .align(Alignment.CenterEnd)
+                      .padding(vertical = 6.dp)
+                      .graphicsLayer { alpha = scrollbarAlpha },
+                )
+              }
+            }
+          } else {
+            Box(
+              modifier =
+                Modifier
+                  .fillMaxSize()
+                  .padding(bottom = if (selectionManager.isInSelectionMode) 0.dp else navigationBarHeight),
+            ) {
+              LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                  start = 8.dp,
+                  end = 8.dp,
+                  bottom = bottomPadding,
+                ),
+              ) {
+                items(
+                  count = videosWithInfo.size,
+                  key = { index -> "${videosWithInfo[index].video.id}_${videosWithInfo[index].video.path}" },
+                ) { index ->
+                  val videoWithInfo = videosWithInfo[index]
+                  val isRecentlyPlayed = recentlyPlayedFilePath?.let { videoWithInfo.video.path == it } ?: false
+
+                  VideoCard(
+                    video = videoWithInfo.video,
+                    progressPercentage = videoWithInfo.progressPercentage,
+                    isRecentlyPlayed = isRecentlyPlayed,
+                    isSelected = selectionManager.isSelected(videoWithInfo.video),
+                    isOldAndUnplayed = videoWithInfo.isOldAndUnplayed,
+                    isWatched = videoWithInfo.isWatched,
+                    onClick = { onVideoClick(videoWithInfo.video) },
+                    onLongClick = { onVideoLongClick(videoWithInfo.video) },
+                    onThumbClick = if (tapThumbnailToSelect) {
+                      { selectionManager.toggle(videoWithInfo.video) }
+                    } else {
+                      { onVideoClick(videoWithInfo.video) }
+                    },
+                    isGridMode = false,
+                    showSubtitleIndicator = showSubtitleIndicator,
+                    allowThumbnailGeneration = false,
+                    uiConfig = videoCardUiConfig,
+                  )
+                }
+              }
+
+              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                ExpressiveScrollBar(
+                  listState = listState,
+                  dragLabelProvider = { index ->
+                    fastScrollGlyph(videosWithInfo.getOrNull(index)?.video?.displayName)
+                  },
+                  modifier =
+                    Modifier
+                      .align(Alignment.CenterEnd)
+                      .padding(vertical = 6.dp)
+                      .graphicsLayer { alpha = scrollbarAlpha },
+                )
+              }
+            }
+          }
+        }
       }
     }
   }
+}
 
 private fun visibleVideoWindow(
   firstVisibleIndex: Int,
@@ -1000,25 +1015,6 @@ private fun visibleVideoWindow(
   return (start..end).toList()
 }
 
-private fun responsiveVideoGridColumns(
-  availableWidthDp: Int,
-  preferredColumns: Int,
-): Int {
-  val safePreferred = preferredColumns.coerceAtLeast(1)
-  val minCellDp =
-    when (safePreferred) {
-      1 -> 280
-      2 -> 150
-      3 -> 120
-      4 -> 100
-      else -> 88
-    }
-  val horizontalPaddingDp = 16
-  val spacingDp = 4
-  val usableWidthDp = (availableWidthDp - horizontalPaddingDp).coerceAtLeast(minCellDp)
-  val widthBasedColumns = ((usableWidthDp + spacingDp) / (minCellDp + spacingDp)).coerceAtLeast(1)
-  return widthBasedColumns.coerceIn(1, safePreferred + 2)
-}
 
 
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/utils/ResponsiveGridUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/utils/ResponsiveGridUtils.kt
@@ -1,0 +1,68 @@
+package app.gyrolet.mpvrx.ui.utils
+
+import androidx.compose.runtime.Composable
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.preferences.BrowserPreferences
+import org.koin.compose.koinInject
+import kotlin.math.abs
+
+fun lcm(a: Int, b: Int): Int {
+  return if (a == 0 || b == 0) 0 else abs(a * b) / gcd(a, b)
+}
+
+fun gcd(a: Int, b: Int): Int {
+  return if (b == 0) a else gcd(b, a % b)
+}
+
+data class ResponsiveGridSpans(
+  val spans: Int,
+  val folderSpan: Int,
+  val videoSpan: Int
+)
+
+@Composable
+fun calculateResponsiveGridSpans(
+  maxWidth: Dp,
+  folderMinWidth: Dp = 100.dp,
+  videoMinWidth: Dp = 130.dp,
+  contentHorizontalPadding: Dp = 8.dp,
+  itemSpacing: Dp = 2.dp,
+  isGridMode: Boolean = true
+): ResponsiveGridSpans {
+  val browserPreferences = koinInject<BrowserPreferences>()
+  val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
+  val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
+  val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+  val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+  val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+
+  if (!isGridMode) {
+    return ResponsiveGridSpans(spans = 1, folderSpan = 1, videoSpan = 1)
+  }
+
+  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+  val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+  val folderGridColumnsPref = if (isLandscape) folderGridColumnsLandscape else folderGridColumnsPortrait
+  val videoGridColumnsPref = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+
+  val maxFolders: Int
+  val maxVideos: Int
+
+  if (manualGridColumnsEnabled) {
+    maxFolders = folderGridColumnsPref.coerceAtLeast(1)
+    maxVideos = videoGridColumnsPref.coerceAtLeast(1)
+  } else {
+    val usableWidth = maxWidth - (contentHorizontalPadding * 2) - itemSpacing
+    maxFolders = (usableWidth / folderMinWidth).toInt().coerceAtLeast(1)
+    maxVideos = (usableWidth / videoMinWidth).toInt().coerceAtLeast(1)
+  }
+
+  val spans = lcm(maxFolders, maxVideos).coerceAtLeast(1)
+  val folderSpan = spans / maxFolders
+  val videoSpan = spans / maxVideos
+
+  return ResponsiveGridSpans(spans = spans, folderSpan = folderSpan, videoSpan = videoSpan)
+}


### PR DESCRIPTION
- Added dynamic grid layouts that automatically adapt based on available screen space. Credits - [@next player](https://github.com/anilbeesetti/NextPlayer)
- Added a Manual Grid option in the Sort & View settings.
- Users can now override the dynamic behavior and choose a fixed grid size from the view options.
- Updated browser-related screens and sort dialogs to support the new grid configuration.