### PR TITLE
Move MPV startup work off UI thread

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
@@ -381,13 +381,12 @@ class MPVView(
     // Auto-detect font provider (system fonts, embedded fonts, etc.)
     MPVLib.setOptionString("sub-font-provider", "auto")
 
-    // Delay and speed for both primary and secondary
+    // Delay and speed for primary subtitles. Avoid unsupported secondary-sub-*
+    // startup options on Android builds where they are absent.
     val subDelay = (subtitlesPreferences.defaultSubDelay.get() / 1000.0).toString()
     val subSpeed = subtitlesPreferences.defaultSubSpeed.get().toString()
     MPVLib.setOptionString("sub-delay", subDelay)
     MPVLib.setOptionString("sub-speed", subSpeed)
-    MPVLib.setOptionString("secondary-sub-delay", subDelay)
-    MPVLib.setOptionString("secondary-sub-speed", subSpeed)
 
     val preferredFont = subtitlesPreferences.font.get()
     if (preferredFont.isNotBlank()) {
@@ -398,10 +397,8 @@ class MPVView(
     if (subtitlesPreferences.overrideAssSubs.get()) {
       MPVLib.setOptionString("sub-ass-override", "force")
       MPVLib.setOptionString("sub-ass-justify", "yes")
-      MPVLib.setOptionString("secondary-sub-ass-override", "force")
     } else {
       MPVLib.setOptionString("sub-ass-override", "no")
-      MPVLib.setOptionString("secondary-sub-ass-override", "no")
     }
 
     // Typography and styling for both primary and secondary
@@ -417,32 +414,28 @@ class MPVView(
     val borderStyle = subtitlesPreferences.borderStyle.get().value
     val shadowOffset = subtitlesPreferences.shadowOffset.get().toString()
     val subPos = clampSubtitlePosition(subtitlesPreferences.subPos.get())
-    val w = width.takeIf { it > 0 }?.toFloat() ?: context.resources.displayMetrics.widthPixels.toFloat()
-    val h = height.takeIf { it > 0 }?.toFloat() ?: context.resources.displayMetrics.heightPixels.toFloat()
-    val secondarySubPos = calculateSecondarySubtitlePosition(subPos, w, h)
     val subScale = subtitlesPreferences.subScale.get().toString()
 
     val scaleByWindow = if (subtitlesPreferences.scaleByWindow.get()) "yes" else "no"
     val blendMode = if (subtitlesPreferences.blendSubtitlesWithVideo.get() && playerPreferences.isAmbientEnabled.get()) "video" else "no"
     MPVLib.setOptionString("blend-subtitles", blendMode)
 
-    for ((prefix, pos) in listOf("sub-" to subPos.toString(), "secondary-sub-" to secondarySubPos.toString())) {
-      MPVLib.setOptionString("${prefix}font-size", fontSize)
-      MPVLib.setOptionString("${prefix}bold", bold)
-      MPVLib.setOptionString("${prefix}italic", italic)
-      MPVLib.setOptionString("${prefix}justify", justify)
-      MPVLib.setOptionString("${prefix}color", textColor)
-      MPVLib.setOptionString("${prefix}back-color", backgroundColor)
-      MPVLib.setOptionString("${prefix}border-color", borderColor)
-      MPVLib.setOptionString("${prefix}shadow-color", shadowColor)
-      MPVLib.setOptionString("${prefix}border-size", borderSize)
-      MPVLib.setOptionString("${prefix}border-style", borderStyle)
-      MPVLib.setOptionString("${prefix}shadow-offset", shadowOffset)
-      MPVLib.setOptionString("${prefix}scale", subScale)
-      MPVLib.setOptionString("${prefix}pos", pos)
-      MPVLib.setOptionString("${prefix}scale-by-window", scaleByWindow)
-      MPVLib.setOptionString("${prefix}use-margins", scaleByWindow)
-    }
+    val prefix = "sub-"
+    MPVLib.setOptionString("${prefix}font-size", fontSize)
+    MPVLib.setOptionString("${prefix}bold", bold)
+    MPVLib.setOptionString("${prefix}italic", italic)
+    MPVLib.setOptionString("${prefix}justify", justify)
+    MPVLib.setOptionString("${prefix}color", textColor)
+    MPVLib.setOptionString("${prefix}back-color", backgroundColor)
+    MPVLib.setOptionString("${prefix}border-color", borderColor)
+    MPVLib.setOptionString("${prefix}shadow-color", shadowColor)
+    MPVLib.setOptionString("${prefix}border-size", borderSize)
+    MPVLib.setOptionString("${prefix}border-style", borderStyle)
+    MPVLib.setOptionString("${prefix}shadow-offset", shadowOffset)
+    MPVLib.setOptionString("${prefix}scale", subScale)
+    MPVLib.setOptionString("${prefix}pos", subPos.toString())
+    MPVLib.setOptionString("${prefix}scale-by-window", scaleByWindow)
+    MPVLib.setOptionString("${prefix}use-margins", scaleByWindow)
 
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -95,6 +95,7 @@ import `is`.xyz.mpv.Utils
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -114,6 +115,7 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.concurrent.Executors
 
 private enum class BackgroundPlaybackStartResult {
   Started,
@@ -217,7 +219,7 @@ class PlayerActivity :
    * Track selector for automatic audio/subtitle selection
    */
   private val trackSelector: TrackSelector by lazy {
-    TrackSelector(audioPreferences, subtitlesPreferences)
+    TrackSelector(audioPreferences, subtitlesPreferences, mpvDispatcher)
   }
 
   // ==================== Views ====================
@@ -351,8 +353,12 @@ class PlayerActivity :
   private var lastBackgroundThumbnailKey: String? = null
   private var lastBackgroundThumbnail: Bitmap? = null
   private var currentPlayableUri: String? = null // Store current URI for notification re-entry
-  private val playbackRenderDispatcher = Dispatchers.Main
-  private val mediaLoadDispatcher = Dispatchers.Default.limitedParallelism(1)
+  private val mpvDispatcher =
+    Executors.newSingleThreadExecutor { runnable ->
+      Thread(runnable, "MPV-Control-Thread")
+    }.asCoroutineDispatcher()
+  private val playbackRenderDispatcher = mpvDispatcher
+  private val mediaLoadDispatcher = mpvDispatcher
 
   // ==================== Background Playback ====================
 
@@ -530,7 +536,6 @@ class PlayerActivity :
       releaseDetachedBackgroundPlaybackBeforeFreshLaunch()
     }
     setupMPV()
-    viewModel.onMpvCoreInitialized()
     MediaPlaybackService.createNotificationChannel(this)
     setupAudio()
     setupBackPressHandler()
@@ -1047,6 +1052,7 @@ class PlayerActivity :
       }
 
       cleanupMPV(keepBackgroundPlaybackAlive)
+      mpvDispatcher.close()
       if (!keepBackgroundPlaybackAlive) {
         cleanupAudio()
       }
@@ -1526,16 +1532,23 @@ class PlayerActivity :
       }
     }
 
-    // NOW initialize MPV - it will find and load the scripts we just copied
-    initializePlayerWithRendererFallback()
-    runCatching { MPVLib.setThumbnailJavaVM(applicationContext) }
-    mpvInitialized = true
-    Log.d(TAG, "MPV initialized")
+    // NOW initialize MPV on the serialized MPV control thread. It will find and load
+    // the scripts we just copied without blocking the Android main/UI thread.
+    lifecycleScope.launch(mpvDispatcher) {
+      initializePlayerWithRendererFallback()
+      runCatching { MPVLib.setThumbnailJavaVM(applicationContext) }
+      mpvInitialized = true
+      Log.d(TAG, "MPV initialized")
 
-    // Add observer after initialization
-    MPVLib.addObserver(playerObserver)
+      // Add observer after initialization. All subsequent synchronous MPV startup
+      // commands are queued behind this job on the same dispatcher.
+      MPVLib.addObserver(playerObserver)
 
-    scheduleDeferredSubtitleFontsSync()
+      withContext(Dispatchers.Main) {
+        viewModel.onMpvCoreInitialized()
+        scheduleDeferredSubtitleFontsSync()
+      }
+    }
   }
 
   private fun initializePlayerWithRendererFallback() {
@@ -3002,7 +3015,7 @@ class PlayerActivity :
         if (playWhenFileLoaded) {
           playWhenFileLoaded = false
           requestAudioFocus()
-          MPVLib.setPropertyBoolean("pause", false)
+          lifecycleScope.launch(mpvDispatcher) { MPVLib.setPropertyBoolean("pause", false) }
         }
         viewModel.onVideoLoadCompleted()
         handleFileLoaded()
@@ -3075,9 +3088,11 @@ class PlayerActivity :
 
       // Apply default zoom only if there's no saved state
       if (!hasState) {
-        withContext(Dispatchers.Main) {
-          val zoomPreference = playerPreferences.defaultVideoZoom.get()
+        val zoomPreference = playerPreferences.defaultVideoZoom.get()
+        withContext(mpvDispatcher) {
           MPVLib.setPropertyDouble("video-zoom", zoomPreference.toDouble())
+        }
+        withContext(Dispatchers.Main) {
           viewModel.setVideoZoom(zoomPreference)
         }
       }
@@ -3109,7 +3124,7 @@ class PlayerActivity :
       lifecycleScope.launch {
         kotlinx.coroutines.delay(100)
         if (mpvInitialized && !player.isExiting && !isFinishing) {
-          val aspect = player.getVideoOutAspect()
+          val aspect = withContext(mpvDispatcher) { player.getVideoOutAspect() }
           Log.d(TAG, "handleFileLoaded - Video mode, aspect after delay: $aspect")
           if (aspect != null && aspect > 0) {
             setOrientation()
@@ -3125,14 +3140,16 @@ class PlayerActivity :
       if (mpvInitialized && !player.isExiting && !isFinishing) setOrientation()
     }
 
-    applySubtitlePreferences()
-    applyVideoFilterPreferences()
-    viewModel.restoreSavedVideoAspect(showUpdate = false)
+    lifecycleScope.launch(mpvDispatcher) {
+      applySubtitlePreferences()
+      applyVideoFilterPreferences()
+      viewModel.restoreSavedVideoAspect(showUpdate = false)
 
-    if (shouldForceCurrentMediaTitle()) {
-      val preferredTitle = getPreferredCurrentTitle()
-      MPVLib.setPropertyString("force-media-title", preferredTitle)
-      viewModel.setMediaTitle(preferredTitle)
+      if (shouldForceCurrentMediaTitle()) {
+        val preferredTitle = getPreferredCurrentTitle()
+        MPVLib.setPropertyString("force-media-title", preferredTitle)
+        withContext(Dispatchers.Main) { viewModel.setMediaTitle(preferredTitle) }
+      }
     }
 
     viewModel.unpause()
@@ -3346,24 +3363,23 @@ class PlayerActivity :
 
     MPVLib.setPropertyString("blend-subtitles", blendMode)
 
-    for (prefix in listOf("sub-", "secondary-sub-")) {
-      MPVLib.setPropertyString("${prefix}font", font)
-      MPVLib.setPropertyInt("${prefix}font-size", fontSize)
-      MPVLib.setPropertyBoolean("${prefix}bold", bold)
-      MPVLib.setPropertyBoolean("${prefix}italic", italic)
-      MPVLib.setPropertyString("${prefix}justify", justify)
-      MPVLib.setPropertyString("${prefix}border-style", borderStyle)
-      MPVLib.setPropertyInt("${prefix}border-size", borderSize)
-      MPVLib.setPropertyInt("${prefix}outline-size", borderSize)
-      MPVLib.setPropertyInt("${prefix}shadow-offset", shadowOffset)
-      MPVLib.setPropertyString("${prefix}color", textColor)
-      MPVLib.setPropertyString("${prefix}border-color", borderColor)
-      MPVLib.setPropertyString("${prefix}back-color", backgroundColor)
-      MPVLib.setPropertyString("${prefix}shadow-color", shadowColor)
-      MPVLib.setPropertyString("${prefix}scale-by-window", scaleValue)
-      MPVLib.setPropertyString("${prefix}use-margins", scaleValue)
-      MPVLib.setPropertyFloat("${prefix}scale", subScale)
-    }
+    val prefix = "sub-"
+    MPVLib.setPropertyString("${prefix}font", font)
+    MPVLib.setPropertyInt("${prefix}font-size", fontSize)
+    MPVLib.setPropertyBoolean("${prefix}bold", bold)
+    MPVLib.setPropertyBoolean("${prefix}italic", italic)
+    MPVLib.setPropertyString("${prefix}justify", justify)
+    MPVLib.setPropertyString("${prefix}border-style", borderStyle)
+    MPVLib.setPropertyInt("${prefix}border-size", borderSize)
+    MPVLib.setPropertyInt("${prefix}outline-size", borderSize)
+    MPVLib.setPropertyInt("${prefix}shadow-offset", shadowOffset)
+    MPVLib.setPropertyString("${prefix}color", textColor)
+    MPVLib.setPropertyString("${prefix}border-color", borderColor)
+    MPVLib.setPropertyString("${prefix}back-color", backgroundColor)
+    MPVLib.setPropertyString("${prefix}shadow-color", shadowColor)
+    MPVLib.setPropertyString("${prefix}scale-by-window", scaleValue)
+    MPVLib.setPropertyString("${prefix}use-margins", scaleValue)
+    MPVLib.setPropertyFloat("${prefix}scale", subScale)
 
     applySubtitleLayout(
       primaryPosition = subtitlesPreferences.subPos.get(),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/TrackSelector.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/TrackSelector.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import app.gyrolet.mpvrx.preferences.AudioPreferences
 import app.gyrolet.mpvrx.preferences.SubtitlesPreferences
 import `is`.xyz.mpv.MPVLib
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -51,6 +52,7 @@ import kotlinx.coroutines.withContext
 class TrackSelector(
   private val audioPreferences: AudioPreferences,
   private val subtitlesPreferences: SubtitlesPreferences,
+  private val mpvDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) {
   companion object {
     private const val TAG = "TrackSelector"
@@ -69,7 +71,7 @@ class TrackSelector(
     val image: Boolean
   )
 
-  suspend fun onFileLoaded(hasState: Boolean = false) = withContext(Dispatchers.Main) {
+  suspend fun onFileLoaded(hasState: Boolean = false) = withContext(mpvDispatcher) {
     var attempts = 0
     val maxAttempts = 20
     


### PR DESCRIPTION
### Motivation
- Prevent ANR/hangs during player startup by avoiding heavy synchronous MPV work on Android's main/UI thread.
- Serialize MPV initialization, getters/setters, and commands so MPV core access does not block UI rendering.

### Description
- Added a dedicated single-threaded coroutine dispatcher `mpvDispatcher` (`MPV-Control-Thread`) and routed player dispatchers to it via `mpvDispatcher`. (`PlayerActivity.kt`)
- Moved MPV initialization and observer registration onto the MPV control dispatcher and only return to `Dispatchers.Main` for UI updates like `viewModel.onMpvCoreInitialized()` and related UI work. (`PlayerActivity.kt`)
- Serialized media loading and synchronous MPV property writes/reads (e.g. `loadfile`, pause, `video-zoom`, `video-params/*`, and `force-media-title`) through `mpvDispatcher` and updated `startMediaLoad()`, `event()` and `handleFileLoaded()` accordingly. (`PlayerActivity.kt`)
- Updated `TrackSelector` to accept a `mpvDispatcher` and run its `onFileLoaded()` track-list reads on that dispatcher to avoid expensive JNI calls on the main thread. (`TrackSelector.kt`)
- Removed/avoided applying unsupported `secondary-sub-*` startup `option` and `property` calls and limited subtitle startup writes to primary `sub-*` keys to reduce unnecessary MPV work during init. (`MPVView.kt`, `PlayerActivity.kt`)
- Ensure `mpvDispatcher` is closed during teardown (`onDestroy`) to release the dedicated thread. (`PlayerActivity.kt`)

### Testing
- `git diff --check` ran and reported no whitespace/patch problems (success).
- `./gradlew :app:compileDebugKotlin` was attempted but failed due to the environment missing an Android SDK location (`ANDROID_HOME` / `local.properties`), so a full build could not be completed here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b0de87980832b99460229bc0db5c3)