### PR TITLE
Add Google Cast playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ These notes are written in plain English and focus on what changed for real use.
 
 ## 1.5.0-preview.4 — Preview Release
 
+### Google Cast
+- **Native Cast control**: Added the standard stateful Google Cast button to portrait and landscape player controls, including a one-time layout migration for existing users.
+- **Local and remote media handoff**: Receiver-accessible HTTP(S) streams are loaded directly; Android-local `file://` and `content://` media use a tokenized temporary LAN server with byte-range seeking and CORS support.
+- **Playback continuity**: The sender transfers title, play state, duration, and current position, pauses local playback after a successful receiver load, and restores local playback at the receiver position when casting ends.
+- **Complete sender controls**: Added Cast SDK expanded controls, notification/lock-screen integration, reconnection support, and receiver volume controls.
+- **Receiver compatibility guardrail**: Casting uses Google's Default Media Receiver, so containers and codecs unsupported by the selected TV/Chromecast are not transcoded automatically.
+
 ### Playback Lifecycle & Background Playback
 - **One background playback switch**: Audio preferences and the player background button now control the same persistent setting for both audio and video.
 - **Reliable screen lock and unlock handling**: Playback now follows the selected background policy across screen-off, lock-screen, unlock, and resume transitions without losing the prior play state.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | **Player Controls Animation** | 5 animation styles: Default, Elastic Bounce, Cinematic Scale, Slide Up, Minimal Fade |
 | **Always Dark Mode** | Option to keep player controls in dark theme regardless of app theme |
 | **Themed Player Controls** | Adaptive controls that match your app theme or system accent |
+| **Material 3 Expressive UI** | Expressive components, spring-based navigation, responsive grids, and polished predictive-back motion |
 
 </details>
 
@@ -90,6 +91,7 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | **Horizontal Swipe to Seek** | Swipe across video to seek with live time/delta overlay |
 | **Long-Press Dynamic Speed** | Long-press activates configurable speed boost; swipe left/right to adjust across 8 presets |
 | **Subtitle Drag Gesture** | Long-press center screen to drag subtitles vertically when active |
+| **Subtitle Zoom & Dialogue Seek** | Pinch subtitle text to resize it and swipe across subtitles to seek between dialogue lines |
 | **Pinch-to-Zoom with Pan** | Pinch to zoom (-1x to 3x) with simultaneous pan and single-finger pan after zoom |
 | **Volume Boost via Gesture** | Vertical swipe volume can exceed 100% into configurable boost range |
 | **Swap Volume/Brightness Sides** | Option to swap which screen side controls volume vs brightness |
@@ -155,6 +157,9 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | **Comprehensive Styling** | Font, size, bold, italic, border, shadow, colors, justification, scale by window |
 | **Three Online Search Modes** | Wyzie, SubtitleHub (6 aggregated sources), and Hybrid (both merged) |
 | **TMDB Integration** | Full media search with season/episode browsing for subtitles |
+| **Subtitle Font Manager** | Choose a font directory, reload fonts, clear the cache, and select a default subtitle font |
+| **Speech-to-Subtitle Generation** | Experimental subtitle generation from the active audio using supported cloud or offline Whisper providers |
+| **Explicit Subtitle Off** | Disable subtitles directly without cycling through every available track |
 
 </details>
 
@@ -164,13 +169,30 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | Feature | Description |
 |---|---|
 | **Fully Customizable Layout** | Four configurable zones (top-left/right, bottom-left/right) + portrait bottom row |
-| **24+ Button Types** | Mirror, Vertical Flip, A-B Loop, Custom Skip, Background Playback, Ambient, and more |
+| **25+ Button Types** | Cast, Mirror, Vertical Flip, A-B Loop, Custom Skip, Background Playback, Ambient, and more |
 | **Custom User Buttons** | Create arbitrary buttons executing Lua, JavaScript, or mpv commands |
 | **Landscape/Portrait Adaptive Layouts** | Completely different control layouts per orientation |
 | **"Slide to Unlock" Controls** | Slide mechanism when controls are locked |
 | **Hide Button Backgrounds** | Transparent buttons with only icons visible |
 | **Centralized "More Sheet"** | Quick access to all player buttons and custom controls |
 | **In-Player Settings** | Toggle 10+ settings (gestures, PiP, UI behavior) without leaving playback |
+
+</details>
+
+<details close>
+<summary><b>📺 Google Cast</b></summary>
+
+| Feature | Description |
+|---|---|
+| **Native Cast Button** | Standard stateful Google Cast route icon in both portrait and landscape player controls |
+| **Device Discovery** | Google Cast framework discovery and native device chooser for Chromecast and Cast-enabled TVs |
+| **Position Handoff** | Transfers the current title, play state, duration, and playback position to the receiver |
+| **Local File Casting** | Tokenized temporary LAN server exposes `file://` and `content://` media with byte-range seeking and CORS headers |
+| **Remote Stream Casting** | Direct handoff for receiver-accessible HTTP and HTTPS media URLs |
+| **Expanded Remote Controls** | Cast SDK controller, notification, lock-screen actions, reconnection, and receiver volume controls |
+| **Return to Phone** | Restores local playback at the receiver's latest position when the Cast session ends |
+
+> Cast uses Google's Default Media Receiver. The TV/Chromecast must support the media container and codecs; mpv-only formats are not transcoded automatically.
 
 </details>
 
@@ -197,6 +219,10 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | **"NEW" Badges** | Configurable threshold for new video indicators |
 | **Grid/List Layout** | Per-orientation column count settings |
 | **Multi-Protocol Network** | Built-in SMB, FTP, and WebDAV clients |
+| **Responsive & Dual-Pane Layouts** | Automatic grid sizing plus optional folder/settings dual-pane views on tablets |
+| **Audio Library Mode** | MediaStore and filesystem audio browsing with square artwork, metadata titles, and mixed sibling playlists |
+| **Safer Folder Deletion** | Media-only folder deletion by default, with an explicit option to delete every contained file |
+| **Settings Search Memory** | Search suggestions and recently used settings queries |
 
 </details>
 
@@ -205,10 +231,12 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 
 | Feature | Description |
 |---|---|
-| **Provider Support** | OpenCode and Groq with configurable API keys and models |
+| **Provider Support** | OpenAI, Anthropic, Groq, OpenRouter, Together, and OpenCode Zen with provider-specific models and API protocols |
 | **AI Subtitle Translation** | Translate subtitles with custom prompts |
 | **AI Subtitle Formatting** | Reformat subtitle styling with custom prompts |
 | **AI File Renaming** | Bulk rename video files with custom rename prompts |
+| **Reasoning-Safe Parsing** | Removes reasoning blocks and code fences while accepting structured provider responses and citations |
+| **Speech Providers** | Cloud transcription plus experimental offline Whisper subtitle generation |
 
 </details>
 
@@ -220,6 +248,7 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | **Dual Language** | Lua (.lua) and JavaScript (.js) script support |
 | **Sora Code Editor** | Built-in editor with TextMate syntax highlighting |
 | **Runtime Script Loading** | Enable/disable scripts without restarting |
+| **Lua Module Support** | Recursive `script-modules/` synchronization enables custom scripts to use `require()` helpers |
 | **Config Editor** | Built-in editor for mpv.conf and input.conf |
 
 </details>
@@ -237,12 +266,17 @@ MpvRx pushes the mpv-android experience further with deep customization, thermal
 | **Frame Navigation** | Frame-by-frame forward/backward with frame number display |
 | **Sleep Timer** | Built-in with quick presets (15/30/45/60 min) |
 | **Adaptive Background Playback** | Auto-PiP on Home, auto-resume after screen unlock |
+| **Unified Background Playback** | One persistent audio/video switch; Back can return to browser lists without stopping the current media |
 | **Notification Styles** | None, Media, or Progress with Chapters (Android 16+) |
 | **Safe Area / Window Offset** | Prevents camera notch overlap |
 | **Display Cutout Mode** | Full-bleed on notch devices |
 | **Remember Brightness** | Persists brightness level set during playback |
 | **M3U Playlist Support** | Parse and play local M3U playlists |
 | **yt-dlp Integration** | High-performance streaming support for YouTube, Twitch, Bilibili, and more via a native Python bridge (SDK 29+ bypass) |
+| **yt-dlp Quality Controls** | Independent codec, resolution, FPS, HDR, container, and audio-bitrate preferences |
+| **Dynamic Refresh Rate** | Matches supported display refresh rates to the current video's frame rate for smoother motion |
+| **Audio Blob Visualizer** | OpenGL ES 3.0 FFT-reactive blob with bloom, touch rotation, pinch zoom, and an Audio Settings toggle |
+| **Screenshot Templates** | Filename placeholders for source name, playback position, and millisecond-accurate timestamps |
 
 </details>
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -237,6 +237,7 @@ dependencies {
   implementation(libs.mediainfo.lib)
   implementation("com.llamatik:library:1.4.0")
   implementation(libs.androidx.profileinstaller)
+  implementation(libs.google.cast.framework)
   
   implementation(files("libs/mpvlib.aar"))
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,14 @@
         android:hardwareAccelerated="true"
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="35">
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="app.gyrolet.mpvrx.ui.cast.MpvRxCastOptionsProvider" />
+
+        <receiver
+            android:name="androidx.mediarouter.media.MediaTransferReceiver"
+            android:exported="true" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -347,6 +355,12 @@
                 <data android:pathPattern=".*" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.cast.CastExpandedControlsActivity"
+            android:exported="false"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.mpvrx" />
         <activity android:name=".presentation.crash.CrashActivity" />
 
         <activity

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
@@ -52,7 +52,7 @@ class AppearancePreferences(
   val topRightControls =
     preferenceStore.getString(
       "top_right_controls",
-      "CURRENT_CHAPTER,DECODER,AUDIO_TRACK,SUBTITLES,MORE_OPTIONS",
+      "CAST,CURRENT_CHAPTER,DECODER,AUDIO_TRACK,SUBTITLES,MORE_OPTIONS",
     )
 
   val bottomRightControls =
@@ -70,8 +70,32 @@ class AppearancePreferences(
   val portraitBottomControls =
     preferenceStore.getString(
       "portrait_bottom_controls",
-      "SCREEN_ROTATION,DECODER,AUDIO_TRACK,SUBTITLES,BOOKMARKS_CHAPTERS,PLAYBACK_SPEED,BACKGROUND_PLAYBACK,REPEAT_MODE,SHUFFLE,VIDEO_ZOOM,FRAME_NAVIGATION,ASPECT_RATIO,PICTURE_IN_PICTURE,LOCK_CONTROLS,MORE_OPTIONS",
+      "CAST,SCREEN_ROTATION,DECODER,AUDIO_TRACK,SUBTITLES,BOOKMARKS_CHAPTERS,PLAYBACK_SPEED,BACKGROUND_PLAYBACK,REPEAT_MODE,SHUFFLE,VIDEO_ZOOM,FRAME_NAVIGATION,ASPECT_RATIO,PICTURE_IN_PICTURE,LOCK_CONTROLS,MORE_OPTIONS",
     )
+
+  private val castButtonMigrationComplete =
+    preferenceStore.getBoolean("cast_button_migration_complete", false)
+
+  init {
+    if (!castButtonMigrationComplete.get()) {
+      val landscapeButtons =
+        listOf(
+          topLeftControls.get(),
+          topRightControls.get(),
+          bottomRightControls.get(),
+          bottomLeftControls.get(),
+        ).flatMap { it.split(',') }
+          .map { it.trim().uppercase() }
+      if ("CAST" !in landscapeButtons) {
+        topRightControls.set("CAST,${topRightControls.get()}")
+      }
+      val portraitButtons = portraitBottomControls.get().split(',').map { it.trim().uppercase() }
+      if ("CAST" !in portraitButtons) {
+        portraitBottomControls.set("CAST,${portraitBottomControls.get()}")
+      }
+      castButtonMigrationComplete.set(true)
+    }
+  }
 
   fun parseButtons(
     csv: String,

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerButton.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerButton.kt
@@ -21,6 +21,7 @@ enum class PlayerButton(
   FRAME_NAVIGATION(Icons.Default.Screenshot),
   VIDEO_ZOOM(Icons.Outlined.ZoomIn),
   PICTURE_IN_PICTURE(Icons.Outlined.PictureInPictureAlt),
+  CAST(Icons.Outlined.Cast),
   ASPECT_RATIO(Icons.Outlined.AspectRatio),
   LOCK_CONTROLS(Icons.Outlined.LockOpen),
   AUDIO_TRACK(Icons.Outlined.Audiotrack),
@@ -67,6 +68,7 @@ fun getPlayerButtonLabel(button: PlayerButton): String =
     PlayerButton.FRAME_NAVIGATION -> "Frame Navigation" // stringResource(R.string.btn_label_frame_nav)
     PlayerButton.VIDEO_ZOOM -> "Video Zoom" // stringResource(R.string.btn_label_zoom)
     PlayerButton.PICTURE_IN_PICTURE -> "Picture-in-Picture" // stringResource(R.string.btn_label_pip)
+    PlayerButton.CAST -> "Cast"
     PlayerButton.ASPECT_RATIO -> "Aspect Ratio" // stringResource(R.string.btn_label_aspect)
     PlayerButton.LOCK_CONTROLS -> "Lock Controls" // stringResource(R.string.btn_label_lock)
     PlayerButton.AUDIO_TRACK -> "Audio Track" // stringResource(R.string.btn_label_audio)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastExpandedControlsActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastExpandedControlsActivity.kt
@@ -1,0 +1,15 @@
+package app.gyrolet.mpvrx.ui.cast
+
+import android.view.Menu
+import app.gyrolet.mpvrx.R
+import com.google.android.gms.cast.framework.CastButtonFactory
+import com.google.android.gms.cast.framework.media.widget.ExpandedControllerActivity
+
+class CastExpandedControlsActivity : ExpandedControllerActivity() {
+  override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    super.onCreateOptionsMenu(menu)
+    menuInflater.inflate(R.menu.cast_expanded_controls, menu)
+    CastButtonFactory.setUpMediaRouteButton(this, menu, R.id.media_route_menu_item)
+    return true
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastMediaServer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastMediaServer.kt
@@ -1,0 +1,192 @@
+package app.gyrolet.mpvrx.ui.cast
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.util.Log
+import fi.iki.elonen.NanoHTTPD
+import java.io.FilterInputStream
+import java.io.InputStream
+import java.net.Inet4Address
+import java.util.UUID
+
+/** Serves one Android-local media item to the selected Cast receiver. */
+internal class CastMediaServer private constructor(
+  private val appContext: Context,
+  private val source: Uri,
+  private val mimeType: String,
+  private val contentLength: Long,
+  private val token: String,
+) : NanoHTTPD("0.0.0.0", 0) {
+  override fun serve(session: IHTTPSession): Response {
+    if (session.uri != "/$token") return textResponse(Response.Status.NOT_FOUND, "Not found")
+    if (session.method == Method.OPTIONS) {
+      return newFixedLengthResponse(Response.Status.NO_CONTENT, mimeType, "").apply {
+        addHeader("Access-Control-Allow-Origin", "*")
+        addHeader("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+        addHeader("Access-Control-Allow-Headers", "Range, Content-Type")
+      }
+    }
+    if (session.method != Method.GET && session.method != Method.HEAD) {
+      return textResponse(Response.Status.METHOD_NOT_ALLOWED, "Method not allowed")
+    }
+
+    return runCatching {
+      val range = session.headers["range"]
+      if (range != null && range.startsWith("bytes=") && contentLength > 0L) {
+        serveRange(session, range)
+      } else {
+        serveFull(session)
+      }
+    }.getOrElse { error ->
+      Log.e(TAG, "Failed to serve Cast media", error)
+      textResponse(Response.Status.INTERNAL_ERROR, "Unable to read media")
+    }
+  }
+
+  private fun serveFull(session: IHTTPSession): Response {
+    if (session.method == Method.HEAD) {
+      return newFixedLengthResponse(Response.Status.OK, mimeType, "").withMediaHeaders(contentLength)
+    }
+
+    val input = openAt(0L) ?: return textResponse(Response.Status.NOT_FOUND, "Media unavailable")
+    val response =
+      if (contentLength > 0L) {
+        newFixedLengthResponse(Response.Status.OK, mimeType, input, contentLength)
+      } else {
+        newChunkedResponse(Response.Status.OK, mimeType, input)
+      }
+    return response.withMediaHeaders(contentLength)
+  }
+
+  private fun serveRange(session: IHTTPSession, rangeHeader: String): Response {
+    val value = rangeHeader.removePrefix("bytes=").substringBefore(',')
+    val parts = value.split('-', limit = 2)
+    val startText = parts.getOrElse(0) { "" }
+    val endText = parts.getOrElse(1) { "" }
+    val start =
+      if (startText.isBlank()) {
+        val suffix = endText.toLongOrNull() ?: return rangeNotSatisfiable()
+        (contentLength - suffix).coerceAtLeast(0L)
+      } else {
+        startText.toLongOrNull() ?: return rangeNotSatisfiable()
+      }
+    val end =
+      if (startText.isBlank()) {
+        contentLength - 1L
+      } else {
+        (endText.toLongOrNull() ?: (contentLength - 1L)).coerceAtMost(contentLength - 1L)
+      }
+
+    if (start !in 0 until contentLength || end < start) return rangeNotSatisfiable()
+    val length = end - start + 1L
+    if (session.method == Method.HEAD) {
+      return newFixedLengthResponse(Response.Status.PARTIAL_CONTENT, mimeType, "")
+        .withRangeHeaders(start, end, length)
+    }
+
+    val input = openAt(start) ?: return textResponse(Response.Status.NOT_FOUND, "Media unavailable")
+    return newFixedLengthResponse(Response.Status.PARTIAL_CONTENT, mimeType, input, length)
+      .withRangeHeaders(start, end, length)
+  }
+
+  private fun openAt(offset: Long): InputStream? {
+    val descriptor = appContext.contentResolver.openAssetFileDescriptor(source, "r") ?: return null
+    val input = descriptor.createInputStream()
+    var remaining = offset
+    while (remaining > 0L) {
+      val skipped = input.skip(remaining)
+      if (skipped <= 0L) {
+        input.close()
+        descriptor.close()
+        return null
+      }
+      remaining -= skipped
+    }
+    return object : FilterInputStream(input) {
+      override fun close() {
+        runCatching { super.close() }
+        runCatching { descriptor.close() }
+      }
+    }
+  }
+
+  private fun Response.withMediaHeaders(length: Long): Response = apply {
+    addHeader("Accept-Ranges", "bytes")
+    addHeader("Access-Control-Allow-Origin", "*")
+    addHeader("Access-Control-Allow-Headers", "Range, Content-Type")
+    addHeader("Access-Control-Expose-Headers", "Content-Range, Accept-Ranges, Content-Length")
+    if (length > 0L) addHeader("Content-Length", length.toString())
+  }
+
+  private fun Response.withRangeHeaders(start: Long, end: Long, length: Long): Response = apply {
+    withMediaHeaders(length)
+    addHeader("Content-Range", "bytes $start-$end/$contentLength")
+  }
+
+  private fun rangeNotSatisfiable(): Response =
+    textResponse(Response.Status.RANGE_NOT_SATISFIABLE, "Range not satisfiable").apply {
+      addHeader("Content-Range", "bytes */$contentLength")
+    }
+
+  private fun textResponse(status: Response.IStatus, message: String): Response =
+    newFixedLengthResponse(status, MIME_PLAINTEXT, message).apply {
+      addHeader("Access-Control-Allow-Origin", "*")
+    }
+
+  companion object {
+    private const val TAG = "CastMediaServer"
+
+    @Volatile private var active: CastMediaServer? = null
+
+    @Synchronized
+    fun expose(context: Context, source: Uri, mimeType: String): String? {
+      stop()
+      val host = runCatching { findLanAddress(context) }.getOrNull() ?: return null
+      val token = UUID.randomUUID().toString().replace("-", "")
+      val server =
+        CastMediaServer(
+          appContext = context.applicationContext,
+          source = source,
+          mimeType = mimeType,
+          contentLength = runCatching { queryLength(context, source) }.getOrDefault(-1L),
+          token = token,
+        )
+      return runCatching {
+        server.start(SOCKET_READ_TIMEOUT, false)
+        active = server
+        "http://$host:${server.listeningPort}/$token"
+      }.onFailure { error ->
+        Log.e(TAG, "Unable to start Cast media server", error)
+        server.stop()
+      }.getOrNull()
+    }
+
+    @Synchronized
+    fun stop() {
+      active?.stop()
+      active = null
+    }
+
+    private fun queryLength(context: Context, uri: Uri): Long {
+      context.contentResolver.openAssetFileDescriptor(uri, "r")?.use { descriptor ->
+        if (descriptor.length >= 0L) return descriptor.length
+      }
+      return context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+        if (cursor.moveToFirst()) cursor.getLong(0) else -1L
+      } ?: -1L
+    }
+
+    private fun findLanAddress(context: Context): String? {
+      val connectivity = context.getSystemService(ConnectivityManager::class.java)
+      val properties = connectivity.getLinkProperties(connectivity.activeNetwork)
+      return properties?.linkAddresses
+        ?.asSequence()
+        ?.map { it.address }
+        ?.filterIsInstance<Inet4Address>()
+        ?.firstOrNull { !it.isLoopbackAddress && it.isSiteLocalAddress }
+        ?.hostAddress
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastPlaybackController.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastPlaybackController.kt
@@ -1,0 +1,190 @@
+package app.gyrolet.mpvrx.ui.cast
+
+import android.content.Intent
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaLoadRequestData
+import com.google.android.gms.cast.MediaMetadata
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.SessionManagerListener
+
+data class CastMediaSnapshot(
+  val source: Uri,
+  val title: String,
+  val mimeType: String?,
+  val durationMs: Long,
+  val positionMs: Long,
+  val isPlaying: Boolean,
+)
+
+/** Transfers the active mpv item to the Default Media Receiver and back. */
+class CastPlaybackController(
+  private val activity: AppCompatActivity,
+  private val currentMedia: () -> CastMediaSnapshot?,
+  private val pauseLocal: () -> Unit,
+  private val restoreLocal: (positionMs: Long, play: Boolean) -> Unit,
+  private val notifyUser: (String) -> Unit,
+) {
+  private val castContext: CastContext by lazy { CastContext.getSharedInstance(activity) }
+  private var localWasPlaying = false
+  private var lastRemotePositionMs = 0L
+  private var remoteWasPlaying = false
+  private var capturedRemoteEndState = false
+  private var transferredByThisController = false
+
+  private val sessionListener =
+    object : SessionManagerListener<CastSession> {
+      override fun onSessionStarted(session: CastSession, sessionId: String) {
+        loadCurrentMedia(session)
+      }
+
+      override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+        val remote = session.remoteMediaClient
+        if (remote?.mediaInfo != null) {
+          transferredByThisController = true
+          localWasPlaying = currentMedia()?.isPlaying == true
+          pauseLocal()
+        } else {
+          loadCurrentMedia(session)
+        }
+      }
+
+      override fun onSessionEnding(session: CastSession) {
+        session.remoteMediaClient?.let { remote ->
+          lastRemotePositionMs = remote.approximateStreamPosition
+          remoteWasPlaying = remote.isPlaying
+          capturedRemoteEndState = true
+        }
+      }
+
+      override fun onSessionEnded(session: CastSession, error: Int) {
+        CastMediaServer.stop()
+        if (transferredByThisController) {
+          restoreLocal(
+            lastRemotePositionMs,
+            if (capturedRemoteEndState) remoteWasPlaying else localWasPlaying,
+          )
+        }
+        capturedRemoteEndState = false
+        transferredByThisController = false
+      }
+
+      override fun onSessionStartFailed(session: CastSession, error: Int) {
+        CastMediaServer.stop()
+        notifyUser("Could not connect to Cast device")
+      }
+
+      override fun onSessionResumeFailed(session: CastSession, error: Int) {
+        CastMediaServer.stop()
+      }
+
+      override fun onSessionStarting(session: CastSession) = Unit
+      override fun onSessionResuming(session: CastSession, sessionId: String) = Unit
+      override fun onSessionSuspended(session: CastSession, reason: Int) = Unit
+    }
+
+  fun start() {
+    castContext.sessionManager.addSessionManagerListener(sessionListener, CastSession::class.java)
+    castContext.sessionManager.currentCastSession
+      ?.takeIf { it.isConnected }
+      ?.let { session -> sessionListener.onSessionResumed(session, false) }
+  }
+
+  fun release() {
+    castContext.sessionManager.removeSessionManagerListener(sessionListener, CastSession::class.java)
+    if (castContext.sessionManager.currentCastSession?.isConnected != true) {
+      CastMediaServer.stop()
+    }
+  }
+
+  private fun loadCurrentMedia(session: CastSession) {
+    val snapshot = currentMedia()
+    if (snapshot == null) {
+      notifyUser("Media is not ready to cast")
+      castContext.sessionManager.endCurrentSession(true)
+      return
+    }
+
+    val contentUrl = resolveContentUrl(snapshot)
+    if (contentUrl == null) {
+      notifyUser("This media source cannot be reached by the Cast device")
+      castContext.sessionManager.endCurrentSession(true)
+      return
+    }
+
+    val contentType = snapshot.mimeType ?: inferMimeType(snapshot.source)
+    val metadataType =
+      if (contentType.startsWith("audio/")) {
+        MediaMetadata.MEDIA_TYPE_MUSIC_TRACK
+      } else {
+        MediaMetadata.MEDIA_TYPE_MOVIE
+      }
+    val metadata = MediaMetadata(metadataType).apply {
+      putString(MediaMetadata.KEY_TITLE, snapshot.title)
+    }
+    val mediaInfo =
+      MediaInfo.Builder(contentUrl)
+        .setStreamType(
+          if (snapshot.durationMs > 0L) MediaInfo.STREAM_TYPE_BUFFERED else MediaInfo.STREAM_TYPE_LIVE,
+        )
+        .setContentType(contentType)
+        .setMetadata(metadata)
+        .setStreamDuration(snapshot.durationMs.coerceAtLeast(0L))
+        .build()
+    val request =
+      MediaLoadRequestData.Builder()
+        .setMediaInfo(mediaInfo)
+        .setAutoplay(snapshot.isPlaying)
+        .setCurrentTime(snapshot.positionMs.coerceAtLeast(0L))
+        .build()
+    val remote = session.remoteMediaClient ?: run {
+      notifyUser("Cast receiver is not ready")
+      return
+    }
+
+    remote.load(request).setResultCallback { result ->
+      activity.runOnUiThread {
+        if (result.status.isSuccess) {
+          localWasPlaying = snapshot.isPlaying
+          lastRemotePositionMs = snapshot.positionMs
+          remoteWasPlaying = snapshot.isPlaying
+          capturedRemoteEndState = false
+          transferredByThisController = true
+          pauseLocal()
+          activity.startActivity(Intent(activity, CastExpandedControlsActivity::class.java))
+        } else {
+          CastMediaServer.stop()
+          notifyUser(result.status.statusMessage ?: "Unable to play this media on the Cast device")
+        }
+      }
+    }
+  }
+
+  private fun resolveContentUrl(snapshot: CastMediaSnapshot): String? {
+    val scheme = snapshot.source.scheme?.lowercase()
+    if (scheme == "http" || scheme == "https") {
+      val host = snapshot.source.host.orEmpty()
+      if (host != "127.0.0.1" && host != "localhost" && host != "0.0.0.0") {
+        return snapshot.source.toString()
+      }
+      return null
+    }
+    if (scheme == "content" || scheme == "file") {
+      return CastMediaServer.expose(
+        context = activity,
+        source = snapshot.source,
+        mimeType = snapshot.mimeType ?: inferMimeType(snapshot.source),
+      )
+    }
+    return null
+  }
+
+  private fun inferMimeType(uri: Uri): String {
+    activity.contentResolver.getType(uri)?.let { return it }
+    val extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+    return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.lowercase()) ?: "video/mp4"
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastPlayerButton.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/cast/CastPlayerButton.kt
@@ -1,0 +1,58 @@
+package app.gyrolet.mpvrx.ui.cast
+
+import android.graphics.Color
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.mediarouter.app.MediaRouteButton
+import app.gyrolet.mpvrx.ui.theme.controlColor
+import com.google.android.gms.cast.framework.CastButtonFactory
+
+/** The SDK-owned Cast icon supplies available, connecting, and connected states. */
+@Composable
+fun CastPlayerButton(
+  hideBackground: Boolean,
+  buttonSize: Dp,
+) {
+  Surface(
+    shape = CircleShape,
+    color =
+      if (hideBackground) {
+        ComposeColor.Transparent
+      } else {
+        MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f)
+      },
+    contentColor = if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface,
+    border =
+      if (hideBackground) {
+        null
+      } else {
+        BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+      },
+    modifier = Modifier.size(buttonSize),
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      AndroidView(
+        factory = { context ->
+          MediaRouteButton(context).apply {
+            setBackgroundColor(Color.TRANSPARENT)
+            contentDescription = "Cast"
+            CastButtonFactory.setUpMediaRouteButton(context.applicationContext, this)
+          }
+        },
+        modifier = Modifier.fillMaxSize(),
+      )
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/cast/MpvRxCastOptionsProvider.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/cast/MpvRxCastOptionsProvider.kt
@@ -1,0 +1,31 @@
+package app.gyrolet.mpvrx.ui.cast
+
+import android.content.Context
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.framework.CastOptions
+import com.google.android.gms.cast.framework.OptionsProvider
+import com.google.android.gms.cast.framework.SessionProvider
+import com.google.android.gms.cast.framework.media.CastMediaOptions
+import com.google.android.gms.cast.framework.media.NotificationOptions
+
+class MpvRxCastOptionsProvider : OptionsProvider {
+  override fun getCastOptions(context: Context): CastOptions {
+    val notificationOptions =
+      NotificationOptions.Builder()
+        .setTargetActivityClassName(CastExpandedControlsActivity::class.java.name)
+        .build()
+    val mediaOptions =
+      CastMediaOptions.Builder()
+        .setNotificationOptions(notificationOptions)
+        .setExpandedControllerActivityClassName(CastExpandedControlsActivity::class.java.name)
+        .build()
+
+    return CastOptions.Builder()
+      .setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
+      .setCastMediaOptions(mediaOptions)
+      .setRemoteToLocalEnabled(true)
+      .build()
+  }
+
+  override fun getAdditionalSessionProviders(context: Context): List<SessionProvider>? = null
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/icons/Icons.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/icons/Icons.kt
@@ -5,6 +5,7 @@ import com.composables.icons.materialsymbols.MaterialSymbols
 import com.composables.icons.materialsymbols.roundedfilled.R
 import com.composables.icons.materialsymbols.roundedfilled.Brand_family
 import com.composables.icons.materialsymbols.roundedfilled.Cancel
+import com.composables.icons.materialsymbols.roundedfilled.Cast
 import com.composables.icons.materialsymbols.roundedfilled.Close
 import com.composables.icons.materialsymbols.roundedfilled.Code
 import com.composables.icons.materialsymbols.roundedfilled.Developer_board
@@ -62,6 +63,7 @@ object Icons {
     val CameraAlt = AppIcon(R.drawable.materialsymbols_ic_photo_camera_rounded_filled)
     val Cancel = AppIcon(MaterialSymbols.RoundedFilled.Cancel)
     val CatchingPokemon = AppIcon(R.drawable.materialsymbols_ic_pets_rounded_filled)
+    val Cast = AppIcon(MaterialSymbols.RoundedFilled.Cast)
     val Check = AppIcon(AppR.drawable.ic_material_symbols_check)
     val CheckCircle = AppIcon(R.drawable.materialsymbols_ic_check_circle_rounded_filled)
     val Checklist = AppIcon(R.drawable.materialsymbols_ic_checklist_rounded_filled)
@@ -411,6 +413,7 @@ object Icons {
     val Bookmarks = Shared.Bookmarks
     val BlurOff = Shared.BlurOff
     val BlurOn = Shared.BlurOn
+    val Cast = Shared.Cast
     val BugReport = Shared.BugReport
     val Clear = Shared.Clear
     val Edit = Shared.Edit

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -73,6 +73,8 @@ import app.gyrolet.mpvrx.preferences.VideoSortType
 import app.gyrolet.mpvrx.ui.browser.playlist.ALL_VIDEOS_PLAYLIST_ID
 import app.gyrolet.mpvrx.ui.browser.playlist.buildAllVideosPlaylistEntity
 import app.gyrolet.mpvrx.ui.browser.playlist.isAllVideosPlaylist
+import app.gyrolet.mpvrx.ui.cast.CastMediaSnapshot
+import app.gyrolet.mpvrx.ui.cast.CastPlaybackController
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.ui.player.controls.PlayerControls
 import app.gyrolet.mpvrx.ui.player.visualizer.BlobOverlay
@@ -316,6 +318,7 @@ class PlayerActivity :
    * Helper for managing Picture-in-Picture mode.
    */
   private lateinit var pipHelper: MPVPipHelper
+  private lateinit var castPlaybackController: CastPlaybackController
 
   private var isReady = false // Single flag: true when video loaded and ready
   private var isUserFinishing = false
@@ -630,6 +633,7 @@ class PlayerActivity :
         }
       }
     }
+    setupCastPlayback()
 
     // Only set orientation immediately if NOT in Video mode
     // For Video mode, wait for video-params/aspect to become available
@@ -874,6 +878,52 @@ class PlayerActivity :
     pipHelper = MPVPipHelper(activity = this, mpvView = player)
   }
 
+  private fun setupCastPlayback() {
+    castPlaybackController =
+      CastPlaybackController(
+        activity = this,
+        currentMedia = ::currentCastMediaSnapshot,
+        pauseLocal = viewModel::pause,
+        restoreLocal = { positionMs, play ->
+          if (!isFinishing && !isDestroyed) {
+            viewModel.seekTo((positionMs / 1000L).toInt().coerceAtLeast(0))
+            if (play) viewModel.unpause() else viewModel.pause()
+          }
+        },
+        notifyUser = viewModel::showToast,
+      )
+    castPlaybackController.start()
+  }
+
+  private fun currentCastMediaSnapshot(): CastMediaSnapshot? {
+    if (!isReady || fileName.isBlank()) return null
+    val source =
+      sequenceOf(
+        currentPlayableUri,
+        runCatching { MPVLib.getPropertyString("path") }.getOrNull(),
+        intent?.dataString,
+      ).filterNotNull()
+        .filter { it.isNotBlank() }
+        .map { sourceText ->
+          val parsed = Uri.parse(sourceText)
+          if (parsed.scheme.isNullOrBlank()) Uri.fromFile(File(sourceText)) else parsed
+        }.firstOrNull { uri ->
+          when (uri.scheme?.lowercase()) {
+            "content", "file" -> true
+            "http", "https" -> uri.host !in setOf("127.0.0.1", "localhost", "0.0.0.0")
+            else -> false
+          }
+        } ?: return null
+    return CastMediaSnapshot(
+      source = source,
+      title = getPreferredCurrentTitle().ifBlank { fileName },
+      mimeType = intent?.type ?: runCatching { contentResolver.getType(source) }.getOrNull(),
+      durationMs = ((MPVLib.getPropertyDouble("duration") ?: 0.0) * 1000.0).toLong(),
+      positionMs = ((MPVLib.getPropertyDouble("time-pos") ?: 0.0) * 1000.0).toLong(),
+      isPlaying = MPVLib.getPropertyBoolean("pause") == false,
+    )
+  }
+
   private fun setupAudio() {
     audioPreferences.audioChannels.get().let {
       runCatching {
@@ -975,6 +1025,7 @@ class PlayerActivity :
       )
 
     runCatching {
+      if (::castPlaybackController.isInitialized) castPlaybackController.release()
       cancelSystemBarsAutoHide()
       saveVideoPlaybackState(fileName, immediate = true)
       if (!keepBackgroundPlaybackAlive) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControlsShared.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControlsShared.kt
@@ -57,6 +57,7 @@ import app.gyrolet.mpvrx.preferences.PlayerButton
 import app.gyrolet.mpvrx.preferences.PlayerClockFormat
 import app.gyrolet.mpvrx.preferences.PlayerPreferences
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
+import app.gyrolet.mpvrx.ui.cast.CastPlayerButton
 import app.gyrolet.mpvrx.ui.player.Panels
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerViewModel
@@ -520,6 +521,13 @@ fun RenderPlayerButton(
         onClick = { activity.enterPipModeHidingOverlay() },
         color = if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface,
         modifier = Modifier.size(buttonSize),
+      )
+    }
+
+    PlayerButton.CAST -> {
+      CastPlayerButton(
+        hideBackground = hideBackground,
+        buttonSize = buttonSize,
       )
     }
 

--- a/app/src/main/res/menu/cast_expanded_controls.xml
+++ b/app/src/main/res/menu/cast_expanded_controls.xml
@@ -1,0 +1,8 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/media_route_menu_item"
+        android:title="Cast"
+        app:actionProviderClass="androidx.mediarouter.app.MediaRouteActionProvider"
+        app:showAsAction="always" />
+</menu>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ materialSymbols = "2.2.1"
 seeker = "2.0.1"
 kotlinTest = "2.3.21"
 curlAndroid = "8.18.0"
+googleCast = "22.3.1"
 
 [libraries]
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
@@ -106,6 +107,7 @@ desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref 
 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 curl-android = { module = "io.github.vvb2060.ndk:curl", version.ref = "curlAndroid" }
+google-cast-framework = { module = "com.google.android.gms:play-services-cast-framework", version.ref = "googleCast" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 


### PR DESCRIPTION
## What changed

- Added Google Cast discovery and a native stateful Cast route button to customizable portrait and landscape player controls.
- Transfers the current media title, play state, duration, and position to Google's Default Media Receiver.
- Serves local `file://` and `content://` media through a tokenized temporary LAN endpoint with range requests and CORS; receiver-accessible HTTP(S) sources are handed off directly.
- Added expanded Cast controls, notification/lock-screen integration, reconnection handling, and return-to-phone playback continuity.
- Refreshed README and changelog coverage for Cast and other significant features added since the README's previous update.

## Why

mpvRx did not have an integrated sender flow for Chromecast or Cast-enabled TVs. Users can now discover receivers and move supported playback between the phone and receiver without manually opening a separate casting app.

## User impact

The Cast button is added to default layouts and migrated into existing layouts once, while remaining fully customizable. Casting uses the receiver's native codec/container support and does not transcode unsupported formats.

## Static validation

- `git diff --check`
- Parsed the Android manifest and Cast menu as XML
- Verified balanced README `<details>` sections
- Verified Cast wiring and removal of custom/non-library Cast drawable references with repository searches

Per request, no compilation or tests were run.
