### PR TITLE
feat(browser): add independent list/grid layout option for folder view

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
@@ -58,6 +58,9 @@ class BrowserPreferences(
   val showProgressBar = preferenceStore.getBoolean("show_progress_bar", true)
   val centerGridTitles = preferenceStore.getBoolean("center_grid_titles", true)
   val mediaLayoutMode = preferenceStore.getEnum("media_layout_mode", MediaLayoutMode.LIST)
+  val folderViewFolderLayoutMode = preferenceStore.getEnum("folder_view_folder_layout_mode", MediaLayoutMode.LIST)
+  val folderViewVideoLayoutMode = preferenceStore.getEnum("folder_view_video_layout_mode", MediaLayoutMode.LIST)
+  val separateFolderVideoLayout = preferenceStore.getBoolean("separate_folder_video_layout", false)
   val manualGridColumnsEnabled = preferenceStore.getBoolean("manual_grid_columns_enabled", false)
 
   // Visibility preferences for folder card chips

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
@@ -50,6 +50,9 @@ fun FolderSortDialog(
   val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
   val folderViewMode by browserPreferences.folderViewMode.collectAsState()
+  val folderViewFolderLayoutMode by browserPreferences.folderViewFolderLayoutMode.collectAsState()
+  val folderViewVideoLayoutMode by browserPreferences.folderViewVideoLayoutMode.collectAsState()
+  val separateFolderVideoLayout by browserPreferences.separateFolderVideoLayout.collectAsState()
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
   val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
   val folderGridColumnsPortrait by browserPreferences.folderGridColumnsPortrait.collectAsState()
@@ -79,7 +82,10 @@ fun FolderSortDialog(
   val dynamicFolderColumns = (usableFolderWidth / folderMinWidth).toInt().coerceIn(1, maxColumns)
   val dynamicVideoColumns = (usableVideoWidth / videoMinWidth).toInt().coerceIn(1, maxColumns)
 
-  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
+  val isAlbumView = folderViewMode == FolderViewMode.AlbumView
+  val activeLayoutMode = if (isAlbumView) folderViewFolderLayoutMode else mediaLayoutMode
+
+  val folderGridColumnSelector = if (activeLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
       currentValue = folderGridColumns.coerceIn(1, maxColumns),
@@ -92,7 +98,7 @@ fun FolderSortDialog(
     )
   } else null
 
-  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
+  val videoGridColumnSelector = if (activeLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
       currentValue = videoGridColumns.coerceIn(1, maxColumns),
@@ -104,8 +110,6 @@ fun FolderSortDialog(
       steps = maxColumns - 2,
     )
   } else null
-
-  val isAlbumView = folderViewMode == FolderViewMode.AlbumView
 
   SortDialog(
     isOpen = isOpen,
@@ -169,12 +173,28 @@ fun FolderSortDialog(
       secondOptionLabel = "Grid",
       firstOptionIcon = Icons.RoundedFilled.ViewList,
       secondOptionIcon = Icons.RoundedFilled.GridView,
-      isFirstOptionSelected = mediaLayoutMode == MediaLayoutMode.LIST,
+      isFirstOptionSelected = activeLayoutMode == MediaLayoutMode.LIST,
       onViewModeChange = { isFirstOption ->
-        browserPreferences.mediaLayoutMode.set(
-          if (isFirstOption) MediaLayoutMode.LIST else MediaLayoutMode.GRID
-        )
+        val newLayout = if (isFirstOption) MediaLayoutMode.LIST else MediaLayoutMode.GRID
+        if (isAlbumView) {
+          browserPreferences.folderViewFolderLayoutMode.set(newLayout)
+          if (!separateFolderVideoLayout) {
+            browserPreferences.folderViewVideoLayoutMode.set(newLayout)
+          }
+        } else {
+          browserPreferences.mediaLayoutMode.set(newLayout)
+        }
       },
+      checkboxLabel = if (isAlbumView) "Only for folder list" else null,
+      isCheckboxChecked = separateFolderVideoLayout,
+      onCheckboxChange = if (isAlbumView) {
+        { checked ->
+          browserPreferences.separateFolderVideoLayout.set(checked)
+          if (!checked) {
+            browserPreferences.folderViewVideoLayoutMode.set(browserPreferences.folderViewFolderLayoutMode.get())
+          }
+        }
+      } else null,
     ),
     visibilityToggles = buildList {
       add(
@@ -219,7 +239,7 @@ fun FolderSortDialog(
           onCheckedChange = { browserPreferences.showDateChip.set(it) },
         )
       )
-      if (mediaLayoutMode == MediaLayoutMode.GRID) {
+      if (activeLayoutMode == MediaLayoutMode.GRID) {
         add(
           VisibilityToggle(
             label = "Manual Grid Columns",
@@ -268,6 +288,7 @@ fun VideoSortDialog(
   onSortTypeChange: (VideoSortType) -> Unit,
   onSortOrderChange: (SortOrder) -> Unit,
   isDualPane: Boolean = false,
+  isFolderView: Boolean = true,
 ) {
   val browserPreferences = koinInject<BrowserPreferences>()
   val appearancePreferences = koinInject<AppearancePreferences>()
@@ -281,6 +302,9 @@ fun VideoSortDialog(
   val showExtensionField by browserPreferences.showExtensionField.collectAsState()
   val showDurationField by browserPreferences.showDurationField.collectAsState()
   val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
+  val folderViewVideoLayoutMode by browserPreferences.folderViewVideoLayoutMode.collectAsState()
+  val folderViewFolderLayoutMode by browserPreferences.folderViewFolderLayoutMode.collectAsState()
+  val separateFolderVideoLayout by browserPreferences.separateFolderVideoLayout.collectAsState()
   val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
   val folderViewMode by browserPreferences.folderViewMode.collectAsState()
   val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
@@ -289,6 +313,8 @@ fun VideoSortDialog(
   val folderGridColumnsLandscape by browserPreferences.folderGridColumnsLandscape.collectAsState()
   val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
   val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+
+  val activeLayoutMode = if (isFolderView) folderViewVideoLayoutMode else mediaLayoutMode
 
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
@@ -312,7 +338,7 @@ fun VideoSortDialog(
   val dynamicFolderColumns = (usableFolderWidth / folderMinWidth).toInt().coerceIn(1, maxColumns)
   val dynamicVideoColumns = (usableVideoWidth / videoMinWidth).toInt().coerceIn(1, maxColumns)
 
-  val folderGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
+  val folderGridColumnSelector = if (activeLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Folder Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
       currentValue = folderGridColumns.coerceIn(1, maxColumns),
@@ -325,7 +351,7 @@ fun VideoSortDialog(
     )
   } else null
 
-  val videoGridColumnSelector = if (mediaLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
+  val videoGridColumnSelector = if (activeLayoutMode == MediaLayoutMode.GRID && manualGridColumnsEnabled) {
     GridColumnSelector(
       label = "Video Grid Columns (${if (isLandscape) "Landscape" else "Portrait"})",
       currentValue = videoGridColumns.coerceIn(1, maxColumns),
@@ -402,12 +428,28 @@ fun VideoSortDialog(
       secondOptionLabel = "Grid",
       firstOptionIcon = Icons.RoundedFilled.ViewList,
       secondOptionIcon = Icons.RoundedFilled.GridView,
-      isFirstOptionSelected = mediaLayoutMode == MediaLayoutMode.LIST,
+      isFirstOptionSelected = activeLayoutMode == MediaLayoutMode.LIST,
       onViewModeChange = { isFirstOption ->
-        browserPreferences.mediaLayoutMode.set(
-          if (isFirstOption) MediaLayoutMode.LIST else MediaLayoutMode.GRID
-        )
+        val newLayout = if (isFirstOption) MediaLayoutMode.LIST else MediaLayoutMode.GRID
+        if (isFolderView) {
+          browserPreferences.folderViewVideoLayoutMode.set(newLayout)
+          if (!separateFolderVideoLayout) {
+            browserPreferences.folderViewFolderLayoutMode.set(newLayout)
+          }
+        } else {
+          browserPreferences.mediaLayoutMode.set(newLayout)
+        }
       },
+      checkboxLabel = if (isFolderView) "Only for video list" else null,
+      isCheckboxChecked = separateFolderVideoLayout,
+      onCheckboxChange = if (isFolderView) {
+        { checked ->
+          browserPreferences.separateFolderVideoLayout.set(checked)
+          if (!checked) {
+            browserPreferences.folderViewFolderLayoutMode.set(browserPreferences.folderViewVideoLayoutMode.get())
+          }
+        }
+      } else null,
     ),
     visibilityToggles =
       buildList {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
@@ -18,12 +18,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -183,6 +185,35 @@ fun SortDialog(
                 },
               ) {
                 Text(text = layoutModeSelector.secondOptionLabel)
+              }
+            }
+            if (layoutModeSelector.checkboxLabel != null && layoutModeSelector.onCheckboxChange != null) {
+              Spacer(modifier = Modifier.height(4.dp))
+              Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                  .fillMaxWidth()
+                  .clip(RoundedCornerShape(8.dp))
+                  .clickable {
+                    if (enableLayoutModeOptions) {
+                      layoutModeSelector.onCheckboxChange.invoke(!layoutModeSelector.isCheckboxChecked)
+                    }
+                  }
+                  .padding(vertical = 2.dp),
+              ) {
+                Checkbox(
+                  checked = layoutModeSelector.isCheckboxChecked,
+                  onCheckedChange = { checked ->
+                    if (enableLayoutModeOptions) {
+                      layoutModeSelector.onCheckboxChange.invoke(checked)
+                    }
+                  },
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                  text = layoutModeSelector.checkboxLabel,
+                  style = MaterialTheme.typography.bodyMedium,
+                )
               }
             }
           }
@@ -488,6 +519,9 @@ data class ViewModeSelector(
   val secondOptionIcon: AppIcon,
   val isFirstOptionSelected: Boolean,
   val onViewModeChange: (Boolean) -> Unit,
+  val checkboxLabel: String? = null,
+  val isCheckboxChecked: Boolean = false,
+  val onCheckboxChange: ((Boolean) -> Unit)? = null,
 )
 
 data class GridColumnSelector(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
@@ -176,7 +176,7 @@ object FolderListScreen : Screen {
     val foldersWereDeleted by viewModel.foldersWereDeleted.collectAsState()
 
     // Preferences
-    val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+    val mediaLayoutMode by browserPreferences.folderViewFolderLayoutMode.collectAsState()
     val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
     val folderSortType by browserPreferences.folderSortType.collectAsState()
     val folderSortOrder by browserPreferences.folderSortOrder.collectAsState()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -533,7 +533,8 @@ fun MediaLibraryContent() {
         sortType = videoSortType,
         sortOrder = videoSortOrder,
         onSortTypeChange = { browserPreferences.videoSortType.set(it) },
-        onSortOrderChange = { browserPreferences.videoSortOrder.set(it) }
+        onSortOrderChange = { browserPreferences.videoSortOrder.set(it) },
+        isFolderView = false,
       )
     }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -665,7 +665,7 @@ internal fun VideoListContent(
   val gesturePreferences = koinInject<GesturePreferences>()
   val browserPreferences = koinInject<BrowserPreferences>()
   val appearancePreferences = koinInject<AppearancePreferences>()
-  val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
+  val mediaLayoutMode by browserPreferences.folderViewVideoLayoutMode.collectAsState()
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isTablet = configuration.smallestScreenWidthDp >= 600
   val bottomPadding = if (showFloatingBottomBar) {


### PR DESCRIPTION
Add options to separate list and grid layout modes between the folder list and video list screens under Folder View.