### PR TITLE
Fix background playback and PiP transitions

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVPipHelper.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVPipHelper.kt
@@ -93,11 +93,14 @@ class MPVPipHelper(
       .apply {
         getVideoAspectRatio()?.let { aspectRatio ->
           setAspectRatio(aspectRatio)
-          setSourceRectHint(calculateSourceRect(aspectRatio))
+          calculateSourceRect(aspectRatio)?.let { sourceRect -> setSourceRectHint(sourceRect) }
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
           setAutoEnterEnabled(playerPreferences.autoPiPOnNavigation.get())
+          // Video surfaces can resize continuously, so let Android morph the
+          // full-screen frame into and out of PiP instead of cross-fading it.
+          setSeamlessResizeEnabled(true)
         }
 
         setActions(createPipActions())
@@ -112,22 +115,27 @@ class MPVPipHelper(
     return Rational(width, height).takeIf { it.toFloat() in 0.5f..2.39f }
   }
 
-  private fun calculateSourceRect(aspectRatio: Rational): Rect {
-    val viewWidth = mpvView.width.toFloat()
-    val viewHeight = mpvView.height.toFloat()
+  private fun calculateSourceRect(aspectRatio: Rational): Rect? {
+    val visiblePlayerRect = Rect()
+    if (!mpvView.getGlobalVisibleRect(visiblePlayerRect) || visiblePlayerRect.isEmpty) return null
+
+    val viewWidth = visiblePlayerRect.width().toFloat()
+    val viewHeight = visiblePlayerRect.height().toFloat()
+    if (viewWidth <= 0f || viewHeight <= 0f) return null
+
     val videoAspect = aspectRatio.toFloat()
     val viewAspect = viewWidth / viewHeight
 
     return if (viewAspect < videoAspect) {
       // Letterboxed (black bars top/bottom)
       val height = viewWidth / videoAspect
-      val top = ((viewHeight - height) / 2).toInt()
-      Rect(0, top, viewWidth.toInt(), (height + top).toInt())
+      val top = visiblePlayerRect.top + ((viewHeight - height) / 2).toInt()
+      Rect(visiblePlayerRect.left, top, visiblePlayerRect.right, top + height.toInt())
     } else {
       // Pillarboxed (black bars left/right)
       val width = viewHeight * videoAspect
-      val left = ((viewWidth - width) / 2).toInt()
-      Rect(left, 0, (width + left).toInt(), viewHeight.toInt())
+      val left = visiblePlayerRect.left + ((viewWidth - width) / 2).toInt()
+      Rect(left, visiblePlayerRect.top, left + width.toInt(), visiblePlayerRect.bottom)
     }
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -365,23 +365,29 @@ class PlayerActivity :
 
   private val notificationPermissionLauncher =
     registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+      val wasEnablingFromPlayerControls = pendingBackgroundTransition
       if (granted) {
         pendingBackgroundPlaybackStart = false
         val started = startBackgroundPlaybackInternal(bindToActivity = false)
         if (pendingBackgroundTransition && started) {
           pendingBackgroundTransition = false
           isBackgroundPlaybackSessionActive = true
-          if (wasPlayingBeforePause && viewModel.paused == true) viewModel.unpause()
-          movePlayerToBackground()
+          viewModel.showToast("Background playback on")
         } else if (pendingBackNavigationBackgroundTransition && started) {
           pendingBackNavigationBackgroundTransition = false
           finishIntoBackgroundPlayback()
         } else if (!started) {
+          if (wasEnablingFromPlayerControls) {
+            audioPreferences.backgroundPlayback.set(false)
+          }
           pendingBackgroundTransition = false
           pendingBackNavigationBackgroundTransition = false
           isBackgroundPlaybackSessionActive = false
         }
       } else {
+        if (wasEnablingFromPlayerControls) {
+          audioPreferences.backgroundPlayback.set(false)
+        }
         pendingBackgroundPlaybackStart = false
         pendingBackgroundTransition = false
         pendingBackNavigationBackgroundTransition = false
@@ -4404,11 +4410,10 @@ class PlayerActivity :
     }
 
     Log.d(TAG, "Background playback enabled from player controls")
-    wasPlayingBeforePause = viewModel.paused == false
     when (startBackgroundPlayback()) {
       BackgroundPlaybackStartResult.Started -> {
         isBackgroundPlaybackSessionActive = true
-        movePlayerToBackground()
+        viewModel.showToast("Background playback on")
       }
       BackgroundPlaybackStartResult.PendingPermission -> pendingBackgroundTransition = true
       BackgroundPlaybackStartResult.Blocked -> {
@@ -4417,17 +4422,6 @@ class PlayerActivity :
         pendingBackgroundTransition = false
       }
     }
-  }
-
-  private fun movePlayerToBackground() {
-    // Restore system UI before going to background
-    restoreSystemUI()
-
-    // Keep this activity and MPV instance alive in the task. Finishing here detaches
-    // the observer that owns repeat/playlist EOF handling and forces streams to
-    // reload when the user opens the player again from the notification.
-    disableVideoForBackground()
-    moveTaskToBack(true)
   }
 
   private fun finishIntoBackgroundPlayback() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -1,6 +1,7 @@
 package app.gyrolet.mpvrx.ui.player
 
 import android.Manifest
+import android.animation.ValueAnimator
 import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.ComponentName
@@ -29,6 +30,7 @@ import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
+import android.view.animation.PathInterpolator
 import android.widget.Toast
 import androidx.activity.BackEventCompat
 import androidx.activity.OnBackPressedCallback
@@ -321,6 +323,7 @@ class PlayerActivity :
   private var wasInPipMode = false
   private var handledPipDismissal = false
   private var pendingBackgroundTransition = false
+  private var pendingBackNavigationBackgroundTransition = false
   private var noisyReceiverRegistered = false
   private var lastVid = -1 // Track video track for background playback optimization
   private var isInBackgroundPlayback = false // Track if we are currently in background playback mode
@@ -370,13 +373,18 @@ class PlayerActivity :
           isBackgroundPlaybackSessionActive = true
           if (wasPlayingBeforePause && viewModel.paused == true) viewModel.unpause()
           movePlayerToBackground()
+        } else if (pendingBackNavigationBackgroundTransition && started) {
+          pendingBackNavigationBackgroundTransition = false
+          finishIntoBackgroundPlayback()
         } else if (!started) {
           pendingBackgroundTransition = false
+          pendingBackNavigationBackgroundTransition = false
           isBackgroundPlaybackSessionActive = false
         }
       } else {
         pendingBackgroundPlaybackStart = false
         pendingBackgroundTransition = false
+        pendingBackNavigationBackgroundTransition = false
         isBackgroundPlaybackSessionActive = false
         Toast.makeText(
           this,
@@ -706,8 +714,10 @@ class PlayerActivity :
         }
 
         override fun handleOnBackPressed() {
+          // Do not let the predictive-back transform compete with Android's
+          // full-screen-to-PiP surface morph.
+          resetPredictiveBackProgress(animate = false)
           handleBackPress()
-          resetPredictiveBackProgress()
         }
       }
 
@@ -721,8 +731,12 @@ class PlayerActivity :
         viewModel.sheetShown,
         viewModel.panelShown,
         playerPreferences.autoPiPOnNavigation.changes(),
-      ) { sheetShown, panelShown, autoPipOnNavigation ->
-        sheetShown != Sheets.None || panelShown != Panels.None || autoPipOnNavigation
+        audioPreferences.backgroundPlayback.changes(),
+      ) { sheetShown, panelShown, autoPipOnNavigation, backgroundPlaybackEnabled ->
+        sheetShown != Sheets.None ||
+          panelShown != Panels.None ||
+          autoPipOnNavigation ||
+          backgroundPlaybackEnabled
       }
         .distinctUntilChanged()
         .collect { callback.isEnabled = it }
@@ -732,7 +746,8 @@ class PlayerActivity :
   private fun shouldInterceptBackPress(): Boolean =
     viewModel.sheetShown.value != Sheets.None ||
       viewModel.panelShown.value != Panels.None ||
-      playerPreferences.autoPiPOnNavigation.get()
+      playerPreferences.autoPiPOnNavigation.get() ||
+      isBackgroundPlaybackEnabled()
 
   private fun applyPredictiveBackProgress(backEvent: BackEventCompat) {
     val root = binding.root
@@ -755,7 +770,17 @@ class PlayerActivity :
     binding.controls.alpha = 1f - (0.2f * progress)
   }
 
-  private fun resetPredictiveBackProgress() {
+  private fun resetPredictiveBackProgress(animate: Boolean = true) {
+    binding.root.animate().cancel()
+    binding.controls.animate().cancel()
+    if (!animate || !ValueAnimator.areAnimatorsEnabled()) {
+      binding.root.scaleX = 1f
+      binding.root.scaleY = 1f
+      binding.root.translationX = 0f
+      binding.controls.alpha = 1f
+      return
+    }
+
     binding.root.animate()
       .scaleX(1f)
       .scaleY(1f)
@@ -782,9 +807,30 @@ class PlayerActivity :
       return
     }
 
+    // Background playback takes precedence on Back: return to the browser while
+    // handing the live MPV session to the foreground service.
+    if (
+      PlayerLifecyclePolicy.shouldStartBackgroundPlaybackOnBack(
+        backgroundPlaybackEnabled = isBackgroundPlaybackEnabled(),
+        mediaReady = isReady,
+      )
+    ) {
+      when (startBackgroundPlayback()) {
+        BackgroundPlaybackStartResult.Started -> finishIntoBackgroundPlayback()
+        BackgroundPlaybackStartResult.PendingPermission -> {
+          pendingBackNavigationBackgroundTransition = true
+        }
+        BackgroundPlaybackStartResult.Blocked -> {
+          isUserFinishing = true
+          finish()
+        }
+      }
+      return
+    }
+
     // Check if auto PIP is enabled - enter PIP mode instead of finishing
     if (playerPreferences.autoPiPOnNavigation.get() && isReady) {
-      pipHelper.enterPipMode()
+      enterPipModeSmoothly()
       return
     }
 
@@ -898,7 +944,7 @@ class PlayerActivity :
     super.onUserLeaveHint()
     // Enter PIP mode when user presses home button if auto PIP is enabled
     if (playerPreferences.autoPiPOnNavigation.get() && isReady && !isFinishing) {
-      pipHelper.enterPipMode()
+      enterPipModeSmoothly()
     }
   }
 
@@ -1048,6 +1094,7 @@ class PlayerActivity :
       val shouldPause =
         PlayerLifecyclePolicy.shouldPauseOnPause(
           backgroundPlaybackEnabled = isBackgroundPlaybackEnabled(),
+          backgroundPlaybackSessionActive = isBackgroundPlaybackSessionActive,
           isUserFinishing = isUserFinishing,
           isInPictureInPictureMode = isInPip,
           isScreenOffOrLocked = isDeviceScreenOffOrLocked(),
@@ -1085,7 +1132,9 @@ class PlayerActivity :
         endBackgroundPlayback()
       }
       
-      reportJellyfinStop()
+      if (!isBackgroundPlaybackSessionActive) {
+        reportJellyfinStop()
+      }
       setReturnIntent()
     }.onFailure { e ->
       Log.e(TAG, "Error during finish", e)
@@ -3796,13 +3845,26 @@ class PlayerActivity :
       handledPipDismissal = false
     }
 
-    binding.controls.alpha = if (isInPictureInPictureMode) 0f else 1f
+    binding.controls.animate().cancel()
+    if (isInPictureInPictureMode) {
+      binding.controls.alpha = 0f
+    }
 
     runCatching {
       if (isInPictureInPictureMode) {
         enterPipUIMode()
       } else {
         exitPipUIMode()
+        if (ValueAnimator.areAnimatorsEnabled()) {
+          binding.controls.alpha = 0f
+          binding.controls.animate()
+            .alpha(1f)
+            .setDuration(180L)
+            .setInterpolator(PathInterpolator(0.25f, 1f, 0.5f, 1f))
+            .start()
+        } else {
+          binding.controls.alpha = 1f
+        }
       }
     }.onFailure { e ->
       Log.e(TAG, "Error handling PiP mode change", e)
@@ -3846,8 +3908,17 @@ class PlayerActivity :
       Log.e(TAG, "Error entering PiP mode with hidden overlay", e)
     }
 
-    binding.controls.alpha = 0f
+    enterPipModeSmoothly()
+  }
 
+  private fun enterPipModeSmoothly() {
+    binding.root.animate().cancel()
+    binding.controls.animate().cancel()
+    binding.root.scaleX = 1f
+    binding.root.scaleY = 1f
+    binding.root.translationX = 0f
+    binding.controls.alpha = 0f
+    pipHelper.updatePictureInPictureParams()
     pipHelper.enterPipMode()
   }
 
@@ -4289,6 +4360,7 @@ class PlayerActivity :
     Log.d(TAG, "Ending background playback service")
     isBackgroundPlaybackSessionActive = false
     pendingBackgroundTransition = false
+    pendingBackNavigationBackgroundTransition = false
     
     if (serviceBound) {
       try {
@@ -4356,6 +4428,14 @@ class PlayerActivity :
     // reload when the user opens the player again from the notification.
     disableVideoForBackground()
     moveTaskToBack(true)
+  }
+
+  private fun finishIntoBackgroundPlayback() {
+    isBackgroundPlaybackSessionActive = true
+    pendingBackNavigationBackgroundTransition = false
+    disableVideoForBackground()
+    isUserFinishing = true
+    finish()
   }
 
   // ==================== PlayerHost ====================

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerLifecyclePolicy.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerLifecyclePolicy.kt
@@ -3,15 +3,21 @@ package app.gyrolet.mpvrx.ui.player
 internal object PlayerLifecyclePolicy {
   fun shouldPauseOnPause(
     backgroundPlaybackEnabled: Boolean,
+    backgroundPlaybackSessionActive: Boolean,
     isUserFinishing: Boolean,
     isInPictureInPictureMode: Boolean,
     isScreenOffOrLocked: Boolean,
   ): Boolean {
-    if (isUserFinishing) return true
+    if (isUserFinishing && !backgroundPlaybackSessionActive) return true
     if (isInPictureInPictureMode && !isScreenOffOrLocked) return false
 
     return !backgroundPlaybackEnabled
   }
+
+  fun shouldStartBackgroundPlaybackOnBack(
+    backgroundPlaybackEnabled: Boolean,
+    mediaReady: Boolean,
+  ): Boolean = backgroundPlaybackEnabled && mediaReady
 
   fun shouldKeepBackgroundPlaybackAliveOnDestroy(
     backgroundPlaybackEnabled: Boolean,


### PR DESCRIPTION
## What changed

- Keep playback alive when Back returns from the player to video or folder lists while background playback is enabled.
- Hand the active MPV session to the foreground playback service before finishing the player Activity.
- Keep the player open when Background Play is enabled from player controls; show confirmation and prepare the background service without navigating away.
- Roll the toggle back if required notification permission is denied, avoiding a false enabled state.
- Improve normal-to-PiP and PiP-to-normal motion with accurate visible video bounds, seamless resizing, normalized predictive-back state, and a short controls fade on expansion.
- Respect the system animator setting when restoring controls.

## Why

Back previously marked the player as intentionally finishing before the background session was active, which caused playback to pause. The Background Play control also immediately moved the task away from the player instead of behaving like an enable/disable toggle. PiP supplied view-local source bounds and could retain predictive-back transforms, producing a jumpier system transition.

## Impact

Users can enable background playback without leaving the current video, browse video and folder lists while media continues playing, and move into or out of PiP with smoother system transitions.

## Validation

- `git diff --check`
- Static call-site and lifecycle consistency review
- Build and automated tests intentionally not run per request
