### PR TITLE
feat(ui): implement tablet dual-pane layouts for folder view and settings

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
@@ -25,6 +25,7 @@ class BrowserPreferences(
   val videoSortOrder = preferenceStore.getEnum("video_sort_order", SortOrder.Ascending)
 
   val folderViewMode = preferenceStore.getEnum("folder_view_mode", FolderViewMode.AlbumView)
+  val dualPaneForTablet = preferenceStore.getBoolean("dual_pane_for_tablet", true)
 
   private val isTablet = context.resources.configuration.smallestScreenWidthDp >= 600
   val maxColumns = if (isTablet) 8 else 4

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -27,6 +28,7 @@ import app.gyrolet.mpvrx.ui.player.NavigationAnimStyle
 import org.koin.compose.koinInject
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -117,6 +119,7 @@ object MainScreen : Screen {
     val showNetworkTab by appearancePreferences.showNetworkTab.collectAsState()
     val hideNavigationBar = NavigationBarState.shouldHideNavigationBar
     val isPermissionDenied = NavigationBarState.isPermissionDenied
+    val isDualPaneFolderSelected = NavigationBarState.isDualPaneFolderSelected
     
     val visibleTabs = remember(
       showHomeTab,
@@ -129,6 +132,37 @@ object MainScreen : Screen {
         if (showRecentsTab) add(MainTab.RECENTS)
         if (showPlaylistsTab) add(MainTab.PLAYLISTS)
         if (showNetworkTab) add(MainTab.NETWORK)
+      }
+    }
+
+    val mainNavBar = @Composable { modifier: Modifier ->
+      NavigationBar(
+        modifier = modifier.clip(AppShapeScale.extraLargeIncreased)
+      ) {
+        visibleTabs.forEach { tab ->
+          NavigationBarItem(
+            icon = {
+              when (tab) {
+                MainTab.HOME -> Icon(Icons.Filled.Home, contentDescription = "Home")
+                MainTab.RECENTS -> Icon(Icons.Filled.History, contentDescription = "Recents")
+                MainTab.PLAYLISTS -> Icon(Icons.Filled.PlaylistPlay, contentDescription = "Playlists")
+                MainTab.NETWORK -> Icon(Icons.Filled.BringYourOwnIp, contentDescription = "Network")
+              }
+            },
+            label = {
+              Text(
+                when (tab) {
+                  MainTab.HOME -> "Home"
+                  MainTab.RECENTS -> "Recents"
+                  MainTab.PLAYLISTS -> "Playlists"
+                  MainTab.NETWORK -> "Network"
+                }
+              )
+            },
+            selected = selectedTab == tab,
+            onClick = { selectedTab = tab },
+          )
+        }
       }
     }
     
@@ -145,10 +179,54 @@ object MainScreen : Screen {
       }
     }
 
+    val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val targetNavBarWidth = if (isDualPaneFolderSelected) screenWidth * 0.4f else screenWidth
+
+    val navBarWidth by animateDpAsState(
+      targetValue = targetNavBarWidth,
+      animationSpec = spring(
+        dampingRatio = Spring.DampingRatioNoBouncy,
+        stiffness = Spring.StiffnessMediumLow
+      ),
+      label = "nav_bar_width"
+    )
+
     // Scaffold with bottom navigation bar
     Scaffold(
       modifier = Modifier.fillMaxSize(),
-      bottomBar = {
+    ) { paddingValues ->
+      Box(modifier = Modifier.fillMaxSize()) {
+        val fabBottomPadding = 80.dp
+
+        AnimatedContent(
+          targetState = selectedTab,
+          transitionSpec = {
+            val initialIndex = visibleTabs.indexOf(initialState)
+            val targetIndex = visibleTabs.indexOf(targetState)
+            buildNavTransition(
+              forward = targetIndex >= initialIndex,
+              style   = navAnimStyle,
+              speed   = animSpeed,
+              density = density,
+            )
+          },
+          label = "tab_animation"
+        ) { targetTab ->
+          CompositionLocalProvider(
+            LocalNavigationBarHeight provides fabBottomPadding,
+            LocalMainNavigationBar provides mainNavBar
+          ) {
+            val effectiveTab = if (visibleTabs.isEmpty()) MainTab.HOME else targetTab
+            when (effectiveTab) {
+              MainTab.HOME -> FolderListScreen.Content()
+              MainTab.RECENTS -> RecentlyPlayedScreen.Content()
+              MainTab.PLAYLISTS -> PlaylistScreen.Content()
+              MainTab.NETWORK -> NetworkStreamingScreen.Content()
+            }
+          }
+        }
+
         // Animated bottom navigation bar with slide animations
         AnimatedVisibility(
           visible = !hideNavigationBar && visibleTabs.isNotEmpty() && !isPermissionDenied,
@@ -165,10 +243,12 @@ object MainScreen : Screen {
               stiffness = AppMotion.Spatial.StandardDp.stiffness,
             ),
             targetOffsetY = { fullHeight -> fullHeight }
-          )
+          ),
+          modifier = Modifier.align(androidx.compose.ui.Alignment.BottomStart)
         ) {
           NavigationBar(
             modifier = Modifier
+              .width(navBarWidth)
               .clip(AppShapeScale.extraLargeIncreased)
           ) {
             visibleTabs.forEach { tab ->
@@ -198,43 +278,16 @@ object MainScreen : Screen {
           }
         }
       }
-    ) { paddingValues ->
-      Box(modifier = Modifier.fillMaxSize()) {
-        val fabBottomPadding =  80.dp 
-
-        AnimatedContent(
-          targetState = selectedTab,
-          transitionSpec = {
-            val initialIndex = visibleTabs.indexOf(initialState)
-            val targetIndex = visibleTabs.indexOf(targetState)
-            buildNavTransition(
-              forward = targetIndex >= initialIndex,
-              style   = navAnimStyle,
-              speed   = animSpeed,
-              density = density,
-            )
-          },
-          label = "tab_animation"
-        ) { targetTab ->
-          CompositionLocalProvider(
-            LocalNavigationBarHeight provides fabBottomPadding
-          ) {
-            val effectiveTab = if (visibleTabs.isEmpty()) MainTab.HOME else targetTab
-            when (effectiveTab) {
-              MainTab.HOME -> FolderListScreen.Content()
-              MainTab.RECENTS -> RecentlyPlayedScreen.Content()
-              MainTab.PLAYLISTS -> PlaylistScreen.Content()
-              MainTab.NETWORK -> NetworkStreamingScreen.Content()
-            }
-          }
-        }
-      }
     }
   }
 }
 
-// CompositionLocal for navigation bar height
 val LocalNavigationBarHeight = compositionLocalOf { 0.dp }
+
+// CompositionLocal for main navigation bar
+val LocalMainNavigationBar = compositionLocalOf<@Composable (Modifier) -> Unit> {
+  { }
+}
 
 /** Builds the [ContentTransform] for tab navigation based on the selected style. */
 fun buildNavTransition(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/NavigationBarState.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/NavigationBarState.kt
@@ -12,6 +12,8 @@ object NavigationBarState {
   var isInSelectionMode: Boolean by mutableStateOf(false)
     private set
 
+  var isDualPaneFolderSelected: Boolean by mutableStateOf(false)
+
   var shouldHideNavigationBar: Boolean by mutableStateOf(false)
     private set
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
@@ -32,6 +32,7 @@ fun FolderSortDialog(
   val showDateChip by browserPreferences.showDateChip.collectAsState()
   val showFolderPath by browserPreferences.showFolderPath.collectAsState()
   val showFolderThumbnails by browserPreferences.showFolderThumbnails.collectAsState()
+  val dualPaneForTablet by browserPreferences.dualPaneForTablet.collectAsState()
   val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
   val folderViewMode by browserPreferences.folderViewMode.collectAsState()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
@@ -10,8 +10,11 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.key
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -42,6 +45,7 @@ import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleFloatingActionButton
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
@@ -49,6 +53,7 @@ import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.animateFloatingActionButton
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -86,6 +91,7 @@ import app.gyrolet.mpvrx.preferences.MediaLayoutMode
 import app.gyrolet.mpvrx.preferences.SortOrder
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.presentation.Screen
+import app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen
 import app.gyrolet.mpvrx.presentation.components.pullrefresh.PullRefreshBox
 import app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight
 import app.gyrolet.mpvrx.ui.browser.cards.FolderCard
@@ -174,6 +180,21 @@ object FolderListScreen : Screen {
     val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
     val enableRecentlyPlayed by advancedPreferences.enableRecentlyPlayed.collectAsState()
     val pinnedFolderPaths by foldersPreferences.pinnedFolders.collectAsState()
+    val dualPaneForTablet by browserPreferences.dualPaneForTablet.collectAsState()
+
+    val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val isTablet = configuration.smallestScreenWidthDp >= 600
+    val isDualPaneActive = isTablet && dualPaneForTablet
+
+    var selectedFolderBucketId by rememberSaveable { mutableStateOf<String?>(null) }
+    var selectedFolderName by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(isDualPaneActive) {
+      if (!isDualPaneActive) {
+        selectedFolderBucketId = null
+        selectedFolderName = null
+      }
+    }
 
     // UI state - use standalone states to avoid scroll issues with predictive back gesture
     val listState = rememberLazyListState()
@@ -329,6 +350,10 @@ object FolderListScreen : Screen {
       )
     }
 
+    LaunchedEffect(isDualPaneActive, selectedFolderBucketId) {
+      navBarState.isDualPaneFolderSelected = isDualPaneActive && selectedFolderBucketId != null
+    }
+
     // Lifecycle observer for refresh
     DisposableEffect(lifecycleOwner) {
       val observer = LifecycleEventObserver { _, event ->
@@ -341,7 +366,7 @@ object FolderListScreen : Screen {
     }
 
     // Optimized back handler for immediate response
-    val shouldHandleBack = selectionManager.isInSelectionMode || isSearching || isFabExpanded.value
+    val shouldHandleBack = selectionManager.isInSelectionMode || isSearching || isFabExpanded.value || (isDualPaneActive && selectedFolderBucketId != null)
     androidx.activity.compose.BackHandler(enabled = shouldHandleBack) {
       when {
         isFabExpanded.value -> isFabExpanded.value = false
@@ -349,6 +374,10 @@ object FolderListScreen : Screen {
         isSearching -> {
           isSearching = false
           searchQuery = ""
+        }
+        isDualPaneActive && selectedFolderBucketId != null -> {
+          selectedFolderBucketId = null
+          selectedFolderName = null
         }
       }
     }
@@ -362,341 +391,389 @@ object FolderListScreen : Screen {
       onExpandedChange = { isFabExpanded.value = it },
     )
 
-    Scaffold(
-      topBar = {
-        if (isSearching) {
-          SearchBar(
-            inputField = {
-              SearchBarDefaults.InputField(
-                query = searchQuery,
-                onQueryChange = { searchQuery = it },
-                onSearch = { },
-                expanded = false,
-                onExpandedChange = { },
-                placeholder = { Text("Search folders and videos...") },
-                leadingIcon = {
-                  Icon(
-                    imageVector = Icons.Filled.Search,
-                    contentDescription = "Search",
-                  )
-                },
-                trailingIcon = {
-                  IconButton(
-                    onClick = {
-                      isSearching = false
-                      searchQuery = ""
-                    },
-                  ) {
+    @Composable
+    fun FoldersPane() {
+      Scaffold(
+        topBar = {
+          if (isSearching) {
+            SearchBar(
+              inputField = {
+                SearchBarDefaults.InputField(
+                  query = searchQuery,
+                  onQueryChange = { searchQuery = it },
+                  onSearch = { },
+                  expanded = false,
+                  onExpandedChange = { },
+                  placeholder = { Text("Search folders and videos...") },
+                  leadingIcon = {
                     Icon(
-                      imageVector = Icons.Filled.Close,
-                      contentDescription = "Cancel",
+                      imageVector = Icons.Filled.Search,
+                      contentDescription = "Search",
                     )
-                  }
-                },
-                modifier = Modifier.focusRequester(focusRequester),
-              )
-            },
-            expanded = false,
-            onExpandedChange = { },
-            modifier = Modifier
-              .fillMaxWidth()
-              .padding(horizontal = 16.dp),
-            shape = RoundedCornerShape(28.dp),
-            tonalElevation = 6.dp,
-          ) {
-            // Empty content for SearchBar
-          }
-        } else {
-          BrowserTopBar(
-            title = stringResource(app.gyrolet.mpvrx.R.string.app_name),
-            isInSelectionMode = selectionManager.isInSelectionMode,
-            selectedCount = selectionManager.selectedCount,
-            totalCount = videoFolders.size,
-            onBackClick = null,
-            onCancelSelection = { selectionManager.clear() },
-            onSortClick = { sortDialogOpen.value = true },
-            onSearchClick = {
-              isSearching = !isSearching
-              coroutineScope.launch {
-                buildSearchIndex(context)
-              }
-            },
-            onSettingsClick = {
-              backstack.add(app.gyrolet.mpvrx.ui.preferences.PreferencesScreen)
-            },
-            onRenameClick = null,
-            isSingleSelection = selectionManager.isSingleSelection,
-            onInfoClick = null,
-            onShareClick = {
-              coroutineScope.launch {
-                val selectedIds = selectionManager.getSelectedItems().map { it.bucketId }.toSet()
-                val allVideos = app.gyrolet.mpvrx.repository.MediaFileRepository
-                  .getVideosForBuckets(context, selectedIds)
-                if (allVideos.isNotEmpty()) {
-                  MediaUtils.shareVideos(context, allVideos)
+                  },
+                  trailingIcon = {
+                    IconButton(
+                      onClick = {
+                        isSearching = false
+                        searchQuery = ""
+                      },
+                    ) {
+                      Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Cancel",
+                      )
+                    }
+                  },
+                  modifier = Modifier.focusRequester(focusRequester),
+                )
+              },
+              expanded = false,
+              onExpandedChange = { },
+              modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+              shape = RoundedCornerShape(28.dp),
+              tonalElevation = 6.dp,
+            ) {
+              // Empty content for SearchBar
+            }
+          } else {
+            BrowserTopBar(
+              title = stringResource(app.gyrolet.mpvrx.R.string.app_name),
+              isInSelectionMode = selectionManager.isInSelectionMode,
+              selectedCount = selectionManager.selectedCount,
+              totalCount = videoFolders.size,
+              onBackClick = null,
+              onCancelSelection = { selectionManager.clear() },
+              onSortClick = { sortDialogOpen.value = true },
+              onSearchClick = {
+                isSearching = !isSearching
+                coroutineScope.launch {
+                  buildSearchIndex(context)
                 }
-              }
-            },
-            onCopyClick = {
-              val selectedPaths = selectionManager.getSelectedItems().map { it.path }.distinct()
-              if (selectedPaths.isNotEmpty()) {
-                SafeClipboard.copyPlainText(context, "Selected folder paths", selectedPaths.joinToString("\n"))
-              }
-            },
-            onPlayClick = {
-              coroutineScope.launch {
-                val selectedIds = selectionManager.getSelectedItems().map { it.bucketId }.toSet()
-                val allVideos = app.gyrolet.mpvrx.repository.MediaFileRepository
-                  .getVideosForBuckets(context, selectedIds)
-                if (allVideos.isNotEmpty()) {
-                  if (allVideos.size == 1) {
-                    MediaUtils.playFile(allVideos.first(), context)
-                  } else {
-                    val intent = Intent(Intent.ACTION_VIEW, allVideos.first().uri)
-                    intent.setClass(context, app.gyrolet.mpvrx.ui.player.PlayerActivity::class.java)
-                    intent.putExtra("internal_launch", true)
-                    intent.putParcelableArrayListExtra("playlist", ArrayList(allVideos.map { it.uri }))
-                    intent.putExtra("playlist_index", 0)
-                    intent.putExtra("launch_source", "playlist")
-                    context.startActivity(intent)
+              },
+              onSettingsClick = {
+                backstack.add(app.gyrolet.mpvrx.ui.preferences.PreferencesScreen)
+              },
+              onRenameClick = null,
+              isSingleSelection = selectionManager.isSingleSelection,
+              onInfoClick = null,
+              onShareClick = {
+                coroutineScope.launch {
+                  val selectedIds = selectionManager.getSelectedItems().map { it.bucketId }.toSet()
+                  val allVideos = app.gyrolet.mpvrx.repository.MediaFileRepository
+                    .getVideosForBuckets(context, selectedIds)
+                  if (allVideos.isNotEmpty()) {
+                    MediaUtils.shareVideos(context, allVideos)
                   }
+                }
+              },
+              onCopyClick = {
+                val selectedPaths = selectionManager.getSelectedItems().map { it.path }.distinct()
+                if (selectedPaths.isNotEmpty()) {
+                  SafeClipboard.copyPlainText(context, "Selected folder paths", selectedPaths.joinToString("\n"))
+                }
+              },
+              onPlayClick = {
+                coroutineScope.launch {
+                  val selectedIds = selectionManager.getSelectedItems().map { it.bucketId }.toSet()
+                  val allVideos = app.gyrolet.mpvrx.repository.MediaFileRepository
+                    .getVideosForBuckets(context, selectedIds)
+                  if (allVideos.isNotEmpty()) {
+                    if (allVideos.size == 1) {
+                      MediaUtils.playFile(allVideos.first(), context)
+                    } else {
+                      val intent = Intent(Intent.ACTION_VIEW, allVideos.first().uri)
+                      intent.setClass(context, app.gyrolet.mpvrx.ui.player.PlayerActivity::class.java)
+                      intent.putExtra("internal_launch", true)
+                      intent.putParcelableArrayListExtra("playlist", ArrayList(allVideos.map { it.uri }))
+                      intent.putExtra("playlist_index", 0)
+                      intent.putExtra("launch_source", "playlist")
+                      context.startActivity(intent)
+                    }
+                    selectionManager.clear()
+                  }
+                }
+              },
+              onPinClick = {
+                coroutineScope.launch {
+                  val selectedFolders = selectionManager.getSelectedItems()
+                  if (selectedFolders.isEmpty()) return@launch
+                  val updated = foldersPreferences.pinnedFolders.get().toMutableSet()
+                  val shouldUnpinAll = selectedFolders.all { it.path in updated }
+                  selectedFolders.forEach { folder ->
+                    if (shouldUnpinAll) {
+                      updated.remove(folder.path)
+                    } else {
+                      updated.add(folder.path)
+                    }
+                  }
+                  foldersPreferences.pinnedFolders.set(updated)
                   selectionManager.clear()
                 }
-              }
-            },
-            onPinClick = {
-              coroutineScope.launch {
-                val selectedFolders = selectionManager.getSelectedItems()
-                if (selectedFolders.isEmpty()) return@launch
-                val updated = foldersPreferences.pinnedFolders.get().toMutableSet()
-                val shouldUnpinAll = selectedFolders.all { it.path in updated }
-                selectedFolders.forEach { folder ->
-                  if (shouldUnpinAll) {
-                    updated.remove(folder.path)
+              },
+              onBlacklistClick = {
+                coroutineScope.launch {
+                  val selectedFolders = selectionManager.getSelectedItems()
+                  val blacklistedFolders = foldersPreferences.blacklistedFolders.get().toMutableSet()
+                  selectedFolders.forEach { folder ->
+                    blacklistedFolders.add(folder.path)
+                  }
+                  foldersPreferences.blacklistedFolders.set(blacklistedFolders)
+                  selectionManager.clear()
+                  viewModel.refresh()
+                  android.widget.Toast.makeText(
+                    context,
+                    foldersBlacklistedMessage,
+                    android.widget.Toast.LENGTH_SHORT,
+                  ).show()
+                }
+              },
+              onDeleteClick = null,
+              onSelectAll = { selectionManager.selectAll() },
+              onInvertSelection = { selectionManager.invertSelection() },
+              onDeselectAll = { selectionManager.clear() },
+            )
+          }
+        },
+        floatingActionButton = {
+          FloatingActionButtonMenu(
+            modifier = Modifier.padding(bottom = navigationBarHeight + 8.dp),
+            expanded = isFabExpanded.value,
+            button = {
+              TooltipBox(
+                positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                  if (isFabExpanded.value) {
+                    TooltipAnchorPosition.Start
                   } else {
-                    updated.add(folder.path)
+                    TooltipAnchorPosition.Above
                   }
-                }
-                foldersPreferences.pinnedFolders.set(updated)
-                selectionManager.clear()
-              }
-            },
-            onBlacklistClick = {
-              coroutineScope.launch {
-                val selectedFolders = selectionManager.getSelectedItems()
-                val blacklistedFolders = foldersPreferences.blacklistedFolders.get().toMutableSet()
-                selectedFolders.forEach { folder ->
-                  blacklistedFolders.add(folder.path)
-                }
-                foldersPreferences.blacklistedFolders.set(blacklistedFolders)
-                selectionManager.clear()
-                viewModel.refresh()
-                android.widget.Toast.makeText(
-                  context,
-                  foldersBlacklistedMessage,
-                  android.widget.Toast.LENGTH_SHORT,
-                ).show()
-              }
-            },
-            onDeleteClick = null,
-            onSelectAll = { selectionManager.selectAll() },
-            onInvertSelection = { selectionManager.invertSelection() },
-            onDeselectAll = { selectionManager.clear() },
-          )
-        }
-      },
-      floatingActionButton = {
-        FloatingActionButtonMenu(
-          modifier = Modifier.padding(bottom = navigationBarHeight + 8.dp),
-          expanded = isFabExpanded.value,
-          button = {
-            TooltipBox(
-              positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                if (isFabExpanded.value) {
-                  TooltipAnchorPosition.Start
-                } else {
-                  TooltipAnchorPosition.Above
-                }
-              ),
-              tooltip = { PlainTooltip { Text("Toggle menu") } },
-              state = rememberTooltipState(),
-            ) {
-              ToggleFloatingActionButton(
-                modifier = Modifier.animateFloatingActionButton(
-                  visible = !selectionManager.isInSelectionMode && isFabVisible.value && !app.gyrolet.mpvrx.ui.browser.MainScreen.getPermissionDeniedState(),
-                  alignment = Alignment.BottomEnd,
                 ),
-                checked = isFabExpanded.value,
-                onCheckedChange = { isFabExpanded.value = !isFabExpanded.value },
+                tooltip = { PlainTooltip { Text("Toggle menu") } },
+                state = rememberTooltipState(),
               ) {
-                val imageVector by remember {
-                  derivedStateOf {
-                    if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.PlayArrow
+                ToggleFloatingActionButton(
+                  modifier = Modifier.animateFloatingActionButton(
+                    visible = !selectionManager.isInSelectionMode && isFabVisible.value && !app.gyrolet.mpvrx.ui.browser.MainScreen.getPermissionDeniedState() && !(isDualPaneActive && selectedFolderBucketId != null),
+                    alignment = Alignment.BottomEnd,
+                  ),
+                  checked = isFabExpanded.value,
+                  onCheckedChange = { isFabExpanded.value = !isFabExpanded.value },
+                ) {
+                  val imageVector by remember {
+                    derivedStateOf {
+                      if (checkedProgress > 0.5f) Icons.Filled.Close else Icons.Filled.PlayArrow
+                    }
+                  }
+                  Icon(
+                    imageVector = imageVector,
+                    contentDescription = null,
+                    modifier = Modifier.animateIcon({ checkedProgress }),
+                  )
+                }
+              }
+            },
+          ) {
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded.value = false
+                filePicker.launch(arrayOf("video/*"))
+              },
+              icon = { Icon(Icons.Filled.FileOpen, contentDescription = null) },
+              text = { Text(text = "Open File") },
+            )
+
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded.value = false
+                coroutineScope.launch {
+                  val recentlyPlayedVideos = RecentlyPlayedOps.getRecentlyPlayed(limit = 1)
+                  val lastPlayed = recentlyPlayedVideos.firstOrNull()
+                  if (lastPlayed != null) {
+                    MediaUtils.playFile(lastPlayed.filePath, context, "recently_played_button")
                   }
                 }
-                Icon(
-                  imageVector = imageVector,
-                  contentDescription = null,
-                  modifier = Modifier.animateIcon({ checkedProgress }),
+              },
+              icon = { Icon(Icons.Filled.History, contentDescription = null) },
+              text = { Text(text = "Recently Played") },
+            )
+
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded.value = false
+                showLinkDialog.value = true
+              },
+              icon = { Icon(Icons.Filled.Link, contentDescription = null) },
+              text = { Text(text = "Open Link") },
+            )
+          }
+        },
+      ) { padding ->
+        Box(modifier = Modifier.padding(padding)) {
+          when (permissionState.status) {
+            PermissionStatus.Granted -> {
+              if (isSearching) {
+                // Show search results
+                Box(modifier = Modifier.fillMaxSize()) {
+                  if (isSearchLoading) {
+                    // Loading state
+                    Box(
+                      modifier = Modifier.fillMaxSize(),
+                      contentAlignment = Alignment.Center,
+                    ) {
+                      CircularProgressIndicator()
+                    }
+                  } else if (searchResults.isEmpty()) {
+                    // No results
+                    EmptyState(
+                      icon = Icons.Filled.Search,
+                      title = "No results found",
+                      message = "No folders or videos match your search query",
+                      modifier = Modifier.fillMaxSize(),
+                    )
+                  } else {
+                    // Show search results
+                    SearchResultsContent(
+                      searchResults = searchResults,
+                      navigationBarHeight = navigationBarHeight,
+                      onFolderClick = { folder ->
+                        if (isDualPaneActive) {
+                          selectedFolderBucketId = folder.bucketId
+                          selectedFolderName = folder.name
+                          isSearching = false
+                          searchQuery = ""
+                        } else {
+                          backstack.add(app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen(folder.bucketId, folder.name))
+                        }
+                      },
+                      onVideoClick = { video ->
+                        MediaUtils.playFile(video, context)
+                      },
+                      mediaLayoutMode = mediaLayoutMode,
+                    )
+                  }
+                }
+              } else {
+                FolderListContent(
+                  folders = filteredFolders,
+                  foldersWithNewCount = foldersWithNewCount,
+                  pinnedFolderPaths = pinnedFolderPaths,
+                  recentlyPlayedFilePath = recentlyPlayedFilePath,
+                  isLoading = isLoading,
+                  scanStatus = scanStatus,
+                  hasCompletedInitialLoad = hasCompletedInitialLoad,
+                  foldersWereDeleted = foldersWereDeleted,
+                  mediaLayoutMode = mediaLayoutMode,
+                  tapThumbnailToSelect = tapThumbnailToSelect,
+                  navigationBarHeight = navigationBarHeight,
+                  listState = listState,
+                  gridState = gridState,
+                  isRefreshing = isRefreshing,
+                  selectionManager = selectionManager,
+                  onRefresh = { viewModel.refresh() },
+                  onFolderClick = { folder ->
+                    if (selectionManager.isInSelectionMode) {
+                      selectionManager.toggle(folder)
+                    } else {
+                      if (isDualPaneActive) {
+                        selectedFolderBucketId = folder.bucketId
+                        selectedFolderName = folder.name
+                      } else {
+                        backstack.add(app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen(folder.bucketId, folder.name))
+                      }
+                    }
+                  },
+                  onFolderLongClick = { folder ->
+                    selectionManager.handleLongClick(folder)
+                  },
+                  onTogglePin = { folder ->
+                    coroutineScope.launch {
+                      val updated = foldersPreferences.pinnedFolders.get().toMutableSet()
+                      if (!updated.add(folder.path)) {
+                        updated.remove(folder.path)
+                      }
+                      foldersPreferences.pinnedFolders.set(updated)
+                    }
+                  },
+                  selectedFolderBucketId = selectedFolderBucketId,
                 )
               }
             }
-          },
-        ) {
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded.value = false
-              filePicker.launch(arrayOf("video/*"))
-            },
-            icon = { Icon(Icons.Filled.FileOpen, contentDescription = null) },
-            text = { Text(text = "Open File") },
-          )
 
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded.value = false
-              coroutineScope.launch {
-                val recentlyPlayedVideos = RecentlyPlayedOps.getRecentlyPlayed(limit = 1)
-                val lastPlayed = recentlyPlayedVideos.firstOrNull()
-                if (lastPlayed != null) {
-                  MediaUtils.playFile(lastPlayed.filePath, context, "recently_played_button")
-                }
-              }
-            },
-            icon = { Icon(Icons.Filled.History, contentDescription = null) },
-            text = { Text(text = "Recently Played") },
-          )
-
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded.value = false
-              showLinkDialog.value = true
-            },
-            icon = { Icon(Icons.Filled.Link, contentDescription = null) },
-            text = { Text(text = "Open Link") },
-          )
-        }
-      },
-    ) { padding ->
-      Box(modifier = Modifier.padding(padding)) {
-        when (permissionState.status) {
-          PermissionStatus.Granted -> {
-            if (isSearching) {
-              // Show search results
-              Box(modifier = Modifier.fillMaxSize()) {
-                if (isSearchLoading) {
-                  // Loading state
-                  Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                  ) {
-                    CircularProgressIndicator()
-                  }
-                } else if (searchResults.isEmpty()) {
-                  // No results
-                  EmptyState(
-                    icon = Icons.Filled.Search,
-                    title = "No results found",
-                    message = "No folders or videos match your search query",
-                    modifier = Modifier.fillMaxSize(),
-                  )
-                } else {
-                  // Show search results
-                  SearchResultsContent(
-                    searchResults = searchResults,
-                    navigationBarHeight = navigationBarHeight,
-                    onFolderClick = { folder ->
-                      backstack.add(app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen(folder.bucketId, folder.name))
-                    },
-                    onVideoClick = { video ->
-                      MediaUtils.playFile(video, context)
-                    },
-                    mediaLayoutMode = mediaLayoutMode,
-                  )
-                }
-              }
-            } else {
-              FolderListContent(
-                folders = filteredFolders,
-                foldersWithNewCount = foldersWithNewCount,
-                pinnedFolderPaths = pinnedFolderPaths,
-                recentlyPlayedFilePath = recentlyPlayedFilePath,
-                isLoading = isLoading,
-                scanStatus = scanStatus,
-                hasCompletedInitialLoad = hasCompletedInitialLoad,
-                foldersWereDeleted = foldersWereDeleted,
-                mediaLayoutMode = mediaLayoutMode,
-                tapThumbnailToSelect = tapThumbnailToSelect,
-                navigationBarHeight = navigationBarHeight,
-                listState = listState,
-                gridState = gridState,
-                isRefreshing = isRefreshing,
-                selectionManager = selectionManager,
-                onRefresh = { viewModel.refresh() },
-                onFolderClick = { folder ->
-                  if (selectionManager.isInSelectionMode) {
-                    selectionManager.toggle(folder)
-                  } else {
-                    backstack.add(app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen(folder.bucketId, folder.name))
-                  }
-                },
-                onFolderLongClick = { folder ->
-                  selectionManager.handleLongClick(folder)
-                },
-                onTogglePin = { folder ->
-                  coroutineScope.launch {
-                    val updated = foldersPreferences.pinnedFolders.get().toMutableSet()
-                    if (!updated.add(folder.path)) {
-                      updated.remove(folder.path)
-                    }
-                    foldersPreferences.pinnedFolders.set(updated)
-                  }
-                },
+            is PermissionStatus.Denied -> {
+              PermissionDeniedState(
+                onRequestPermission = { permissionState.launchPermissionRequest() },
+                modifier = Modifier,
               )
             }
           }
 
-          is PermissionStatus.Denied -> {
-            PermissionDeniedState(
-              onRequestPermission = { permissionState.launchPermissionRequest() },
-              modifier = Modifier,
+          if (selectionManager.isInSelectionMode) {
+            BrowserBottomBar(
+              isSelectionMode = true,
+              onCopyClick = {
+                operationType.value = CopyPasteOps.OperationType.Copy
+                if (CopyPasteOps.canUseDirectFileOperations()) {
+                  folderPickerOpen.value = true
+                } else {
+                  treePickerLauncher.launch(null)
+                }
+              },
+              onMoveClick = {
+                operationType.value = CopyPasteOps.OperationType.Move
+                if (CopyPasteOps.canUseDirectFileOperations()) {
+                  folderPickerOpen.value = true
+                } else {
+                  treePickerLauncher.launch(null)
+                }
+              },
+              onRenameClick = { renameDialogOpen = true },
+              onDeleteClick = { pendingDeleteFolders = selectionManager.getSelectedItems() },
+              onAddToPlaylistClick = { },
+              showCopy = true,
+              showMove = true,
+              showRename = selectionManager.isSingleSelection,
+              showDownscale = false,
+              showAddToPlaylist = false,
+              modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = if (navBarState.shouldHideNavigationBar) 0.dp else navigationBarHeight),
             )
           }
         }
+      }
+    }
 
-        if (selectionManager.isInSelectionMode) {
-          BrowserBottomBar(
-            isSelectionMode = true,
-            onCopyClick = {
-              operationType.value = CopyPasteOps.OperationType.Copy
-              if (CopyPasteOps.canUseDirectFileOperations()) {
-                folderPickerOpen.value = true
-              } else {
-                treePickerLauncher.launch(null)
-              }
-            },
-            onMoveClick = {
-              operationType.value = CopyPasteOps.OperationType.Move
-              if (CopyPasteOps.canUseDirectFileOperations()) {
-                folderPickerOpen.value = true
-              } else {
-                treePickerLauncher.launch(null)
-              }
-            },
-            onRenameClick = { renameDialogOpen = true },
-            onDeleteClick = { pendingDeleteFolders = selectionManager.getSelectedItems() },
-            onAddToPlaylistClick = { },
-            showCopy = true,
-            showMove = true,
-            showRename = selectionManager.isSingleSelection,
-            showDownscale = false,
-            showAddToPlaylist = false,
-            modifier = Modifier
-              .align(Alignment.BottomCenter)
-              .padding(bottom = if (navBarState.shouldHideNavigationBar) 0.dp else navigationBarHeight),
-          )
+    if (isDualPaneActive && selectedFolderBucketId != null) {
+      Row(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.weight(0.4f)) {
+          FoldersPane()
+        }
+        VerticalDivider(
+          modifier = Modifier.fillMaxHeight(),
+          color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+          thickness = 1.dp
+        )
+        Box(modifier = Modifier.weight(0.6f)) {
+          key(selectedFolderBucketId) {
+            CompositionLocalProvider(
+              app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight provides 0.dp
+            ) {
+              VideoListScreen(
+                bucketId = selectedFolderBucketId!!,
+                folderName = selectedFolderName.orEmpty(),
+                onBack = {
+                  selectedFolderBucketId = null
+                  selectedFolderName = null
+                }
+              ).Content()
+            }
+          }
         }
       }
+    } else {
+      FoldersPane()
+    }
 
       // Dialogs
       PlayLinkSheet(
@@ -830,7 +907,6 @@ object FolderListScreen : Screen {
       }
     }
   }
-}
 
 @Composable
 private fun FolderListContent(
@@ -853,6 +929,7 @@ private fun FolderListContent(
   onFolderClick: (VideoFolder) -> Unit,
   onFolderLongClick: (VideoFolder) -> Unit,
   onTogglePin: (VideoFolder) -> Unit,
+  selectedFolderBucketId: String? = null,
 ) {
   val isGridMode = mediaLayoutMode == MediaLayoutMode.GRID
   val showLoading = isLoading && !hasCompletedInitialLoad
@@ -908,6 +985,7 @@ private fun FolderListContent(
           onFolderClick = onFolderClick,
           onFolderLongClick = onFolderLongClick,
           onTogglePin = onTogglePin,
+          selectedFolderBucketId = selectedFolderBucketId,
         )
       } else {
         ListContent(
@@ -923,6 +1001,7 @@ private fun FolderListContent(
           onFolderClick = onFolderClick,
           onFolderLongClick = onFolderLongClick,
           onTogglePin = onTogglePin,
+          selectedFolderBucketId = selectedFolderBucketId,
         )
       }
     }
@@ -943,6 +1022,7 @@ private fun GridContent(
   onFolderClick: (VideoFolder) -> Unit,
   onFolderLongClick: (VideoFolder) -> Unit,
   onTogglePin: (VideoFolder) -> Unit,
+  selectedFolderBucketId: String? = null,
 ) {
   BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
     val browserPreferences = org.koin.compose.koinInject<app.gyrolet.mpvrx.preferences.BrowserPreferences>()
@@ -1042,6 +1122,7 @@ private fun ListContent(
   onFolderClick: (VideoFolder) -> Unit,
   onFolderLongClick: (VideoFolder) -> Unit,
   onTogglePin: (VideoFolder) -> Unit,
+  selectedFolderBucketId: String? = null,
 ) {
   Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -118,8 +118,9 @@ import kotlin.math.roundToInt
 
 @Serializable
 data class VideoListScreen(
-  private val bucketId: String,
-  private val folderName: String,
+  val bucketId: String,
+  val folderName: String,
+  @kotlinx.serialization.Transient val onBack: (() -> Unit)? = null,
 ) : Screen {
   @OptIn(ExperimentalMaterial3ExpressiveApi::class)
   @Composable
@@ -283,7 +284,11 @@ data class VideoListScreen(
             if (selectionManager.isInSelectionMode) {
               selectionManager.clear()
             } else {
-              backstack.popSafely()
+              if (onBack != null) {
+                onBack()
+              } else {
+                backstack.popSafely()
+              }
             }
           },
           onCancelSelection = { selectionManager.clear() },

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
@@ -89,6 +89,7 @@ object AppearancePreferencesScreen : Screen {
         var isThemeSectionExpanded by rememberSaveable { mutableStateOf(true) }
         val storedThumbnailMode by browserPreferences.thumbnailMode.collectAsState()
         val thumbnailFramePosition by browserPreferences.thumbnailFramePosition.collectAsState()
+        val dualPaneForTablet by browserPreferences.dualPaneForTablet.collectAsState()
         val thumbnailCacheClearedMessage = stringResource(R.string.pref_thumbnail_cache_cleared)
 
         val thumbnailMode = storedThumbnailMode
@@ -340,6 +341,22 @@ object AppearancePreferencesScreen : Screen {
                                 summary = {
                                     Text(
                                         text = stringResource(R.string.pref_appearance_auto_scroll_summary),
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                }
+                            )
+
+                            PreferenceDivider()
+
+                            SwitchPreference(
+                                value = dualPaneForTablet,
+                                onValueChange = { browserPreferences.dualPaneForTablet.set(it) },
+                                title = {
+                                    Text(text = "Dual Pane View")
+                                },
+                                summary = {
+                                    Text(
+                                        text = "Enable dual pane layout on tablets in folder view",
                                         color = MaterialTheme.colorScheme.outline,
                                     )
                                 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/PreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/PreferencesScreen.kt
@@ -4,6 +4,7 @@ import app.gyrolet.mpvrx.ui.icons.AppIcon
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,6 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +32,15 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.navigation3.runtime.NavBackStack
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.key
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -63,8 +75,61 @@ object PreferencesScreen : Screen {
   override fun Content() {
     val backstack = LocalBackStack.current
     val colorScheme = MaterialTheme.colorScheme
-    val emphasizedTypography = LocalEmphasizedTypography.current
     val sections = settingsSections()
+
+    val configuration = LocalConfiguration.current
+    val isTablet = configuration.smallestScreenWidthDp >= 600
+
+    var selectedScreen by remember { mutableStateOf<Screen>(AppearancePreferencesScreen) }
+
+    if (isTablet) {
+      Row(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.weight(0.4f)) {
+          SettingsPane(
+            sections = sections,
+            selectedScreen = selectedScreen,
+            onScreenSelected = { selectedScreen = it }
+          )
+        }
+        VerticalDivider(
+          modifier = Modifier.fillMaxHeight(),
+          color = colorScheme.outlineVariant.copy(alpha = 0.5f),
+          thickness = 1.dp
+        )
+        Box(modifier = Modifier.weight(0.6f)) {
+          key(selectedScreen) {
+            @Suppress("UNCHECKED_CAST")
+            val detailBackstack = rememberNavBackStack(selectedScreen) as NavBackStack<Screen>
+            CompositionLocalProvider(
+              LocalBackStack provides detailBackstack
+            ) {
+              val activeScreen = detailBackstack.lastOrNull() ?: selectedScreen
+              key(activeScreen) {
+                activeScreen.Content()
+              }
+            }
+          }
+        }
+      }
+    } else {
+      SettingsPane(
+        sections = sections,
+        selectedScreen = null,
+        onScreenSelected = { backstack.add(it) }
+      )
+    }
+  }
+
+  @OptIn(ExperimentalMaterial3Api::class)
+  @Composable
+  private fun SettingsPane(
+    sections: List<SettingsSection>,
+    selectedScreen: Screen?,
+    onScreenSelected: (Screen) -> Unit,
+  ) {
+    val backstack = LocalBackStack.current
+    val colorScheme = MaterialTheme.colorScheme
+    val emphasizedTypography = LocalEmphasizedTypography.current
 
     Scaffold(
       topBar = {
@@ -104,7 +169,8 @@ object PreferencesScreen : Screen {
         items(sections, key = { it.title }) { section ->
           SettingsSectionBlock(
             section = section,
-            onItemClick = { backstack.add(it.screen) },
+            selectedScreen = selectedScreen,
+            onItemClick = { destination -> onScreenSelected(destination.screen) },
           )
         }
       }
@@ -281,6 +347,7 @@ private fun SettingsSearchEntry(
 @Composable
 private fun SettingsSectionBlock(
   section: SettingsSection,
+  selectedScreen: Screen?,
   onItemClick: (SettingsDestination) -> Unit,
 ) {
   val emphasizedTypography = LocalEmphasizedTypography.current
@@ -304,6 +371,7 @@ private fun SettingsSectionBlock(
 
     SettingsDestinationGroup(
       section = section,
+      selectedScreen = selectedScreen,
       onItemClick = onItemClick,
       modifier = Modifier.padding(horizontal = 16.dp),
     )
@@ -313,6 +381,7 @@ private fun SettingsSectionBlock(
 @Composable
 private fun SettingsDestinationGroup(
   section: SettingsSection,
+  selectedScreen: Screen?,
   onItemClick: (SettingsDestination) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -327,6 +396,7 @@ private fun SettingsDestinationGroup(
         SettingsDestinationRow(
           item = item,
           tint = section.tint,
+          isSelected = selectedScreen == item.screen,
           onClick = { onItemClick(item) },
         )
         if (index < section.items.lastIndex) {
@@ -344,11 +414,18 @@ private fun SettingsDestinationGroup(
 private fun SettingsDestinationRow(
   item: SettingsDestination,
   tint: Color,
+  isSelected: Boolean,
   onClick: () -> Unit,
 ) {
+  val rowBgColor = if (isSelected) {
+    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+  } else {
+    Color.Transparent
+  }
   Row(
     modifier = Modifier
       .fillMaxWidth()
+      .background(rowBgColor)
       .clickable(onClick = onClick)
       .padding(horizontal = 14.dp, vertical = 13.dp),
     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
- Add dual-pane support for video folder views on tablets (>= 600dp width) with a custom vertical divider, controlled via preference settings.
- Implement smooth navigation bar width-shrinking animation (from 100% to 40% width) aligned to the left folders list, hiding beneath the details list.
- Implement tablet settings split-pane layout (40% list / 60% sub-preferences) using a localized dummy NavBackStack for nested navigation and row highlights.
- Hide the top bar settings action and detail back arrow in detail views when embedded in dual-pane layouts.


<img width="1280" height="854" alt="2026-07-06 22 06 27" src="https://github.com/user-attachments/assets/d17b2751-49b7-4017-8b4a-b487c935310b" />
<img width="1280" height="854" alt="2026-07-06 22 06 37" src="https://github.com/user-attachments/assets/104981af-8b17-49f2-a8ce-bdbe9d35650b" />
<img width="1280" height="854" alt="2026-07-06 22 06 41" src="https://github.com/user-attachments/assets/465b1b3b-638c-4f80-b24d-6f92e3c106a6" />
