### PR TITLE
Hide inactive swipe action backgrounds

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/SwipeableVideoActions.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/SwipeableVideoActions.kt
@@ -91,45 +91,47 @@ fun SwipeableVideoActions(
     modifier =
       Modifier
         .fillMaxWidth()
-        .clip(shape),
+        .clip(shape)
+        .background(MaterialTheme.colorScheme.surface),
   ) {
-    Box(
-      modifier =
-        Modifier
-          .matchParentSize()
-          .background(MaterialTheme.colorScheme.primaryContainer),
-      contentAlignment = Alignment.CenterStart,
-    ) {
-      SwipeVideoAction(
-        label = if (isWatched) "Unwatch" else "Watched",
-        icon = if (isWatched) Icons.RoundedFilled.RemoveCircle else Icons.RoundedFilled.CheckCircle,
-        background = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        width = actionWidth,
-        onClick = null,
-      )
+    if (offsetX > 0f) {
+      Box(
+        modifier = Modifier.matchParentSize(),
+        contentAlignment = Alignment.CenterStart,
+      ) {
+        SwipeVideoAction(
+          label = if (isWatched) "Unwatch" else "Watched",
+          icon = if (isWatched) Icons.RoundedFilled.RemoveCircle else Icons.RoundedFilled.CheckCircle,
+          background = MaterialTheme.colorScheme.primaryContainer,
+          contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+          width = actionWidth,
+          onClick = null,
+        )
+      }
     }
 
-    Row(
-      modifier = Modifier.matchParentSize(),
-      horizontalArrangement = Arrangement.End,
-    ) {
-      SwipeVideoAction(
-        label = "Rename",
-        icon = Icons.RoundedFilled.Edit,
-        background = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-        width = actionWidth,
-        onClick = { settle(0f, onRename) },
-      )
-      SwipeVideoAction(
-        label = "Delete",
-        icon = Icons.RoundedFilled.Delete,
-        background = MaterialTheme.colorScheme.errorContainer,
-        contentColor = MaterialTheme.colorScheme.onErrorContainer,
-        width = actionWidth,
-        onClick = { settle(0f, onDelete) },
-      )
+    if (offsetX < 0f) {
+      Row(
+        modifier = Modifier.matchParentSize(),
+        horizontalArrangement = Arrangement.End,
+      ) {
+        SwipeVideoAction(
+          label = "Rename",
+          icon = Icons.RoundedFilled.Edit,
+          background = MaterialTheme.colorScheme.secondaryContainer,
+          contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+          width = actionWidth,
+          onClick = { settle(0f, onRename) },
+        )
+        SwipeVideoAction(
+          label = "Delete",
+          icon = Icons.RoundedFilled.Delete,
+          background = MaterialTheme.colorScheme.errorContainer,
+          contentColor = MaterialTheme.colorScheme.onErrorContainer,
+          width = actionWidth,
+          onClick = { settle(0f, onDelete) },
+        )
+      }
     }
 
     Box(


### PR DESCRIPTION
### Motivation
- Prevent the faint rounded action colors from peeking through the row corners when the swipeable row is at rest by providing a solid surface base and only showing actions while actively swiping.
- Improve visual cleanliness of the `SwipeableVideoActions` row so the UI resting state matches the surface background.

### Description
- Add a clipped surface-colored base to the swipeable container by applying `.background(MaterialTheme.colorScheme.surface)` to the outer clipped `Box` so the resting area is visually consistent with the surface.
- Render the right-side "Watched/Unwatch" action only when `offsetX > 0f` and render the left-side `Rename/Delete` actions only when `offsetX < 0f` so inactive action panes are not drawn behind the row.
- Keep the existing drag/settle logic and `offsetX` state unchanged so interaction behavior is preserved while the visuals are fixed.
- File modified: `app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/SwipeableVideoActions.kt`.

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin` but the build is blocked in this environment because the Android SDK location is not configured (missing `ANDROID_HOME` or `local.properties` `sdk.dir`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a82d29294832b981579da6f8abbb3)