### PR TITLE
Improve thumbnails and audio playlist visuals

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
@@ -256,7 +256,7 @@ class ThumbnailRepository(
     video: Video,
     width: Int,
     height: Int,
-  ): String = "${videoBaseKey(video)}|$width|$height|${thumbnailModeKey()}"
+  ): String = "${videoBaseKey(video)}|$width|$height|${thumbnailModeKey()}|${thumbnailQualityKey()}"
 
   /**
    * Folder prefetch and a visible card may request different sizes for the same source.
@@ -267,9 +267,13 @@ class ThumbnailRepository(
     key: String,
     video: Video,
   ): Boolean =
-    key.startsWith("${videoBaseKey(video)}|") && key.endsWith("|${thumbnailModeKey()}")
+    key.startsWith("${videoBaseKey(video)}|") &&
+      key.endsWith("|${thumbnailModeKey()}|${thumbnailQualityKey()}")
 
-  fun diskCacheKey(video: Video): String = "video-thumb|${videoBaseKey(video)}|${thumbnailModeKey()}"
+  // Keep extraction-quality changes from reusing smaller legacy images that were
+  // cached without their requested dimensions in the key.
+  fun diskCacheKey(video: Video): String =
+    "video-thumb-v2|${videoBaseKey(video)}|${thumbnailModeKey()}|${thumbnailQualityKey()}"
 
   private fun videoBaseKey(video: Video): String {
     if (isNetworkUrl(video.path)) {
@@ -295,7 +299,7 @@ class ThumbnailRepository(
     heightPx: Int,
   ): Bitmap? {
     val mode = browserPreferences.thumbnailMode.get()
-    val dimension = maxOf(widthPx, heightPx, MAX_THUMBNAIL_SIZE).coerceAtMost(DISK_THUMBNAIL_SIZE)
+    val dimension = maxOf(widthPx, heightPx, MAX_THUMBNAIL_SIZE).coerceAtMost(thumbnailMaxSize())
 
     if (video.isAudio || mode == ThumbnailMode.Smart || mode == ThumbnailMode.EmbeddedThumbnail) {
       generateEmbeddedArtwork(video)?.let { return scaleBitmap(it, widthPx, heightPx) }
@@ -314,7 +318,7 @@ class ThumbnailRepository(
       val retriever = MediaMetadataRetriever()
       try {
         setLocalDataSource(retriever, video)
-        EmbeddedArtworkResolver.decodeEmbeddedArtwork(video.path, retriever)?.scaleToThumbnailMax(DISK_THUMBNAIL_SIZE)
+        EmbeddedArtworkResolver.decodeEmbeddedArtwork(video.path, retriever)?.scaleToThumbnailMax(thumbnailMaxSize())
       } finally {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) retriever.close() else retriever.release()
       }
@@ -421,7 +425,7 @@ class ThumbnailRepository(
       BitmapFactory.decodeFile(
         file.absolutePath,
         BitmapFactory.Options().apply {
-          inSampleSize = calculateThumbnailSampleSize(bounds.outWidth, bounds.outHeight, DISK_THUMBNAIL_SIZE)
+          inSampleSize = calculateThumbnailSampleSize(bounds.outWidth, bounds.outHeight, thumbnailMaxSize())
           inPreferredConfig = Bitmap.Config.RGB_565
         },
       )
@@ -661,8 +665,8 @@ class ThumbnailRepository(
       return@withContext null
     }
 
-    val memKey  = "$path|network|$widthPx|$heightPx|${thumbnailModeKey()}"
-    val diskKey = "video-thumb|$path|network|${thumbnailModeKey()}"
+    val memKey  = "$path|network|$widthPx|$heightPx|${thumbnailModeKey()}|${thumbnailQualityKey()}"
+    val diskKey = "video-thumb-v2|$path|network|${thumbnailModeKey()}|${thumbnailQualityKey()}"
 
     // Memory cache hit
     synchronized(memoryCache) { memoryCache.get(memKey) }?.let { return@withContext it }
@@ -716,8 +720,8 @@ class ThumbnailRepository(
       return null
     }
 
-    val memKey = "$path|network|$widthPx|$heightPx|${thumbnailModeKey()}"
-    val diskKey = "video-thumb|$path|network|${thumbnailModeKey()}"
+    val memKey = "$path|network|$widthPx|$heightPx|${thumbnailModeKey()}|${thumbnailQualityKey()}"
+    val diskKey = "video-thumb-v2|$path|network|${thumbnailModeKey()}|${thumbnailQualityKey()}"
 
     // Memory cache hit
     synchronized(memoryCache) { memoryCache.get(memKey) }?.let { return it }
@@ -789,7 +793,7 @@ class ThumbnailRepository(
 
   /** The memory-cache key used by [getThumbnailForNetworkPath]. */
   fun thumbnailKeyForNetworkPath(path: String, widthPx: Int, heightPx: Int): String =
-    "$path|network|$widthPx|$heightPx|${thumbnailModeKey()}"
+    "$path|network|$widthPx|$heightPx|${thumbnailModeKey()}|${thumbnailQualityKey()}"
 
   /**
    * Get a thumbnail for a folder using the first video in the folder.
@@ -823,7 +827,7 @@ class ThumbnailRepository(
     heightPx: Int,
   ): String {
     val md = MessageDigest.getInstance("MD5")
-    md.update("$widthPx|$heightPx|${thumbnailModeKey()}|".toByteArray())
+    md.update("$widthPx|$heightPx|${thumbnailModeKey()}|${thumbnailQualityKey()}|".toByteArray())
     for (video in videos) {
       md.update(video.path.toByteArray())
       md.update("|".toByteArray())
@@ -838,9 +842,9 @@ class ThumbnailRepository(
   private fun thumbnailModeKey(): String =
     browserPreferences.thumbnailMode.get().thumbnailModeCacheKey(browserPreferences.thumbnailFramePosition.get())
 
-  private companion object {
-    const val DISK_THUMBNAIL_SIZE = 1024
-  }
+  private fun thumbnailQualityKey(): String = browserPreferences.thumbnailQuality.get().name
+
+  private fun thumbnailMaxSize(): Int = browserPreferences.thumbnailQuality.get().maxSizePx
 
   private suspend fun generateFastNetworkThumbnail(
     path: String,
@@ -850,7 +854,7 @@ class ThumbnailRepository(
     FastThumbnails.generateAsync(
       path,
       10.0,
-      maxOf(widthPx, heightPx, MAX_THUMBNAIL_SIZE).coerceAtMost(DISK_THUMBNAIL_SIZE),
+      maxOf(widthPx, heightPx, MAX_THUMBNAIL_SIZE).coerceAtMost(thumbnailMaxSize()),
       useHwDec = false,
     )
   }.getOrNull()

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
@@ -48,6 +48,7 @@ class BrowserPreferences(
   // Visibility preferences for video card chips
   val showVideoThumbnails = preferenceStore.getBoolean("show_video_thumbnails", true)
   val thumbnailMode = preferenceStore.getEnum("thumbnail_mode", ThumbnailMode.Smart)
+  val thumbnailQuality = preferenceStore.getEnum("thumbnail_quality", ThumbnailQuality.High)
   val thumbnailFramePosition = preferenceStore.getFloat("thumbnail_frame_position", 33f)
   val showSizeChip = preferenceStore.getBoolean("show_size_chip", true)
   // Metadata-dependent chips (disabled by default for better performance)
@@ -211,6 +212,15 @@ enum class ThumbnailMode {
         FrameAtPosition -> "Frame position"
         EmbeddedThumbnail -> "Embedded thumbnail"
       }
+}
+
+enum class ThumbnailQuality(
+  val maxSizePx: Int,
+  val displayName: String,
+) {
+  Balanced(720, "Balanced (720p)"),
+  High(1080, "High (1080p)"),
+  Ultra(1440, "Ultra (1440p)"),
 }
 
 internal class CoercedPreference(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/FolderCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/FolderCard.kt
@@ -81,6 +81,7 @@ fun FolderCard(
   val showFolderPath by browserPreferences.showFolderPath.collectAsState()
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
   val showFolderThumbnails by browserPreferences.showFolderThumbnails.collectAsState()
+  val thumbnailQuality by browserPreferences.thumbnailQuality.collectAsState()
   val includeAudio by browserPreferences.includeAudioBrowser.collectAsState()
   val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
   val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
@@ -90,7 +91,7 @@ fun FolderCard(
   val thumbnailRepository = koinInject<ThumbnailRepository>()
   var folderThumbnail by remember(folder.bucketId) { mutableStateOf<android.graphics.Bitmap?>(null) }
 
-  LaunchedEffect(folder.bucketId, showFolderThumbnails, isGridMode, manualGridColumnsEnabled, folderGridColumnsPortrait, folderGridColumnsLandscape, isDualPane) {
+  LaunchedEffect(folder.bucketId, showFolderThumbnails, thumbnailQuality, isGridMode, manualGridColumnsEnabled, folderGridColumnsPortrait, folderGridColumnsLandscape, isDualPane) {
     if (isGridMode && showFolderThumbnails) {
       withContext(Dispatchers.IO) {
         val videos = app.gyrolet.mpvrx.repository.MediaFileRepository.getVideosInFolder(context, folder.bucketId)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
@@ -87,6 +87,8 @@ fun VideoCard(
   onThumbClick: () -> Unit = {},
   isGridMode: Boolean = false,
   gridColumns: Int = 1,
+  thumbnailWidthPx: Int? = null,
+  thumbnailHeightPx: Int? = null,
   showSubtitleIndicator: Boolean = true,
   overrideShowSizeChip: Boolean? = null,
   overrideShowResolutionChip: Boolean? = null,
@@ -114,6 +116,7 @@ fun VideoCard(
   val maxLines = if (resolvedUiConfig.unlimitedNameLines) Int.MAX_VALUE else 2
 
   val showThumbnails = resolvedUiConfig.showThumbnails
+  val thumbnailQuality by browserPreferences.thumbnailQuality.collectAsState()
   val showFramerateInResolution = resolvedUiConfig.showFramerateInResolution
   val showProgressBar = resolvedUiConfig.showProgressBar
   val showDateChip = resolvedUiConfig.showDateChip
@@ -181,18 +184,22 @@ fun VideoCard(
           horizontalAlignment = horizontalAlignment,
         ) {
         val thumbnailRepository = koinInject<ThumbnailRepository>()
-        val thumbWidthDp = 160.dp
         val aspect = if (video.isAudio) 1f else 16f / 9f
-        val thumbWidthPx = with(LocalDensity.current) { thumbWidthDp.roundToPx() }
-        val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+        // Screens that know their grid-cell dimensions pass them here. This is
+        // essential for a one-column grid, whose full-width artwork used to be
+        // rendered from a fixed 160 dp thumbnail.
+        val defaultThumbWidthPx = with(LocalDensity.current) { 160.dp.roundToPx() }
+        val resolvedThumbWidthPx = thumbnailWidthPx?.takeIf { it > 0 } ?: defaultThumbWidthPx
+        val resolvedThumbHeightPx = thumbnailHeightPx?.takeIf { it > 0 }
+          ?: (resolvedThumbWidthPx / aspect).roundToInt()
 
         val thumbnailKey =
-          remember(video.id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx) {
-            thumbnailRepository.thumbnailKey(video, thumbWidthPx, thumbHeightPx)
+          remember(video.id, video.dateModified, video.size, resolvedThumbWidthPx, resolvedThumbHeightPx, thumbnailQuality) {
+            thumbnailRepository.thumbnailKey(video, resolvedThumbWidthPx, resolvedThumbHeightPx)
           }
 
         var thumbnail by remember(thumbnailKey) {
-          mutableStateOf(thumbnailRepository.getThumbnailFromMemory(video, thumbWidthPx, thumbHeightPx))
+          mutableStateOf(thumbnailRepository.getThumbnailFromMemory(video, resolvedThumbWidthPx, resolvedThumbHeightPx))
         }
 
         // Update thumbnail when the repository emits that this key became ready (folder prefetch or any other source).
@@ -202,7 +209,7 @@ fun VideoCard(
             .collect {
               thumbnail =
                 withContext(Dispatchers.IO) {
-                  thumbnailRepository.getCachedThumbnail(video, thumbWidthPx, thumbHeightPx)
+                  thumbnailRepository.getCachedThumbnail(video, resolvedThumbWidthPx, resolvedThumbHeightPx)
                 }
             }
         }
@@ -213,9 +220,9 @@ fun VideoCard(
             thumbnail =
               withContext(Dispatchers.IO) {
                 if (allowThumbnailGeneration) {
-                  thumbnailRepository.getThumbnail(video, thumbWidthPx, thumbHeightPx)
+                  thumbnailRepository.getThumbnail(video, resolvedThumbWidthPx, resolvedThumbHeightPx)
                 } else {
-                  thumbnailRepository.getCachedThumbnail(video, thumbWidthPx, thumbHeightPx)
+                  thumbnailRepository.getCachedThumbnail(video, resolvedThumbWidthPx, resolvedThumbHeightPx)
                 }
               }
           }
@@ -464,7 +471,7 @@ fun VideoCard(
         // Load thumbnail with optimized state management
         // Key includes video identity to prevent reloading same thumbnail
         val thumbnailKey =
-          remember(video.id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx) {
+          remember(video.id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx, thumbnailQuality) {
             thumbnailRepository.thumbnailKey(video, thumbWidthPx, thumbHeightPx)
           }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -974,6 +974,8 @@ internal fun VideoListContent(
                       },
                       isGridMode = true,
                       gridColumns = columns,
+                      thumbnailWidthPx = thumbWidthPx,
+                      thumbnailHeightPx = thumbHeightPx,
                       showSubtitleIndicator = showSubtitleIndicator,
                       allowThumbnailGeneration = false,
                       uiConfig = videoCardUiConfig,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -852,10 +852,13 @@ class PlayerActivity :
     binding.controls.setContent {
       MpvrxTheme {
         val isAudioOnly by viewModel.isAudioOnly.collectAsState()
+        val hasAlbumArt by viewModel.hasAlbumArt.collectAsState()
         val audioBlobEnabled by audioPreferences.audioBlobEnabled.collectAsState()
         val paused by MPVLib.propBoolean["pause"].collectAsState()
         Box(modifier = Modifier.fillMaxSize()) {
-          if (isAudioOnly && isCurrentMediaKnownAudio() && audioBlobEnabled) {
+          // Audio-only tracks without artwork otherwise leave the player area blank.
+          // Keep the visualizer enabled by default for that fallback state.
+          if (isAudioOnly && !hasAlbumArt && audioBlobEnabled) {
             BlobOverlay(isPlaying = paused == false)
           }
           PlayerControls(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -43,6 +43,7 @@ import app.gyrolet.mpvrx.utils.media.MediaInfoParser
 import app.gyrolet.mpvrx.utils.media.ParsedMediaInfo
 import app.gyrolet.mpvrx.utils.media.SubtitleHashUtils
 import app.gyrolet.mpvrx.utils.media.resolveSubtitleLookupDirectories
+import app.gyrolet.mpvrx.utils.storage.FileTypeUtils
 import `is`.xyz.mpv.MPVLib
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -3761,6 +3762,12 @@ class PlayerViewModel(
         uri
       }
       val path = resolvedUri.toString()
+      val isAudio =
+        path
+          .substringBefore('?')
+          .substringBefore('#')
+          .substringAfterLast('.', "")
+          .lowercase() in FileTypeUtils.AUDIO_EXTENSIONS
       val isCurrentlyPlaying = index == activity.playlistIndex
 
       // Try to get from cache first (synchronized access)
@@ -3777,6 +3784,7 @@ class PlayerViewModel(
         isWatched = isCurrentlyPlaying && currentProgress >= 95f,
         duration = durationStr,
         resolution = resolutionStr,
+        isAudio = isAudio,
       )
     }
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/PlaylistSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/PlaylistSheet.kt
@@ -74,6 +74,7 @@ data class PlaylistItem(
   val path: String = "", // Video path for thumbnail loading
   val duration: String = "", // Duration in formatted string (e.g., "10:30")
   val resolution: String = "", // Resolution (e.g., "1920x1080")
+  val isAudio: Boolean = false,
 )
 
 @Composable
@@ -97,7 +98,7 @@ private fun PlaylistThumbnail(
       sizeFormatted = "",
       dateModified = 0L,
       dateAdded = 0L,
-      mimeType = "video/*",
+      mimeType = if (item.isAudio) "audio/*" else "video/*",
       bucketId = "",
       bucketDisplayName = "",
       width = 0,
@@ -386,7 +387,7 @@ fun PlaylistTrackListItem(
         contentAlignment = Alignment.Center,
       ) {
         Icon(
-          imageVector = Icons.RoundedFilled.Videocam,
+          imageVector = if (item.isAudio) Icons.RoundedFilled.Audiotrack else Icons.RoundedFilled.Videocam,
           contentDescription = null,
           tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
           modifier = Modifier.size(24.dp),
@@ -482,7 +483,7 @@ fun PlaylistTrackListItem(
                 color = if (item.isPlaying) accentColor else MaterialTheme.colorScheme.onSurfaceVariant,
               )
             }
-          } else {
+          } else if (!item.isAudio) {
             LoadingChip(width = 60.dp)
           }
         }
@@ -557,7 +558,7 @@ fun PlaylistTrackGridItem(
         contentAlignment = Alignment.Center,
       ) {
         Icon(
-          imageVector = Icons.RoundedFilled.Videocam,
+          imageVector = if (item.isAudio) Icons.RoundedFilled.Audiotrack else Icons.RoundedFilled.Videocam,
           contentDescription = null,
           tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
           modifier = Modifier.size(32.dp),
@@ -684,7 +685,7 @@ fun PlaylistTrackGridItem(
                 color = if (item.isPlaying) accentColor else MaterialTheme.colorScheme.onSurfaceVariant,
               )
             }
-          } else {
+          } else if (!item.isAudio) {
             LoadingChip(width = 60.dp)
           }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
@@ -48,6 +48,7 @@ import app.gyrolet.mpvrx.ui.player.VideoOpenAnimation
 import app.gyrolet.mpvrx.ui.player.controls.components.sheets.toFixed
 import app.gyrolet.mpvrx.preferences.MultiChoiceSegmentedButton
 import app.gyrolet.mpvrx.preferences.ThumbnailMode
+import app.gyrolet.mpvrx.preferences.ThumbnailQuality
 import app.gyrolet.mpvrx.preferences.TreeFlattenDepth
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.presentation.Screen
@@ -93,6 +94,7 @@ object AppearancePreferencesScreen : Screen {
         var pendingThumbnailMode by remember { mutableStateOf<ThumbnailMode?>(null) }
         var isThemeSectionExpanded by rememberSaveable { mutableStateOf(true) }
         val storedThumbnailMode by browserPreferences.thumbnailMode.collectAsState()
+        val thumbnailQuality by browserPreferences.thumbnailQuality.collectAsState()
         val thumbnailFramePosition by browserPreferences.thumbnailFramePosition.collectAsState()
         val dualPaneForTablet by browserPreferences.dualPaneForTablet.collectAsState()
         val treeFlattenDepth by browserPreferences.treeFlattenDepth.collectAsState()
@@ -491,6 +493,35 @@ object AppearancePreferencesScreen : Screen {
                                                 "${thumbnailMode.displayName} (${thumbnailFramePosition.roundToInt()}%)"
                                             else -> thumbnailMode.displayName
                                         },
+                                        color = MaterialTheme.colorScheme.outline,
+                                    )
+                                },
+                                enabled = showVideoThumbnails,
+                            )
+
+                            PreferenceDivider()
+
+                            ListPreference(
+                                value = thumbnailQuality,
+                                onValueChange = { newQuality ->
+                                    if (newQuality != thumbnailQuality) {
+                                        scope.launch {
+                                            withContext(Dispatchers.IO) {
+                                                thumbnailRepository.clearThumbnailCache()
+                                            }
+                                            browserPreferences.thumbnailQuality.set(newQuality)
+                                        }
+                                    }
+                                },
+                                values = ThumbnailQuality.entries,
+                                valueToText = { AnnotatedString(it.displayName) },
+                                title = { Text(text = stringResource(id = R.string.pref_appearance_thumbnail_quality_title)) },
+                                summary = {
+                                    Text(
+                                        text = stringResource(
+                                            id = R.string.pref_appearance_thumbnail_quality_summary,
+                                            thumbnailQuality.maxSizePx,
+                                        ),
                                         color = MaterialTheme.colorScheme.outline,
                                     )
                                 },

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SearchablePreference.kt
@@ -90,6 +90,13 @@ object SearchablePreferences {
                 screen = AppearancePreferencesScreen,
             ))
             add(SearchablePreference(
+                titleRes = R.string.pref_appearance_thumbnail_quality_title,
+                summaryRes = R.string.pref_appearance_thumbnail_quality_summary,
+                keywords = listOf("thumbnail", "quality", "resolution", "720p", "1080p", "1440p", "storage"),
+                category = "Appearance",
+                screen = AppearancePreferencesScreen,
+            ))
+            add(SearchablePreference(
                 titleRes = R.string.pref_gesture_tap_thumbnail_to_select_title,
                 summaryRes = R.string.pref_gesture_tap_thumbnail_to_select_summary,
                 keywords = listOf("thumbnail", "selection", "select", "tap", "gesture"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
   <string name="pref_appearance_thumbnail_generation_summary">Choose how thumbnails are generated, including embedded artwork or a specific frame position</string>
   <string name="pref_appearance_thumbnail_generation_change_title">Change thumbnail strategy?</string>
   <string name="pref_appearance_thumbnail_generation_change_summary">This will clear cached thumbnails. New thumbnails will be generated with the selected strategy as you browse.</string>
+  <string name="pref_appearance_thumbnail_quality_title">Thumbnail quality</string>
+  <string name="pref_appearance_thumbnail_quality_summary">Maximum thumbnail resolution: %1$d px. Higher quality uses more storage and may generate more slowly.</string>
   <string name="pref_appearance_thumbnail_position_title">Thumbnail frame position</string>
   <string name="pref_appearance_thumbnail_position_summary">Capture the frame at %1$d%% of the video</string>
   <string name="pref_appearance_show_network_thumbnails_title">Show network thumbnails (Experimental)</string>


### PR DESCRIPTION
## What changed

- adds user-selectable thumbnail quality at 720p, 1080p, or 1440p under Appearance > Thumbnails
- generates full-resolution thumbnails for one-column video grids and refreshes folder thumbnails when quality changes
- versions thumbnail cache keys by quality to prevent low-resolution cache reuse
- marks playlist entries as audio, uses audio placeholders, and hides video-only loading chips for music
- shows the audio blob as the fallback when an audio track has no album artwork

## Why

Video and folder artwork in a single-column grid was generated at a fixed 160 dp size and became visibly soft when stretched. Music playlist rows also displayed video-oriented placeholders and loading indicators, while artwork-free audio could leave the player visually blank.

## Impact

Users can balance thumbnail detail, storage, and generation time. Large grid cards now request an appropriately sized image, and music playback receives correct audio-specific fallbacks.

## Validation

- `git diff --check`
- parsed `strings.xml` with the .NET XML parser
- verified thumbnail-quality references across preferences, cache keys, cards, and folder reload effects
- verified audio fallback wiring in the player and playlist

Android compilation was not run because this environment has no JVM/JDK installed.