### PR TITLE
Added Fast Thumbnail generator

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -9,6 +9,7 @@ import app.gyrolet.mpvrx.di.PreferencesModule
 import app.gyrolet.mpvrx.presentation.crash.CrashActivity
 import app.gyrolet.mpvrx.presentation.crash.GlobalExceptionHandler
 import app.gyrolet.mpvrx.utils.media.MediaLibraryEvents
+import `is`.xyz.mpv.FastThumbnails
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -47,6 +48,8 @@ class App : Application() {
 
     Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(applicationContext, CrashActivity::class.java))
 
+    FastThumbnails.initialize(this)
+    
     applicationScope.launch {
       runCatching {
         val preferences: PlayerPreferences = getKoin().get()

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/CoilVideoThumbnailDecoder.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/CoilVideoThumbnailDecoder.kt
@@ -267,10 +267,16 @@ class CoilVideoThumbnailDecoder(
   }
 
   private suspend fun generateMPVFastThumbnailWithSolidCheck(
-    path: String,
+    path: String?,
     totalDurationMillis: Long,
     frameAt: Float = 0.33f,
   ): Bitmap? {
+    // 1. Check if path is null or empty
+    if (path.isNullOrEmpty()) {
+      android.util.Log.w("generateMPVFastThumbnailWithSolidCheck", "Invalid path: path is null or empty")
+      return null
+    }
+
     val durationSec = (totalDurationMillis / 1000.0).coerceAtLeast(0.0)
   
     return try {
@@ -279,7 +285,8 @@ class CoilVideoThumbnailDecoder(
         return null
       }
       
-      val positionRatio = frameAt.takeIf { it > 0f } ?: 0.33f
+      // 2. Explicitly convert to Double so all math downstream results in Double
+      val positionRatio = (frameAt.takeIf { it > 0f } ?: 0.33f).toDouble()
   
       val base = (durationSec * positionRatio)
         .coerceIn(1.0, maxOf(1.0, durationSec - 1.0))
@@ -295,10 +302,11 @@ class CoilVideoThumbnailDecoder(
   
       var lastBitmap: Bitmap? = null
   
-      for (pos in candidates) {
+      // 3. Explicitly type 'pos' as Double
+      for (pos: Double in candidates) {
         val bmp = FastThumbnails.generateAsync(
           path,
-          pos,
+          pos, // Guaranteed to be Double here
           MAX_THUMBNAIL_SIZE,
           useHwDec = false
         ) ?: continue
@@ -340,48 +348,56 @@ class CoilVideoThumbnailDecoder(
   }
   
   private suspend fun generateMPVFastThumbnail(
-    path: String,
+    path: String?,
     totalDurationMillis: Long,
     frameAt: Float = 0.33f,
   ): Bitmap? {
+    // 1. Check if path is null or empty
+    if (path.isNullOrEmpty()) {
+      android.util.Log.w("generateMPVFastThumbnail", "Invalid path: path is null or empty")
+      return null
+    }
+
     val durationSec = (totalDurationMillis / 1000.0).coerceAtLeast(0.0)
   
     return try {
       if (durationSec <= 0.5) {
-        android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail failed: too short video For ${path}")
+        android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail failed: too short video For $path")
         return null
       }
       
-      val positionRatio = frameAt.takeIf { it > 0f } ?: 0.33f
+      // 2. Explicitly convert to Double so all math downstream results in Double
+      val positionRatio = (frameAt.takeIf { it > 0f } ?: 0.33f).toDouble()
   
       // ---- Deterministic pick (single frame only) ----
       val rawTarget = durationSec * positionRatio
   
-      val targetPosition = rawTarget
+      // 3. Explicitly type 'targetPosition' as Double
+      val targetPosition: Double = rawTarget
         .coerceAtLeast(1.0)                  // avoid black/intro frames
         .coerceAtMost(durationSec - 1.0)     // avoid end fade/black frame
   
       val bmp = FastThumbnails.generateAsync(
         path,
-        targetPosition,
+        targetPosition, // Guaranteed to be Double here
         MAX_THUMBNAIL_SIZE,
         useHwDec = false
       )
   
       if (bmp == null) {
-        android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generation failed: null frame For ${path}")
+        android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generation failed: null frame For $path")
         return null
       }
       
-      android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generated successfully At ${targetPosition}s For ${path}")
+      android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generated successfully At ${targetPosition}s For $path")
       bmp
   
     } catch (e: Throwable) {
-      android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generation failed: ${e.message} For ${path}")
+      android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generation failed: ${e.message} For $path")
       null
     }
   }
-
+  
   private suspend fun decodeWithSoftwareCodec(
     path: String,
     timeUs: Long,

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/CoilVideoThumbnailDecoder.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/CoilVideoThumbnailDecoder.kt
@@ -20,6 +20,7 @@ import android.util.Size
 import android.view.Surface
 import androidx.core.graphics.drawable.toDrawable
 import app.gyrolet.mpvrx.utils.storage.FileTypeUtils
+import `is`.xyz.mpv.FastThumbnails
 import coil3.ImageLoader
 import coil3.annotation.ExperimentalCoilApi
 import coil3.asImage
@@ -106,7 +107,8 @@ class CoilVideoThumbnailDecoder(
         when (strategy) {
           ThumbnailStrategy.FirstFrame -> retriever.getThumbnailFrameAt(0)
           is ThumbnailStrategy.FrameAtPercentage -> {
-            retriever.getThumbnailFrameAt(frameTimeMicros(retriever, strategy.percentage))
+            // retriever.getThumbnailFrameAt(frameTimeMicros(retriever, strategy.percentage))
+            generateMPVFastThumbnailWithSolidCheck(sourcePath, getTotalDurationMillis(retriever), strategy.percentage)
           }
 
           is ThumbnailStrategy.Hybrid -> {
@@ -190,6 +192,12 @@ class CoilVideoThumbnailDecoder(
       else -> null
     }
   }
+  
+  private fun getTotalDurationMillis(
+    retriever: MediaMetadataRetriever,
+  ): Long {
+    return retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0L
+  }
 
   private fun frameTimeMicros(
     retriever: MediaMetadataRetriever,
@@ -256,6 +264,122 @@ class CoilVideoThumbnailDecoder(
       bitmap.recycle()
     }
     return rotated
+  }
+
+  private suspend fun generateMPVFastThumbnailWithSolidCheck(
+    path: String,
+    totalDurationMillis: Long,
+    frameAt: Float = 0.33f,
+  ): Bitmap? {
+    val durationSec = (totalDurationMillis / 1000.0).coerceAtLeast(0.0)
+  
+    return try {
+      if (durationSec <= 0.5) {
+        android.util.Log.w("generateMPVFastThumbnailWithSolidCheck", "Too short video: $path")
+        return null
+      }
+      
+      val positionRatio = frameAt.takeIf { it > 0f } ?: 0.33f
+  
+      val base = (durationSec * positionRatio)
+        .coerceIn(1.0, maxOf(1.0, durationSec - 1.0))
+  
+      val candidates = listOf(
+        base,
+        durationSec * 0.15,
+        durationSec * 0.5,
+        durationSec * 0.75
+      ).map {
+        it.coerceIn(1.0, maxOf(1.0, durationSec - 1.0))
+      }.distinct()
+  
+      var lastBitmap: Bitmap? = null
+  
+      for (pos in candidates) {
+        val bmp = FastThumbnails.generateAsync(
+          path,
+          pos,
+          MAX_THUMBNAIL_SIZE,
+          useHwDec = false
+        ) ?: continue
+  
+        lastBitmap?.recycle()
+        lastBitmap = bmp
+  
+        if (!isMostlySolidThumbnail(bmp)) {
+          android.util.Log.w(
+            "generateMPVFastThumbnailWithSolidCheck",
+            "Good thumbnail at ${pos}s for $path"
+          )
+          return bmp
+        }
+      }
+  
+      // fallback: return last bitmap even if solid
+      if (lastBitmap != null) {
+        android.util.Log.w(
+          "generateMPVFastThumbnailWithSolidCheck",
+          "Fallback solid thumbnail returned for $path"
+        )
+      } else {
+        android.util.Log.w(
+          "generateMPVFastThumbnailWithSolidCheck",
+          "No frame extracted at all for $path"
+        )
+      }
+  
+      lastBitmap
+  
+    } catch (e: Throwable) {
+      android.util.Log.w(
+        "generateMPVFastThumbnailWithSolidCheck",
+        "Exception: ${e.message} for $path"
+      )
+      null
+    }
+  }
+  
+  private suspend fun generateMPVFastThumbnail(
+    path: String,
+    totalDurationMillis: Long,
+    frameAt: Float = 0.33f,
+  ): Bitmap? {
+    val durationSec = (totalDurationMillis / 1000.0).coerceAtLeast(0.0)
+  
+    return try {
+      if (durationSec <= 0.5) {
+        android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail failed: too short video For ${path}")
+        return null
+      }
+      
+      val positionRatio = frameAt.takeIf { it > 0f } ?: 0.33f
+  
+      // ---- Deterministic pick (single frame only) ----
+      val rawTarget = durationSec * positionRatio
+  
+      val targetPosition = rawTarget
+        .coerceAtLeast(1.0)                  // avoid black/intro frames
+        .coerceAtMost(durationSec - 1.0)     // avoid end fade/black frame
+  
+      val bmp = FastThumbnails.generateAsync(
+        path,
+        targetPosition,
+        MAX_THUMBNAIL_SIZE,
+        useHwDec = false
+      )
+  
+      if (bmp == null) {
+        android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generation failed: null frame For ${path}")
+        return null
+      }
+      
+      android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generated successfully At ${targetPosition}s For ${path}")
+      bmp
+  
+    } catch (e: Throwable) {
+      android.util.Log.w("generateMPVFastThumbnail", "MPV thumbnail generation failed: ${e.message} For ${path}")
+      null
+    }
   }
 
   private suspend fun decodeWithSoftwareCodec(

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
@@ -54,7 +54,7 @@ class ThumbnailRepository(
   private val ongoingOperations = ConcurrentHashMap<String, Deferred<Bitmap?>>()
   private val repositoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
   private val maxConcurrentFolders = 3
-  private val generationSemaphore = Semaphore(1)
+  private val generationSemaphore = Semaphore(4)
   private val maxFolderBatchSize = 48
   private val generationFrameDelayMs = 12L
 
@@ -146,7 +146,7 @@ class ThumbnailRepository(
         }
 
       ongoingOperations[key] = deferred
-      deferred.await()
+      return@withContext deferred.await()
     }
 
   suspend fun getCachedThumbnail(


### PR DESCRIPTION
Added MPV Native Fast Thumbnail Generator

Introduced native MPV-based thumbnail generation with two variants:

- "generateMPVFastThumbnail"
  
  - Generates and returns a thumbnail for a specified playback position.

- "generateMPVFastThumbnailWithSolidCheck"
  
  - Generates a thumbnail and checks whether it is mostly a solid-color frame.
  - If the generated thumbnail is detected as mostly solid, it retries up to 3 additional times until a non-solid thumbnail is found.

Features

- Supports all video codecs supported by MPV.
- Faster thumbnail extraction using MPV's native capabilities.
- Improved thumbnail quality by avoiding blank or mostly solid frames.