### PR TITLE
Smooth fast scrollbar navigation

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
@@ -252,6 +252,11 @@ class ThumbnailRepository(
     }
   }
 
+  fun cancelFolderThumbnailGeneration(folderId: String) {
+    folderJobs.remove(folderId)?.cancel()
+    folderStates.remove(folderId)
+  }
+
   fun thumbnailKey(
     video: Video,
     width: Int,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
@@ -94,6 +94,7 @@ fun VideoCard(
   overrideShowResolutionChip: Boolean? = null,
   useFolderNameStyle: Boolean = false,
   allowThumbnailGeneration: Boolean = true,
+  allowThumbnailLoading: Boolean = true,
   uiConfig: VideoCardUiConfig? = null,
 ) {
   val appearancePreferences = koinInject<AppearancePreferences>()
@@ -203,7 +204,8 @@ fun VideoCard(
         }
 
         // Update thumbnail when the repository emits that this key became ready (folder prefetch or any other source).
-        LaunchedEffect(thumbnailKey) {
+        LaunchedEffect(thumbnailKey, allowThumbnailLoading) {
+          if (!allowThumbnailLoading) return@LaunchedEffect
           thumbnailRepository.thumbnailReadyKeys
             .filter { key -> thumbnailRepository.isThumbnailKeyForVideo(key, video) }
             .collect {
@@ -215,8 +217,8 @@ fun VideoCard(
         }
 
         // Optional immediate generation (used on screens that don't run folder-wide sequential generation).
-        LaunchedEffect(thumbnailKey, allowThumbnailGeneration, showThumbnails) {
-          if (thumbnail == null && showThumbnails) {
+        LaunchedEffect(thumbnailKey, allowThumbnailGeneration, allowThumbnailLoading, showThumbnails) {
+          if (allowThumbnailLoading && thumbnail == null && showThumbnails) {
             thumbnail =
               withContext(Dispatchers.IO) {
                 if (allowThumbnailGeneration) {
@@ -481,7 +483,8 @@ fun VideoCard(
         }
 
         // Update thumbnail when the repository emits that this key became ready (folder prefetch or any other source).
-        LaunchedEffect(thumbnailKey) {
+        LaunchedEffect(thumbnailKey, allowThumbnailLoading) {
+          if (!allowThumbnailLoading) return@LaunchedEffect
           thumbnailRepository.thumbnailReadyKeys
             .filter { key -> thumbnailRepository.isThumbnailKeyForVideo(key, video) }
             .collect {
@@ -493,8 +496,8 @@ fun VideoCard(
         }
 
         // Optional immediate generation (used on screens that don't run folder-wide sequential generation).
-        LaunchedEffect(thumbnailKey, allowThumbnailGeneration, showThumbnails) {
-          if (thumbnail == null && showThumbnails) {
+        LaunchedEffect(thumbnailKey, allowThumbnailGeneration, allowThumbnailLoading, showThumbnails) {
+          if (allowThumbnailLoading && thumbnail == null && showThumbnails) {
             thumbnail =
               withContext(Dispatchers.IO) {
                 if (allowThumbnailGeneration) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/ExpressiveScrollBar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/ExpressiveScrollBar.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,6 +66,7 @@ private data class ScrollMetrics(
   val totalItemsCount: Int,
   val maxScrollIndex: Int,
   val scrollableHeight: Float,
+  val itemsPerLine: Int,
 )
 
 private data class VisibleGridLineMetrics(
@@ -240,6 +242,7 @@ fun ExpressiveScrollBar(
   dragLabelSize: Dp = 40.dp,
   dragLabelGap: Dp = 10.dp,
   autoHideDelayMillis: Long = 700L,
+  onDragStateChanged: (Boolean) -> Unit = {},
 ) {
   val listMetricsTracker = remember(listState) { AxisObservationTracker() }
   val gridMetricsTracker = remember(gridState) { AxisObservationTracker() }
@@ -247,6 +250,7 @@ fun ExpressiveScrollBar(
   var isDragging by remember { mutableStateOf(false) }
   var dragProgress by remember { mutableFloatStateOf(-1f) }
   var pendingScrollIndex by remember { mutableIntStateOf(-1) }
+  var dragScrollMetrics by remember { mutableStateOf<ScrollMetrics?>(null) }
   var retainedDragLabel by remember { mutableStateOf<String?>(null) }
   val displayedProgress = remember { Animatable(0f) }
   var hasSyncedDisplayedProgress by remember { mutableStateOf(false) }
@@ -329,7 +333,7 @@ fun ExpressiveScrollBar(
         totalItemsCount = layoutInfo.totalItemsCount
 
         if (visibleItems.isEmpty()) {
-          return ScrollMetrics(0f, totalItemsCount, 1, 1f)
+          return ScrollMetrics(0f, totalItemsCount, 1, 1f, 1)
         }
 
         observeListLayoutMetrics(layoutInfo, listMetricsTracker)
@@ -421,11 +425,11 @@ fun ExpressiveScrollBar(
           (((totalRows - estimatedVisibleRows).toInt().coerceAtLeast(1)) * itemsPerRow)
             .coerceAtMost((totalItemsCount - 1).coerceAtLeast(1))
       } else {
-        return ScrollMetrics(0f, 0, 1, 1f)
+        return ScrollMetrics(0f, 0, 1, 1f, 1)
       }
 
       if (totalItemsCount == 0) {
-        return ScrollMetrics(0f, 0, 1, 1f)
+        return ScrollMetrics(0f, 0, 1, 1f, 1)
       }
 
       val forward = listState?.canScrollForward ?: gridState?.canScrollForward ?: false
@@ -449,11 +453,15 @@ fun ExpressiveScrollBar(
         totalItemsCount = totalItemsCount,
         maxScrollIndex = approximateMaxScrollIndex,
         scrollableHeight = scrollableHeight,
+        itemsPerLine = if (gridState != null) gridState.layoutInfo.maxSpan.coerceAtLeast(1) else 1,
       )
     }
 
     fun updateProgressFromTouch(touchY: Float, grabOffset: Float) {
-      val stats = getScrollStats()
+      // Layout metrics are stable enough for the duration of a drag. Reusing the
+      // initial snapshot avoids scanning and allocating visible-item lists for
+      // every pointer event.
+      val stats = dragScrollMetrics ?: getScrollStats()
       val targetHandleTop = touchY - grabOffset
       val newProgress = (targetHandleTop / stats.scrollableHeight).coerceIn(0f, 1f)
 
@@ -463,14 +471,26 @@ fun ExpressiveScrollBar(
           progress = newProgress,
           maxScrollIndex = stats.maxScrollIndex,
           totalItemsCount = stats.totalItemsCount,
+          itemsPerLine = stats.itemsPerLine,
         )
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(listState, gridState) {
+      var lastDispatchedIndex = -1
       snapshotFlow { pendingScrollIndex }
         .distinctUntilChanged()
         .collectLatest { index ->
-          if (index >= 0) {
+          if (index < 0) {
+            lastDispatchedIndex = -1
+            return@collectLatest
+          }
+
+          // A drag can deliver pointer events faster than Compose can measure a
+          // new lazy-list viewport. Keep only the newest request for each frame.
+          withFrameNanos { }
+          val visibleIndex = listState?.firstVisibleItemIndex ?: gridState?.firstVisibleItemIndex ?: -1
+          if (shouldDispatchDragTarget(index, visibleIndex, lastDispatchedIndex)) {
+            lastDispatchedIndex = index
             listState?.scrollToItem(index)
             gridState?.scrollToItem(index)
           }
@@ -506,13 +526,6 @@ fun ExpressiveScrollBar(
             }
           }
         }
-    }
-
-    LaunchedEffect(isDragging, dragProgress) {
-      if (isDragging && dragProgress >= 0f) {
-        displayedProgress.snapTo(dragProgress)
-        hasSyncedDisplayedProgress = true
-      }
     }
 
     val dragLabelTargetIndex =
@@ -580,8 +593,10 @@ fun ExpressiveScrollBar(
             detectDragGestures(
               onDragStart = { offset ->
                 isDragging = true
+                onDragStateChanged(true)
 
                 val stats = getScrollStats()
+                dragScrollMetrics = stats
                 val handleHeightPx = with(density) { minHeight.toPx() }
                 val visualProgress = displayedProgress.value
                 val handleY = visualProgress * stats.scrollableHeight
@@ -600,11 +615,15 @@ fun ExpressiveScrollBar(
                 isDragging = false
                 dragProgress = -1f
                 pendingScrollIndex = -1
+                dragScrollMetrics = null
+                onDragStateChanged(false)
               },
               onDragCancel = {
                 isDragging = false
                 dragProgress = -1f
                 pendingScrollIndex = -1
+                dragScrollMetrics = null
+                onDragStateChanged(false)
               },
               onDrag = { change, _ ->
                 change.consume()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/ExpressiveScrollBarMetrics.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/ExpressiveScrollBarMetrics.kt
@@ -102,17 +102,33 @@ internal fun resolveDragTargetIndex(
   progress: Float,
   maxScrollIndex: Int,
   totalItemsCount: Int,
+  itemsPerLine: Int = 1,
 ): Int {
   if (totalItemsCount <= 1) return 0
 
   val clampedProgress = progress.coerceIn(0f, 1f)
   val lastIndex = totalItemsCount - 1
-  if (clampedProgress >= 1f) return lastIndex
+  val rawTarget =
+    if (clampedProgress >= 1f) {
+      lastIndex
+    } else {
+      (clampedProgress * maxScrollIndex.coerceAtLeast(1))
+        .toInt()
+        .coerceIn(0, lastIndex)
+    }
+  val safeItemsPerLine = itemsPerLine.coerceAtLeast(1)
 
-  return (clampedProgress * maxScrollIndex.coerceAtLeast(1))
-    .toInt()
-    .coerceIn(0, lastIndex)
+  return rawTarget - (rawTarget % safeItemsPerLine)
 }
+
+internal fun shouldDispatchDragTarget(
+  targetIndex: Int,
+  visibleIndex: Int,
+  lastDispatchedIndex: Int,
+): Boolean =
+  targetIndex >= 0 &&
+    targetIndex != visibleIndex &&
+    targetIndex != lastDispatchedIndex
 
 fun fastScrollGlyph(value: String?): String? {
   val leadingChar =

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/fab/FabScrollHelper.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/fab/FabScrollHelper.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Common helper functions for FAB visibility based on scroll state
@@ -55,26 +57,24 @@ object FabScrollHelper {
         }
         
         // Update FAB visibility based on list scroll direction
-        LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset, justChangedStates.intValue) {
-            // Only process scroll events (not state changes) after a brief delay
-            // This prevents the FAB from hiding when switching tabs
-            if (justChangedStates.intValue > 0) {
-                // Update previous values without changing visibility
-                previousListIndex.intValue = listState.firstVisibleItemIndex
-                previousListScrollOffset.intValue = listState.firstVisibleItemScrollOffset
-                return@LaunchedEffect
-            }
-            
-            updateFabVisibility(
-                isFabVisible, 
-                listState.firstVisibleItemIndex,
-                listState.firstVisibleItemScrollOffset,
-                previousListIndex.intValue,
-                previousListScrollOffset.intValue
-            )
-            
-            previousListIndex.intValue = listState.firstVisibleItemIndex
-            previousListScrollOffset.intValue = listState.firstVisibleItemScrollOffset
+        LaunchedEffect(listState, justChangedStates.intValue) {
+            snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+                .distinctUntilChanged()
+                .collect { (currentIndex, currentOffset) ->
+                    // Ignore direction changes during a tab/state transition.
+                    if (justChangedStates.intValue == 0) {
+                        updateFabVisibility(
+                            isFabVisible,
+                            currentIndex,
+                            currentOffset,
+                            previousListIndex.intValue,
+                            previousListScrollOffset.intValue
+                        )
+                    }
+
+                    previousListIndex.intValue = currentIndex
+                    previousListScrollOffset.intValue = currentOffset
+                }
         }
         
         // Reset the state change counter after a short delay
@@ -87,25 +87,23 @@ object FabScrollHelper {
         
         // Update FAB visibility based on grid scroll direction (if grid state is provided)
         if (gridState != null) {
-            LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset, justChangedStates.intValue) {
-                // Skip processing during tab changes
-                if (justChangedStates.intValue > 0) {
-                    // Update previous values without changing visibility
-                    previousGridIndex.intValue = gridState.firstVisibleItemIndex
-                    previousGridScrollOffset.intValue = gridState.firstVisibleItemScrollOffset
-                    return@LaunchedEffect
-                }
-                
-                updateFabVisibility(
-                    isFabVisible,
-                    gridState.firstVisibleItemIndex,
-                    gridState.firstVisibleItemScrollOffset,
-                    previousGridIndex.intValue,
-                    previousGridScrollOffset.intValue
-                )
-                
-                previousGridIndex.intValue = gridState.firstVisibleItemIndex
-                previousGridScrollOffset.intValue = gridState.firstVisibleItemScrollOffset
+            LaunchedEffect(gridState, justChangedStates.intValue) {
+                snapshotFlow { gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset }
+                    .distinctUntilChanged()
+                    .collect { (currentIndex, currentOffset) ->
+                        if (justChangedStates.intValue == 0) {
+                            updateFabVisibility(
+                                isFabVisible,
+                                currentIndex,
+                                currentOffset,
+                                previousGridIndex.intValue,
+                                previousGridScrollOffset.intValue
+                            )
+                        }
+
+                        previousGridIndex.intValue = currentIndex
+                        previousGridScrollOffset.intValue = currentOffset
+                    }
             }
         }
         

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -108,6 +108,7 @@ import app.gyrolet.mpvrx.utils.history.RecentlyPlayedOps
 import app.gyrolet.mpvrx.utils.media.CopyPasteOps
 import app.gyrolet.mpvrx.utils.media.MediaUtils
 import app.gyrolet.mpvrx.utils.sort.SortUtils
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -776,6 +777,7 @@ internal fun VideoListContent(
         val rememberedListOffset = rememberSaveable { mutableIntStateOf(0) }
         val rememberedGridIndex = rememberSaveable { mutableIntStateOf(0) }
         val rememberedGridOffset = rememberSaveable { mutableIntStateOf(0) }
+        var isScrollbarDragging by remember { mutableStateOf(false) }
         
         val initialListIndex = if (rememberedListIndex.intValue > 0) {
             rememberedListIndex.intValue
@@ -813,14 +815,26 @@ internal fun VideoListContent(
             initialFirstVisibleItemScrollOffset = rememberedGridOffset.intValue
         )
         
-        LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
-            rememberedListIndex.intValue = listState.firstVisibleItemIndex
-            rememberedListOffset.intValue = listState.firstVisibleItemScrollOffset
+        // Persist only after navigation settles. Updating saveable state for every
+        // pixel invalidated the whole list while fast-scrolling large folders.
+        LaunchedEffect(listState) {
+          snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
+            .distinctUntilChanged()
+            .collectLatest { (index, offset) ->
+              delay(SCROLL_POSITION_SETTLE_MILLIS)
+              rememberedListIndex.intValue = index
+              rememberedListOffset.intValue = offset
+            }
         }
-        
-        LaunchedEffect(gridState.firstVisibleItemIndex, gridState.firstVisibleItemScrollOffset) {
-            rememberedGridIndex.intValue = gridState.firstVisibleItemIndex
-            rememberedGridOffset.intValue = gridState.firstVisibleItemScrollOffset
+
+        LaunchedEffect(gridState) {
+          snapshotFlow { gridState.firstVisibleItemIndex to gridState.firstVisibleItemScrollOffset }
+            .distinctUntilChanged()
+            .collectLatest { (index, offset) ->
+              delay(SCROLL_POSITION_SETTLE_MILLIS)
+              rememberedGridIndex.intValue = index
+              rememberedGridOffset.intValue = offset
+            }
         }
 
         val latestVideosWithInfo by rememberUpdatedState(videosWithInfo)
@@ -842,8 +856,14 @@ internal fun VideoListContent(
           mediaLayoutMode,
           thumbnailListKey,
           videoGridColumns,
+          isScrollbarDragging,
         ) {
-          if (!showVideoThumbnails || latestVideosWithInfo.isEmpty()) return@LaunchedEffect
+          if (!showVideoThumbnails || latestVideosWithInfo.isEmpty() || isScrollbarDragging) {
+            if (isScrollbarDragging) {
+              thumbnailRepository.cancelFolderThumbnailGeneration("$folderId:${mediaLayoutMode.name}")
+            }
+            return@LaunchedEffect
+          }
 
           snapshotFlow {
             val itemCount = latestVideosWithInfo.size
@@ -882,6 +902,9 @@ internal fun VideoListContent(
               indices.mapNotNull { index -> currentVideos.getOrNull(index)?.video }
             }
             .collectLatest { visibleVideos ->
+              // A scroll jump can replace the viewport several times in quick
+              // succession. Start I/O only for the viewport that remains visible.
+              delay(THUMBNAIL_SCROLL_SETTLE_MILLIS)
               thumbnailRepository.startFolderThumbnailGeneration(
                 folderId = "$folderId:${mediaLayoutMode.name}",
                 videos = visibleVideos,
@@ -978,6 +1001,7 @@ internal fun VideoListContent(
                       thumbnailHeightPx = thumbHeightPx,
                       showSubtitleIndicator = showSubtitleIndicator,
                       allowThumbnailGeneration = false,
+                      allowThumbnailLoading = !isScrollbarDragging,
                       uiConfig = videoCardUiConfig,
                     )
                   }
@@ -990,6 +1014,7 @@ internal fun VideoListContent(
                   dragLabelProvider = { index ->
                     fastScrollGlyph(videosWithInfo.getOrNull(index)?.video?.displayName)
                   },
+                  onDragStateChanged = { isDragging -> isScrollbarDragging = isDragging },
                   modifier =
                     Modifier
                       .align(Alignment.CenterEnd)
@@ -1046,6 +1071,7 @@ internal fun VideoListContent(
                       isGridMode = false,
                       showSubtitleIndicator = showSubtitleIndicator,
                       allowThumbnailGeneration = false,
+                      allowThumbnailLoading = !isScrollbarDragging,
                       uiConfig = videoCardUiConfig,
                     )
                   }
@@ -1058,6 +1084,7 @@ internal fun VideoListContent(
                   dragLabelProvider = { index ->
                     fastScrollGlyph(videosWithInfo.getOrNull(index)?.video?.displayName)
                   },
+                  onDragStateChanged = { isDragging -> isScrollbarDragging = isDragging },
                   modifier =
                     Modifier
                       .align(Alignment.CenterEnd)
@@ -1088,6 +1115,9 @@ private fun visibleVideoWindow(
   val end = (lastVisibleIndex + prefetchAfter).coerceAtMost(itemCount - 1)
   return (start..end).toList()
 }
+
+private const val SCROLL_POSITION_SETTLE_MILLIS = 150L
+private const val THUMBNAIL_SCROLL_SETTLE_MILLIS = 100L
 
 
 


### PR DESCRIPTION
## What changed

- coalesces scrollbar-driven lazy list/grid jumps to at most one request per display frame
- aligns grid targets to row boundaries and skips redundant navigation requests
- reuses drag-start layout metrics instead of rescanning visible items on every pointer event
- suspends thumbnail disk lookup and cancels folder thumbnail generation while the scrollbar is held
- resumes thumbnail work only for the final settled viewport
- persists scroll position after navigation settles instead of rewriting saveable state for every pixel
- observes FAB scroll direction through a single flow instead of relaunching effects for each offset

## Why

Large video folders stuttered during scrollbar navigation because each drag movement triggered layout metric allocation, immediate `scrollToItem`, thumbnail I/O/job restarts, and saveable-state invalidation at the same time.

## Impact

Scrollbar movement stays responsive in large list and grid views, while thumbnails resume normally after release.

## Validation

Per request, no automated tests or Android compilation were run. The change was reviewed using static source inspection and scoped diff checks only.