### PR TITLE
Add 'Play audio after screen lock' preference and make audio visualizer more resilient

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/AudioPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/AudioPreferences.kt
@@ -14,6 +14,7 @@ class AudioPreferences(
   val audioChannels = preferenceStore.getEnum("audio_channels", AudioChannels.AutoSafe)
   val volumeBoostCap = preferenceStore.getInt("audio_volume_boost_cap", 30)
   val automaticBackgroundPlayback = preferenceStore.getBoolean("automatic_background_playback", false)
+  val playAudioAfterScreenLock = preferenceStore.getBoolean("play_audio_after_screen_lock", false)
   val volumeNormalization = preferenceStore.getBoolean("audio_volume_normalization", false)
   val audioBlobEnabled = preferenceStore.getBoolean("audio_blob_enabled", true)
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -1036,7 +1036,7 @@ class PlayerActivity :
       val isInPip = isInPictureInPictureMode
       val shouldPause =
         PlayerLifecyclePolicy.shouldPauseOnPause(
-          automaticBackgroundPlayback = audioPreferences.automaticBackgroundPlayback.get(),
+          automaticBackgroundPlayback = shouldKeepAudioPlayingInBackground(),
           manualBackgroundPlayback = isManualBackgroundPlayback,
           isUserFinishing = isUserFinishing,
           isInPictureInPictureMode = isInPip,
@@ -1135,7 +1135,7 @@ class PlayerActivity :
 
       if (
         PlayerLifecyclePolicy.shouldStartAutomaticBackgroundPlaybackOnStop(
-          automaticBackgroundPlayback = audioPreferences.automaticBackgroundPlayback.get(),
+          automaticBackgroundPlayback = shouldKeepAudioPlayingInBackground(),
           manualBackgroundPlayback = isManualBackgroundPlayback,
           isUserFinishing = isUserFinishing,
           isFinishing = isFinishing,
@@ -2068,7 +2068,13 @@ class PlayerActivity :
   }
 
   private fun isBackgroundPlaybackActive(): Boolean =
-    isManualBackgroundPlayback || audioPreferences.automaticBackgroundPlayback.get()
+    isManualBackgroundPlayback || shouldKeepAudioPlayingInBackground()
+
+  private fun shouldKeepAudioPlayingInBackground(): Boolean =
+    audioPreferences.automaticBackgroundPlayback.get() || shouldKeepAudioFilePlayingAfterScreenLock()
+
+  private fun shouldKeepAudioFilePlayingAfterScreenLock(): Boolean =
+    audioPreferences.playAudioAfterScreenLock.get() && isCurrentMediaKnownAudio()
 
   private fun resumePlaybackAfterScreenUnlockIfNeeded() {
     if (!screenUnlockPlaybackController.consumeResumeAfterUnlockIfReady(keyguardManager.isDeviceLocked)) return

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/AudioFeatures.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/AudioFeatures.kt
@@ -18,4 +18,13 @@ class AudioFeatures {
         centroid = 0.35f
         active = false
     }
+
+    fun decay(factor: Float, beatFactor: Float = factor) {
+        bass *= factor
+        mid *= factor
+        treble *= factor
+        energy *= factor
+        beat *= beatFactor
+        active = false
+    }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/AudioSpectrumAnalyzer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/AudioSpectrumAnalyzer.kt
@@ -23,7 +23,7 @@ class AudioSpectrumAnalyzer(
 
     @Synchronized
     fun start(audioSessionId: Int): Result<Unit> {
-        stop()
+        stop(resetFeatures = false)
         var pendingInstance: Visualizer? = null
         return runCatching {
             val instance = Visualizer(audioSessionId)
@@ -61,7 +61,7 @@ class AudioSpectrumAnalyzer(
             pendingInstance = null
             features.active = true
         }.onFailure {
-            features.reset()
+            features.active = false
             runCatching { pendingInstance?.release() }
             runCatching { visualizer?.release() }
             visualizer = null
@@ -69,18 +69,22 @@ class AudioSpectrumAnalyzer(
     }
 
     @Synchronized
-    fun stop() {
+    fun stop(resetFeatures: Boolean = true) {
         visualizer?.let { instance ->
             runCatching { instance.enabled = false }
             runCatching { instance.setDataCaptureListener(null, 0, false, false) }
             runCatching { instance.release() }
         }
         visualizer = null
-        features.reset()
-        smoothEnergy = 0f
-        smoothBass = 0f
-        smoothMid = 0f
-        smoothTreble = 0f
+        if (resetFeatures) {
+            features.reset()
+        } else {
+            features.active = false
+        }
+        smoothEnergy = features.energy
+        smoothBass = features.bass
+        smoothMid = features.mid
+        smoothTreble = features.treble
         beatEnvelope = 0f
         previousBass = 0f
         beatCooldownFrames = 0

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobComposable.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobComposable.kt
@@ -49,14 +49,24 @@ fun BlobOverlay(
         if (!hasRecordPermission) recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
     }
 
-    // Try real FFT capture via Visualizer API
+    // Keep the analyzer resilient across player/audio-session changes. Some devices briefly
+    // reject Visualizer creation while mpv swaps files; retry without recreating the GL view so
+    // the blob keeps its animation state instead of stuttering or snapping to idle.
     DisposableEffect(hasRecordPermission) {
         val analyzer = if (hasRecordPermission) AudioSpectrumAnalyzer(features) else null
-        realAnalyzerActive.set(analyzer?.start(0)?.isSuccess == true)
+        val job = scope.launch(Dispatchers.Default) {
+            while (isActive && analyzer != null) {
+                if (!realAnalyzerActive.get()) {
+                    realAnalyzerActive.set(analyzer.start(0).isSuccess)
+                }
+                delay(if (realAnalyzerActive.get()) 1_000L else 350L)
+            }
+        }
 
         onDispose {
+            job.cancel()
             realAnalyzerActive.set(false)
-            analyzer?.stop()
+            analyzer?.stop(resetFeatures = false)
         }
     }
 
@@ -77,11 +87,7 @@ fun BlobOverlay(
                     features.centroid = 0.35f
                     features.active = false
                 } else {
-                    features.bass *= 0.90f
-                    features.mid *= 0.90f
-                    features.treble *= 0.90f
-                    features.energy *= 0.90f
-                    features.beat *= 0.75f
+                    features.decay(0.90f, beatFactor = 0.75f)
                 }
                 delay(33)
             }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AudioPreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AudioPreferencesScreen.kt
@@ -211,6 +211,20 @@ object AudioPreferencesScreen : Screen {
               )
 
               PreferenceDivider()
+              val playAudioAfterScreenLock by preferences.playAudioAfterScreenLock.collectAsState()
+              SwitchPreference(
+                value = playAudioAfterScreenLock,
+                onValueChange = { preferences.playAudioAfterScreenLock.set(it) },
+                title = { Text("Play audio after screen lock") },
+                summary = {
+                  Text(
+                    "Keep audio files playing when the screen turns off or the device locks",
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+              )
+
+              PreferenceDivider()
               val audioChannel by preferences.audioChannels.collectAsState()
               ListPreference(
                 value = audioChannel,


### PR DESCRIPTION
### Motivation
- Provide a user preference to keep audio files playing when the device locks without enabling full automatic background playback. 
- Improve the visualizer/blob animation stability across audio-session and file swaps so the UI doesn't stutter when the `Visualizer` cannot be created.

### Description
- Add `playAudioAfterScreenLock` to `AudioPreferences` and expose it in the preferences UI as a new `SwitchPreference` with a summary; the key is `play_audio_after_screen_lock` and default is `false`.
- Update playback lifecycle logic in `PlayerActivity` to factor background playback checks through `shouldKeepAudioPlayingInBackground()` which incorporates `playAudioAfterScreenLock` via `shouldKeepAudioFilePlayingAfterScreenLock()` and `isCurrentMediaKnownAudio()`.
- Add `AudioFeatures.decay(factor: Float, beatFactor: Float = factor)` and update `AudioSpectrumAnalyzer` to optionally stop without zeroing feature state via `stop(resetFeatures: Boolean = true)` and to avoid recreating features when briefly failing to create a `Visualizer`.
- Make `BlobOverlay` retry creating the `AudioSpectrumAnalyzer` on a background loop, avoid recreating the GL view on analyzer failure, call `analyzer.stop(resetFeatures = false)` when disposing, and use `features.decay(...)` for idle decay behavior.

### Testing
- Built the app with `./gradlew assembleDebug` which completed successfully.
- Ran unit tests with `./gradlew test`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a564bbd695c832bbd1d5d0744454391)