### PR TITLE
fix(player): decouple video and subtitle gesture toggles

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/GestureHandler.kt
@@ -833,7 +833,7 @@ fun GestureHandler(
         }
       }
       .pointerInput(pinchToZoomGesture, pinchToZoomSubtitles, panAndZoomEnabled, areControlsLocked, isVerticalGestureActive) {
-        if (!pinchToZoomGesture || areControlsLocked || isVerticalGestureActive) return@pointerInput
+        if ((!pinchToZoomGesture && !pinchToZoomSubtitles) || areControlsLocked || isVerticalGestureActive) return@pointerInput
 
         awaitEachGesture {
           var zoom = 0f
@@ -891,9 +891,11 @@ fun GestureHandler(
                   initialSubScale = MPVLib.getPropertyFloat("sub-scale") ?: subtitlesPreferences.subScale.get()
                   initialDist = dist
                   lastCalculatedSubScale = initialSubScale
-                } else {
+                } else if (pinchToZoomGesture) {
                   isSubZoomMode = false
                   zoom = viewModel.videoZoom.value
+                } else {
+                  isSubZoomMode = false
                 }
               } else {
                 if (isSubZoomMode) {
@@ -907,7 +909,7 @@ fun GestureHandler(
                     MPVLib.setPropertyFloat("sub-scale", currentSubScale)
                     viewModel.playerUpdate.update { PlayerUpdates.SubtitleZoom(currentSubScale) }
                   }
-                } else {
+                } else if (pinchToZoomGesture) {
                   // Activate on significant pinch movement
                   if (!gestureStarted && abs(dist - prevDist) > 5f) {
                     gestureStarted = true
@@ -1028,7 +1030,7 @@ fun GestureHandler(
         swipeSubtitlesToSeekDialog,
         isSwipeSubtitlesInverted,
       ) {
-        if (!horizontalSwipeToSeek || areControlsLocked || isVerticalGestureActive) return@pointerInput
+        if ((!horizontalSwipeToSeek && !swipeSubtitlesToSeekDialog) || areControlsLocked || isVerticalGestureActive) return@pointerInput
 
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false)
@@ -1086,6 +1088,7 @@ fun GestureHandler(
                   // Only activate if this is clearly a horizontal gesture
                   // and not conflicting with other gestures
                   if (gestureType == null && 
+                      horizontalSwipeToSeek &&
                       !isSubtitleTouch &&
                       abs(deltaX) > 30f && 
                       abs(deltaX) > abs(deltaY) * 2f && // Must be strongly horizontal


### PR DESCRIPTION
Make pinch-to-zoom and swipe-to-seek operate independently from subtitle gestures. #234 