### PR TITLE
feat(audio-player): redesign music player UI inspired by AFinity

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/AudioMiniPlayer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/AudioMiniPlayer.kt
@@ -1,0 +1,187 @@
+package app.gyrolet.mpvrx.ui.browser.components
+
+import android.content.Intent
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.ui.icons.Icon
+import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.player.MediaPlaybackService
+import app.gyrolet.mpvrx.ui.player.PlayerActivity
+import `is`.xyz.mpv.MPVLib
+
+@Composable
+fun AudioMiniPlayer(
+  modifier: Modifier = Modifier,
+) {
+  val isServiceRunning = MediaPlaybackService.isRunning()
+  if (!isServiceRunning) return
+
+  val context = LocalContext.current
+  val paused by MPVLib.propBoolean["pause"].collectAsState()
+  val rawMediaTitle by MPVLib.propString["media-title"].collectAsState()
+  val duration by MPVLib.propInt["duration"].collectAsState()
+  val position by MPVLib.propInt["time-pos"].collectAsState()
+
+  val isPlaying = paused == false
+  val title = rawMediaTitle?.takeIf { it.isNotBlank() } ?: "Audio Track"
+
+  val dur = duration?.toFloat() ?: 0f
+  val pos = position?.toFloat() ?: 0f
+  val progressFraction = if (dur > 0f) (pos / dur).coerceIn(0f, 1f) else 0f
+
+  Surface(
+    modifier = modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(24.dp))
+      .clickable {
+        val intent = Intent(context, PlayerActivity::class.java).apply {
+          flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        context.startActivity(intent)
+      },
+    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.95f),
+    tonalElevation = 6.dp,
+    shadowElevation = 8.dp,
+    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+  ) {
+    val primaryContainerColor = MaterialTheme.colorScheme.primaryContainer
+
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .drawBehind {
+          if (progressFraction > 0f) {
+            drawRect(
+              color = primaryContainerColor.copy(alpha = 0.35f),
+              size = Size(
+                width = size.width * progressFraction,
+                height = size.height,
+              )
+            )
+          }
+        }
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      // Music Icon Badge
+      Box(
+        modifier = Modifier
+          .size(42.dp)
+          .clip(CircleShape)
+          .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.Audiotrack,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.primary,
+          modifier = Modifier.size(24.dp)
+        )
+      }
+
+      Spacer(modifier = Modifier.width(12.dp))
+
+      // Title & Track Status
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.Center
+      ) {
+        Text(
+          text = title,
+          style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+          color = MaterialTheme.colorScheme.onSurface,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.basicMarquee()
+        )
+        Text(
+          text = if (isPlaying) "Playing" else "Paused",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1
+        )
+      }
+
+      Spacer(modifier = Modifier.width(8.dp))
+
+      // Play / Pause Action Button
+      IconButton(
+        onClick = { MPVLib.command("cycle", "pause") },
+        modifier = Modifier.size(36.dp)
+      ) {
+        AnimatedContent(
+          targetState = isPlaying,
+          transitionSpec = { fadeIn() togetherWith fadeOut() },
+          label = "mini_play_pause"
+        ) { playing ->
+          Icon(
+            imageVector = if (playing) Icons.RoundedFilled.Pause else Icons.RoundedFilled.PlayArrow,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(26.dp)
+          )
+        }
+      }
+
+      // Next Track Action Button
+      IconButton(
+        onClick = { MPVLib.command("playlist-next") },
+        modifier = Modifier.size(36.dp)
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.SkipNext,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.onSurface,
+          modifier = Modifier.size(24.dp)
+        )
+      }
+
+      // Close Action Button
+      IconButton(
+        onClick = { MPVLib.command("stop") },
+        modifier = Modifier.size(32.dp)
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.Close,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.onSurfaceVariant,
+          modifier = Modifier.size(18.dp)
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/icons/Icons.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/icons/Icons.kt
@@ -70,6 +70,7 @@ object Icons {
     val DriveFolderUpload by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Drive_folder_upload) }
     val Edit by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Edit) }
     val EditOff by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Edit_off) }
+    val Equalizer by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Equalizer) }
     val ExpandLess by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Expand_less) }
     val ExpandMore by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Expand_more) }
     val FastForward by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Fast_forward) }
@@ -256,6 +257,7 @@ object Icons {
     val DriveFolderUpload get() = Shared.DriveFolderUpload
     val Edit get() = Shared.Edit
     val EditOff get() = Shared.EditOff
+    val Equalizer get() = Shared.Equalizer
     val ExpandLess get() = Shared.ExpandLess
     val ExpandMore get() = Shared.ExpandMore
     val FastForward get() = Shared.FastForward

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -13,6 +13,7 @@ import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.Outline
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
@@ -29,6 +30,8 @@ import android.provider.Settings
 import android.util.Log
 import android.view.KeyEvent
 import android.view.View
+import android.view.ViewGroup
+import android.view.ViewOutlineProvider
 import android.view.WindowManager
 import android.view.animation.PathInterpolator
 import android.widget.Toast
@@ -552,6 +555,7 @@ class PlayerActivity :
     setupBackPressHandler()
     setupPlayerControls()
     setupVideoTransformObserver()
+    setupAudioPlayerViewObserver()
     setupMediaSession()
     // Note: screenStateReceiver is now registered in onStart() and
     // unregistered in onStop(), matching the noisyReceiver pattern.
@@ -861,28 +865,7 @@ class PlayerActivity :
   private fun setupPlayerControls() {
     binding.controls.setContent {
       MpvrxTheme {
-        val isAudioOnly by viewModel.isAudioOnly.collectAsState()
-        val audioBlobEnabled by audioPreferences.audioBlobEnabled.collectAsState()
-        val audioVisualizerStyle by audioPreferences.audioVisualizerStyle.collectAsState()
-        val paused by MPVLib.propBoolean["pause"].collectAsState()
-        val appTheme by appearancePreferences.appTheme.collectAsState()
-        val darkMode by appearancePreferences.darkMode.collectAsState()
-        val amoledMode by appearancePreferences.amoledMode.collectAsState()
-        val useDarkTheme = when (darkMode) {
-          DarkMode.Dark -> true
-          DarkMode.Light -> false
-          DarkMode.System -> isSystemInDarkTheme()
-        }
-        val palette = appTheme.toVisualizerPalette(useDarkTheme, amoledMode)
         Box(modifier = Modifier.fillMaxSize()) {
-          // This setting is explicit: when enabled, visualize every audio-only track,
-          // including files that also have embedded artwork.
-          if (isAudioOnly && audioBlobEnabled) {
-            when (audioVisualizerStyle) {
-              AudioVisualizerStyle.Galaxy -> GalaxyOverlay(isPlaying = paused == false, palette = palette)
-              AudioVisualizerStyle.Blob -> BlobOverlay(isPlaying = paused == false, palette = palette)
-            }
-          }
           PlayerControls(
             viewModel = viewModel,
             onBackPress = ::handleBackPress,
@@ -908,6 +891,46 @@ class PlayerActivity :
           binding.player.scaleY = scale
           binding.player.translationX = panX
           binding.player.translationY = panY
+        }
+      }
+    }
+  }
+
+  private fun setupAudioPlayerViewObserver() {
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewModel.isAudioOnly.collect { isAudioOnly ->
+          if (isAudioOnly) {
+            viewModel.showControls()
+            binding.player.visibility = View.INVISIBLE
+            try {
+              WindowCompat.setDecorFitsSystemWindows(window, true)
+              window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+              binding.root.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+              window.statusBarColor = android.graphics.Color.TRANSPARENT
+              window.navigationBarColor = android.graphics.Color.TRANSPARENT
+              windowInsetsController.apply {
+                systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+                show(WindowInsetsCompat.Type.statusBars())
+                show(WindowInsetsCompat.Type.navigationBars())
+                isAppearanceLightStatusBars = false
+                isAppearanceLightNavigationBars = false
+              }
+            } catch (e: Exception) {
+              Log.e(TAG, "Failed to show system bars for audio playback", e)
+            }
+          } else {
+            val lp = binding.player.layoutParams as ViewGroup.MarginLayoutParams
+            if (lp.width != ViewGroup.LayoutParams.MATCH_PARENT || lp.height != ViewGroup.LayoutParams.MATCH_PARENT || lp.leftMargin != 0 || lp.topMargin != 0) {
+              lp.width = ViewGroup.LayoutParams.MATCH_PARENT
+              lp.height = ViewGroup.LayoutParams.MATCH_PARENT
+              lp.leftMargin = 0
+              lp.topMargin = 0
+              binding.player.layoutParams = lp
+            }
+            binding.player.clipToOutline = false
+            binding.player.visibility = View.VISIBLE
+          }
         }
       }
     }
@@ -1431,6 +1454,20 @@ class PlayerActivity :
   }
 
   private fun handleSystemBarsVisibility(insets: WindowInsetsCompat) {
+    if (viewModel.isAudioOnly.value) {
+      cancelSystemBarsAutoHide()
+      try {
+        windowInsetsController.apply {
+          systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+          show(WindowInsetsCompat.Type.statusBars())
+          show(WindowInsetsCompat.Type.navigationBars())
+          isAppearanceLightStatusBars = false
+          isAppearanceLightNavigationBars = false
+        }
+      } catch (_: Exception) {}
+      return
+    }
+
     val systemBarsVisible =
       insets.isVisible(WindowInsetsCompat.Type.statusBars()) ||
         insets.isVisible(WindowInsetsCompat.Type.navigationBars())
@@ -1444,6 +1481,7 @@ class PlayerActivity :
 
   private fun shouldAutoHideSystemBars(): Boolean =
     !isInPictureInPictureMode &&
+      !viewModel.isAudioOnly.value &&
       !viewModel.controlsShown.value &&
       viewModel.sheetShown.value == Sheets.None &&
       viewModel.panelShown.value == Panels.None
@@ -1472,6 +1510,25 @@ class PlayerActivity :
   @Suppress("DEPRECATION")
   private fun hideSystemBarsForPlayback() {
     cancelSystemBarsAutoHide()
+    if (viewModel.isAudioOnly.value) {
+      try {
+        WindowCompat.setDecorFitsSystemWindows(window, true)
+        window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        binding.root.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+        window.statusBarColor = android.graphics.Color.TRANSPARENT
+        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        windowInsetsController.apply {
+          systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+          show(WindowInsetsCompat.Type.statusBars())
+          show(WindowInsetsCompat.Type.navigationBars())
+          isAppearanceLightStatusBars = false
+          isAppearanceLightNavigationBars = false
+        }
+      } catch (e: Exception) {
+        Log.e(TAG, "Failed to show system bars for audio playback", e)
+      }
+      return
+    }
     try {
       windowInsetsController.apply {
         hide(WindowInsetsCompat.Type.statusBars())

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -4270,12 +4270,20 @@ class PlayerActivity :
       }
 
       KeyEvent.KEYCODE_VOLUME_UP -> {
+        if (viewModel.isAudioOnly.value) {
+          viewModel.changeVolumeBy(1, showUi = true)
+          return true
+        }
         viewModel.changeVolumeBy(1)
         viewModel.displayVolumeSlider()
         return true
       }
 
       KeyEvent.KEYCODE_VOLUME_DOWN -> {
+        if (viewModel.isAudioOnly.value) {
+          viewModel.changeVolumeBy(-1, showUi = true)
+          return true
+        }
         viewModel.changeVolumeBy(-1)
         viewModel.displayVolumeSlider()
         return true

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -904,7 +904,7 @@ class PlayerActivity :
             viewModel.showControls()
             binding.player.visibility = View.INVISIBLE
             try {
-              WindowCompat.setDecorFitsSystemWindows(window, true)
+              WindowCompat.setDecorFitsSystemWindows(window, false)
               window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
               binding.root.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
               window.statusBarColor = android.graphics.Color.TRANSPARENT
@@ -4144,7 +4144,16 @@ class PlayerActivity :
    */
   private fun setOrientation() {
     if (isKnownAudioLaunch(intent) || viewModel.isAudioOnly.value) {
-      requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+      val audioOrient = when (playerPreferences.orientation.get()) {
+        PlayerOrientation.Video, PlayerOrientation.Free -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+        PlayerOrientation.Portrait -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        PlayerOrientation.ReversePortrait -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+        PlayerOrientation.SensorPortrait -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+        PlayerOrientation.Landscape -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        PlayerOrientation.ReverseLandscape -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+        PlayerOrientation.SensorLandscape -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+      }
+      requestedOrientation = audioOrient
       return
     }
     val orientationPref = playerPreferences.orientation.get()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
@@ -104,6 +104,7 @@ enum class Sheets {
   AmbientConfig,
   FrameNavigation,
   Equalizer,
+  AudioProperties,
 }
 
 enum class Panels {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
@@ -103,6 +103,7 @@ enum class Sheets {
   Playlist,
   AmbientConfig,
   FrameNavigation,
+  Equalizer,
 }
 
 enum class Panels {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -45,6 +45,10 @@ import app.gyrolet.mpvrx.utils.media.MediaInfoParser
 import app.gyrolet.mpvrx.utils.media.ParsedMediaInfo
 import app.gyrolet.mpvrx.utils.media.SubtitleHashUtils
 import app.gyrolet.mpvrx.utils.media.resolveSubtitleLookupDirectories
+import app.gyrolet.mpvrx.ui.player.controls.components.sheets.EQ_MAX_DB
+import app.gyrolet.mpvrx.ui.player.controls.components.sheets.EQ_MIN_DB
+import app.gyrolet.mpvrx.ui.player.controls.components.sheets.EqualizerPreset
+import app.gyrolet.mpvrx.ui.player.controls.components.sheets.EqualizerState
 import app.gyrolet.mpvrx.utils.storage.FileTypeUtils
 import `is`.xyz.mpv.MPVLib
 import kotlinx.collections.immutable.persistentListOf
@@ -523,6 +527,54 @@ class PlayerViewModel(
   // Audio player UI state
   val albumArtBounds = MutableStateFlow<android.graphics.Rect?>(null)
   val showVisualizerInAudioPlayer = MutableStateFlow(false)
+  val equalizerState = MutableStateFlow(EqualizerState())
+
+  fun setEqualizerEnabled(enabled: Boolean) {
+    equalizerState.value = equalizerState.value.copy(isEnabled = enabled)
+    applyEqualizerMpvFilters()
+  }
+
+  fun applyEqualizerPreset(preset: EqualizerPreset) {
+    if (preset == EqualizerPreset.CUSTOM) return
+    equalizerState.value = equalizerState.value.copy(
+      currentPreset = preset,
+      bandGains = preset.gains
+    )
+    applyEqualizerMpvFilters()
+  }
+
+  fun setEqualizerBandGain(index: Int, gainDb: Int) {
+    val currentGains = equalizerState.value.bandGains.toMutableList()
+    if (index in currentGains.indices) {
+      currentGains[index] = gainDb.coerceIn(EQ_MIN_DB, EQ_MAX_DB)
+      equalizerState.value = equalizerState.value.copy(
+        currentPreset = EqualizerPreset.CUSTOM,
+        bandGains = currentGains
+      )
+      applyEqualizerMpvFilters()
+    }
+  }
+
+  fun setEqualizerVolumeBoost(db: Int) {
+    equalizerState.value = equalizerState.value.copy(volumeBoostDb = db.coerceIn(0, 10))
+    applyEqualizerMpvFilters()
+  }
+
+  private fun applyEqualizerMpvFilters() {
+    val state = equalizerState.value
+    if (!state.isEnabled) {
+      MPVLib.command("af", "set", "")
+      return
+    }
+    val (g1, g2, g3, g4, g5) = state.bandGains
+    val filterList = mutableListOf<String>()
+    filterList.add("equalizer=g1=$g1:g2=$g2:g3=$g3:g4=$g4:g5=$g5")
+    if (state.volumeBoostDb > 0) {
+      filterList.add("volume=volume=${state.volumeBoostDb}dB")
+    }
+    val afString = filterList.joinToString(",")
+    MPVLib.command("af", "set", afString)
+  }
 
   fun updateAlbumArtBounds(rect: android.graphics.Rect?) {
     albumArtBounds.value = rect

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -530,10 +530,11 @@ class PlayerViewModel(
   val showVisualizerInAudioPlayer = MutableStateFlow(false)
   val equalizerState = MutableStateFlow(EqualizerState())
   private val audioEqualizerManager = AudioEqualizerManager()
+  private var equalizerMpvDebounceJob: Job? = null
 
   fun setEqualizerEnabled(enabled: Boolean) {
     equalizerState.value = equalizerState.value.copy(isEnabled = enabled)
-    applyEqualizerMpvFilters()
+    applyEqualizerMpvFilters(immediate = true)
   }
 
   fun applyEqualizerPreset(preset: EqualizerPreset) {
@@ -542,27 +543,29 @@ class PlayerViewModel(
       currentPreset = preset,
       bandGains = preset.gains
     )
-    applyEqualizerMpvFilters()
+    applyEqualizerMpvFilters(immediate = true)
   }
 
   fun setEqualizerBandGain(index: Int, gainDb: Int) {
     val currentGains = equalizerState.value.bandGains.toMutableList()
-    if (index in currentGains.indices) {
+    if (index in currentGains.indices && currentGains[index] != gainDb) {
       currentGains[index] = gainDb.coerceIn(EQ_MIN_DB, EQ_MAX_DB)
       equalizerState.value = equalizerState.value.copy(
         currentPreset = EqualizerPreset.CUSTOM,
         bandGains = currentGains
       )
-      applyEqualizerMpvFilters()
+      applyEqualizerMpvFilters(immediate = false)
     }
   }
 
   fun setEqualizerVolumeBoost(db: Int) {
-    equalizerState.value = equalizerState.value.copy(volumeBoostDb = db.coerceIn(0, 10))
-    applyEqualizerMpvFilters()
+    if (equalizerState.value.volumeBoostDb != db) {
+      equalizerState.value = equalizerState.value.copy(volumeBoostDb = db.coerceIn(0, 10))
+      applyEqualizerMpvFilters(immediate = false)
+    }
   }
 
-  fun applyEqualizerMpvFilters() {
+  fun applyEqualizerMpvFilters(immediate: Boolean = false) {
     val state = equalizerState.value
 
     // 1. Hardware Android AudioFx (Equalizer & LoudnessEnhancer matching AFinity)
@@ -573,6 +576,20 @@ class PlayerViewModel(
     )
 
     // 2. MPV Audio Filter Fallback
+    // Changing MPV "af" filter property during playback causes MPV to recreate audio filter graph.
+    // Debouncing while dragging prevents audio stutter/breaking.
+    equalizerMpvDebounceJob?.cancel()
+    if (immediate) {
+      updateMpvAfProperty(state)
+    } else {
+      equalizerMpvDebounceJob = viewModelScope.launch(Dispatchers.Default) {
+        delay(150)
+        updateMpvAfProperty(state)
+      }
+    }
+  }
+
+  private fun updateMpvAfProperty(state: EqualizerState) {
     if (!state.isEnabled) {
       MPVLib.setPropertyString("af", "")
       return

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -42,6 +42,7 @@ import app.gyrolet.mpvrx.repository.ai.SubtitleGenerationService
 import app.gyrolet.mpvrx.repository.wyzie.WyzieSearchRepository
 import app.gyrolet.mpvrx.utils.media.ChecksumUtils
 import app.gyrolet.mpvrx.utils.media.MediaInfoParser
+import app.gyrolet.mpvrx.utils.media.AudioEqualizerManager
 import app.gyrolet.mpvrx.utils.media.ParsedMediaInfo
 import app.gyrolet.mpvrx.utils.media.SubtitleHashUtils
 import app.gyrolet.mpvrx.utils.media.resolveSubtitleLookupDirectories
@@ -528,6 +529,7 @@ class PlayerViewModel(
   val albumArtBounds = MutableStateFlow<android.graphics.Rect?>(null)
   val showVisualizerInAudioPlayer = MutableStateFlow(false)
   val equalizerState = MutableStateFlow(EqualizerState())
+  private val audioEqualizerManager = AudioEqualizerManager()
 
   fun setEqualizerEnabled(enabled: Boolean) {
     equalizerState.value = equalizerState.value.copy(isEnabled = enabled)
@@ -560,20 +562,41 @@ class PlayerViewModel(
     applyEqualizerMpvFilters()
   }
 
-  private fun applyEqualizerMpvFilters() {
+  fun applyEqualizerMpvFilters() {
     val state = equalizerState.value
+
+    // 1. Hardware Android AudioFx (Equalizer & LoudnessEnhancer matching AFinity)
+    audioEqualizerManager.updateState(
+      enabled = state.isEnabled,
+      bandGains = state.bandGains,
+      volumeBoostDb = state.volumeBoostDb
+    )
+
+    // 2. MPV Audio Filter Fallback
     if (!state.isEnabled) {
-      MPVLib.command("af", "set", "")
+      MPVLib.setPropertyString("af", "")
       return
     }
-    val (g1, g2, g3, g4, g5) = state.bandGains
+    val freqs = listOf(60, 230, 910, 3600, 14000)
     val filterList = mutableListOf<String>()
-    filterList.add("equalizer=g1=$g1:g2=$g2:g3=$g3:g4=$g4:g5=$g5")
+
+    // Apply pre-amp attenuation for positive gains to prevent clipping distortion
+    val maxGain = state.bandGains.maxOrNull() ?: 0
+    if (maxGain > 0) {
+      filterList.add("volume=volume=${-maxGain}dB")
+    }
+
+    for (i in 0 until 5) {
+      val gain = state.bandGains.getOrElse(i) { 0 }
+      if (gain != 0) {
+        filterList.add("equalizer=f=${freqs[i]}:width_type=o:width=1.5:g=$gain")
+      }
+    }
     if (state.volumeBoostDb > 0) {
       filterList.add("volume=volume=${state.volumeBoostDb}dB")
     }
     val afString = filterList.joinToString(",")
-    MPVLib.command("af", "set", afString)
+    MPVLib.setPropertyString("af", afString)
   }
 
   fun updateAlbumArtBounds(rect: android.graphics.Rect?) {
@@ -582,6 +605,64 @@ class PlayerViewModel(
 
   fun toggleAudioVisualizer() {
     showVisualizerInAudioPlayer.value = !showVisualizerInAudioPlayer.value
+  }
+
+  fun getAudioPropertiesData(): List<app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem> {
+    val title = currentMediaTitle.takeIf { it.isNotBlank() }
+      ?: MPVLib.getPropertyString("metadata/by-key/Title")
+      ?: MPVLib.getPropertyString("media-title")
+      ?: "Unknown Title"
+
+    val artist = MPVLib.getPropertyString("metadata/by-key/Artist")
+      ?: MPVLib.getPropertyString("metadata/by-key/ARTIST")
+      ?: MPVLib.getPropertyString("metadata/by-key/album_artist")
+      ?: "Unknown Artist"
+
+    val album = MPVLib.getPropertyString("metadata/by-key/Album")
+      ?: MPVLib.getPropertyString("metadata/by-key/ALBUM")
+      ?: "Unknown Album"
+
+    val codec = MPVLib.getPropertyString("audio-codec-name")?.uppercase() ?: "Unknown"
+    val samplerateInt = MPVLib.getPropertyInt("audio-params/samplerate") ?: 0
+    val sampleRateStr = if (samplerateInt > 0) String.format(java.util.Locale.US, "%.1f kHz", samplerateInt / 1000f) else "Unknown"
+
+    val channelsInt = MPVLib.getPropertyInt("audio-params/channel-count") ?: 0
+    val channelsStr = when (channelsInt) {
+      1 -> "Mono (1.0)"
+      2 -> "Stereo (2.0)"
+      6 -> "5.1 Surround"
+      8 -> "7.1 Surround"
+      else -> if (channelsInt > 0) "$channelsInt Channels" else "Unknown"
+    }
+
+    val bitrateInt = MPVLib.getPropertyInt("audio-bitrate") ?: 0
+    val bitrateStr = if (bitrateInt > 0) "${bitrateInt / 1000} kbps" else "Variable / Unknown"
+
+    val path = MPVLib.getPropertyString("path") ?: MPVLib.getPropertyString("stream-open-filename") ?: ""
+    val fileSizeStr = if (path.isNotBlank() && !path.startsWith("content://") && !path.startsWith("http")) {
+      runCatching {
+        val bytes = java.io.File(path.removePrefix("file://")).length()
+        if (bytes > 0) String.format(java.util.Locale.US, "%.2f MB", bytes / (1024f * 1024f)) else ""
+      }.getOrDefault("")
+    } else ""
+
+    val formatExt = path.substringBefore('?').substringBefore('#').substringAfterLast('.', "").uppercase()
+
+    return buildList {
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Title", title))
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Artist", artist))
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Album", album))
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Format / Codec", if (formatExt.isNotBlank()) "$formatExt ($codec)" else codec))
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Sample Rate", sampleRateStr))
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Bitrate", bitrateStr))
+      add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("Channels", channelsStr))
+      if (fileSizeStr.isNotBlank()) {
+        add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("File Size", fileSizeStr))
+      }
+      if (path.isNotBlank()) {
+        add(app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem("File Location", path))
+      }
+    }
   }
 
   // Audio state
@@ -1172,6 +1253,7 @@ class PlayerViewModel(
       }
     }
     syncplayManager.updateFileInfo(currentSyncplayFileInfo())
+    applyEqualizerMpvFilters()
   }
 
   private fun currentSyncplayPlaybackState(): SyncplayPlaybackState =
@@ -3444,7 +3526,7 @@ class PlayerViewModel(
     brightnessSliderTimestamp.value = System.currentTimeMillis()
   }
 
-  fun changeVolumeBy(change: Int) {
+  fun changeVolumeBy(change: Int, showUi: Boolean = false) {
     val currentSystemVolume = syncCurrentSystemVolume()
     val mpvVolume = MPVLib.getPropertyInt("volume") ?: 100
     val absoluteMaxVolume = volumeBoostCap ?: (audioPreferences.volumeBoostCap.get() + 100)
@@ -3455,7 +3537,7 @@ class PlayerViewModel(
 
     if (absoluteMaxVolume > 100 && currentSystemVolume == maxVolume) {
       if (mpvVolume == 100 && change < 0) {
-        changeVolumeTo(currentSystemVolume + change)
+        changeVolumeTo(currentSystemVolume + change, showUi)
       }
       val finalMPVVolume = (mpvVolume + change).coerceAtLeast(100)
       if (finalMPVVolume in 100..absoluteMaxVolume) {
@@ -3463,13 +3545,14 @@ class PlayerViewModel(
       }
     }
 
-    changeVolumeTo(currentSystemVolume + change)
+    changeVolumeTo(currentSystemVolume + change, showUi)
   }
 
   fun changeVolumePercentTo(volumePercent: Int) {
     val newPercent = volumePercent.coerceIn(0, 100)
     val newVolume = percentToSystemVolume(newPercent)
-    host.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, newVolume, 0)
+    val flags = if (isAudioOnly.value) AudioManager.FLAG_SHOW_UI else 0
+    host.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, newVolume, flags)
     currentVolume.value = syncCurrentSystemVolume()
     currentVolumePercent.value = newPercent
 
@@ -3481,9 +3564,10 @@ class PlayerViewModel(
     }
   }
 
-  fun changeVolumeTo(volume: Int) {
+  fun changeVolumeTo(volume: Int, showUi: Boolean = false) {
     val newVolume = volume.coerceIn(0..maxVolume)
-    host.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, newVolume, 0)
+    val flags = if (showUi || isAudioOnly.value) AudioManager.FLAG_SHOW_UI else 0
+    host.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, newVolume, flags)
     currentVolume.value = syncCurrentSystemVolume()
 
     if (currentVolume.value < maxVolume) {
@@ -5034,6 +5118,7 @@ class PlayerViewModel(
     runCatching { metadataCache.evictAll() }
 
     runCatching { syncplayManager.clearPlayerBindings() }
+    runCatching { audioEqualizerManager.release() }
 
     super.onCleared()
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -527,7 +527,7 @@ class PlayerViewModel(
 
   // Audio player UI state
   val albumArtBounds = MutableStateFlow<android.graphics.Rect?>(null)
-  val showVisualizerInAudioPlayer = MutableStateFlow(false)
+  val showVisualizerInAudioPlayer = MutableStateFlow(audioPreferences.audioBlobEnabled.get())
   val equalizerState = MutableStateFlow(EqualizerState())
   private val audioEqualizerManager = AudioEqualizerManager()
   private var equalizerMpvDebounceJob: Job? = null
@@ -621,7 +621,9 @@ class PlayerViewModel(
   }
 
   fun toggleAudioVisualizer() {
-    showVisualizerInAudioPlayer.value = !showVisualizerInAudioPlayer.value
+    val newValue = !showVisualizerInAudioPlayer.value
+    showVisualizerInAudioPlayer.value = newValue
+    audioPreferences.audioBlobEnabled.set(newValue)
   }
 
   fun getAudioPropertiesData(): List<app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertyItem> {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -486,11 +486,25 @@ class PlayerViewModel(
       }.stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
 
   val isAudioOnly: StateFlow<Boolean> =
-    MPVLib.propNode["track-list"]
-      .map { node ->
-        val tracks = node?.toObject<List<TrackNode>>(json).orEmpty()
-        tracks.any { it.isAudio } && tracks.none { it.isVideo && !it.isAlbumArtwork }
-      }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+    combine(
+      MPVLib.propNode["track-list"],
+      MPVLib.propString["path"],
+      MPVLib.propString["stream-open-filename"],
+    ) { node, path, streamPath ->
+      val currentPath = path?.takeIf { it.isNotBlank() } ?: streamPath
+      val isFileAudioExt = currentPath?.let { p ->
+        val ext = p.substringBefore('?').substringBefore('#').substringAfterLast('.', "").lowercase()
+        ext in FileTypeUtils.AUDIO_EXTENSIONS
+      } ?: false
+
+      val tracks = node?.toObject<List<TrackNode>>(json).orEmpty()
+      if (tracks.isEmpty()) {
+        isFileAudioExt
+      } else {
+        (tracks.any { it.isAudio } && tracks.none { it.isVideo && !it.isAlbumArtwork }) ||
+          (isFileAudioExt && tracks.none { it.isVideo && !it.isAlbumArtwork })
+      }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, host.isCurrentMediaKnownAudio())
 
   val hasAlbumArt: StateFlow<Boolean> =
     MPVLib.propNode["track-list"]
@@ -505,6 +519,18 @@ class PlayerViewModel(
         node?.toObject<List<ChapterNode>>(json)?.map { it.toSegment() }?.toImmutableList()
           ?: persistentListOf()
       }.stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
+
+  // Audio player UI state
+  val albumArtBounds = MutableStateFlow<android.graphics.Rect?>(null)
+  val showVisualizerInAudioPlayer = MutableStateFlow(false)
+
+  fun updateAlbumArtBounds(rect: android.graphics.Rect?) {
+    albumArtBounds.value = rect
+  }
+
+  fun toggleAudioVisualizer() {
+    showVisualizerInAudioPlayer.value = !showVisualizerInAudioPlayer.value
+  }
 
   // Audio state
   val maxVolume = host.audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
@@ -3885,7 +3911,10 @@ class PlayerViewModel(
           .substringBefore('?')
           .substringBefore('#')
           .substringAfterLast('.', "")
-          .lowercase() in FileTypeUtils.AUDIO_EXTENSIONS
+          .lowercase() in FileTypeUtils.AUDIO_EXTENSIONS ||
+          resolvedUri.toString().lowercase().contains("audio") ||
+          uri.toString().lowercase().contains("audio") ||
+          isAudioOnly.value
       val isCurrentlyPlaying = index == activity.playlistIndex
 
       // Try to get from cache first (synchronized access)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -217,7 +217,7 @@ fun AudioPlayerControls(
       modifier = Modifier.fillMaxSize(),
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-      // 1. Top Header Bar (Close on left, NOW PLAYING center, Playlist on top-right)
+      // 1. Top Header Bar (Close on left, NOW PLAYING center, Info on top-right)
       Box(
         modifier = Modifier
           .fillMaxWidth()
@@ -248,16 +248,35 @@ fun AudioPlayerControls(
           verticalAlignment = Alignment.CenterVertically
         ) {
           IconButton(
-            onClick = { onOpenSheet(Sheets.Playlist) },
-            enabled = playlistModeEnabled
+            onClick = { onOpenSheet(Sheets.AudioProperties) }
           ) {
             Icon(
-              imageVector = Icons.RoundedFilled.QueueMusic,
-              contentDescription = stringResource(R.string.ui_playlist),
-              tint = if (playlistModeEnabled) Color.White else Color.White.copy(alpha = 0.4f),
+              imageVector = Icons.RoundedFilled.Info,
+              contentDescription = stringResource(R.string.player_sheets_more_title),
+              tint = Color.White,
               modifier = Modifier.size(28.dp)
             )
           }
+        }
+      }
+
+      if (isLosslessCodecOrExt) {
+        Spacer(modifier = Modifier.height(4.dp))
+        Surface(
+          shape = RoundedCornerShape(4.dp),
+          color = Color.White.copy(alpha = 0.15f),
+          border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.3f)),
+        ) {
+          Text(
+            text = if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS",
+            style = MaterialTheme.typography.labelSmall.copy(
+              fontWeight = FontWeight.Bold,
+              fontSize = 8.5.sp,
+              letterSpacing = 0.8.sp
+            ),
+            color = Color.White.copy(alpha = 0.9f),
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+          )
         }
       }
 
@@ -357,46 +376,20 @@ fun AudioPlayerControls(
       Spacer(modifier = Modifier.height(16.dp))
 
       // Track Title & Metadata
+      // Track Title & Metadata
       Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.Start
       ) {
-        Row(
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.spacedBy(8.dp),
-          modifier = Modifier.fillMaxWidth()
-        ) {
-          val titleText = lastValidTitle
-          Text(
-            text = titleText,
-            style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
-            color = Color.White,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-              .weight(1f, fill = false)
-              .basicMarquee(iterations = Int.MAX_VALUE)
-          )
-
-          if (isLosslessCodecOrExt) {
-            Surface(
-              shape = RoundedCornerShape(4.dp),
-              color = Color.White.copy(alpha = 0.15f),
-              border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.3f)),
-            ) {
-              Text(
-                text = if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS",
-                style = MaterialTheme.typography.labelSmall.copy(
-                  fontWeight = FontWeight.Bold,
-                  fontSize = 9.sp,
-                  letterSpacing = 0.8.sp
-                ),
-                color = Color.White.copy(alpha = 0.9f),
-                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-              )
-            }
-          }
-        }
+        val titleText = lastValidTitle
+        Text(
+          text = titleText,
+          style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
+          color = Color.White,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE)
+        )
         Spacer(modifier = Modifier.height(4.dp))
         val playlistInfo = viewModel.getPlaylistInfo()
         Text(
@@ -408,7 +401,7 @@ fun AudioPlayerControls(
         )
       }
 
-      Spacer(modifier = Modifier.height(20.dp))
+      Spacer(modifier = Modifier.height(16.dp))
 
       // 3. Audio Transport Controls (Seekbar + Progress Timers)
       var sliderValue by remember(currentPosSec) { mutableFloatStateOf(currentPosSec) }
@@ -467,8 +460,9 @@ fun AudioPlayerControls(
         Row(
           modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 4.dp),
+            .padding(top = 0.dp),
           horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically,
         ) {
           Text(
             text = formatSec(currentPosSec.toLong()),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -1,0 +1,568 @@
+package app.gyrolet.mpvrx.ui.player.controls
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.gyrolet.mpvrx.R
+import app.gyrolet.mpvrx.preferences.AppearancePreferences
+import app.gyrolet.mpvrx.preferences.AudioPreferences
+import app.gyrolet.mpvrx.preferences.AudioVisualizerStyle
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
+import app.gyrolet.mpvrx.ui.icons.Icon
+import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.player.Panels
+import app.gyrolet.mpvrx.ui.player.PlayerViewModel
+import app.gyrolet.mpvrx.ui.player.RepeatMode
+import app.gyrolet.mpvrx.ui.player.Sheets
+import app.gyrolet.mpvrx.ui.player.visualizer.BlobOverlay
+import app.gyrolet.mpvrx.ui.player.visualizer.GalaxyOverlay
+import app.gyrolet.mpvrx.ui.theme.DarkMode
+import `is`.xyz.mpv.MPVLib
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.compose.koinInject
+import java.util.Locale
+
+@Composable
+private fun rememberAudioAlbumArt(pathOrUri: String?): Bitmap? {
+  val context = LocalContext.current
+  var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+  LaunchedEffect(pathOrUri) {
+    if (pathOrUri.isNullOrBlank()) {
+      bitmap = null
+      return@LaunchedEffect
+    }
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val cleanPath = when {
+          pathOrUri.startsWith("file://") -> pathOrUri.removePrefix("file://")
+          pathOrUri.startsWith("content://") -> null
+          else -> pathOrUri
+        }
+        val retriever = MediaMetadataRetriever()
+        if (cleanPath != null) {
+          retriever.setDataSource(cleanPath)
+        } else {
+          retriever.setDataSource(context, Uri.parse(pathOrUri))
+        }
+        val art = retriever.embeddedPicture
+        retriever.release()
+        if (art != null) {
+          BitmapFactory.decodeByteArray(art, 0, art.size)
+        } else null
+      }.onSuccess { loadedBitmap ->
+        bitmap = loadedBitmap
+      }.onFailure {
+        bitmap = null
+      }
+    }
+  }
+  return bitmap
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AudioPlayerControls(
+  viewModel: PlayerViewModel,
+  mediaTitle: String?,
+  onBackPress: () -> Unit,
+  onOpenSheet: (Sheets) -> Unit,
+  onOpenPanel: (Panels) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val paused by MPVLib.propBoolean["pause"].collectAsState()
+  val duration by MPVLib.propInt["duration"].collectAsState()
+  val position by MPVLib.propInt["time-pos"].collectAsState()
+  val precisePosition by viewModel.precisePosition.collectAsState()
+  val preciseDuration by viewModel.preciseDuration.collectAsState()
+
+  val currentPath by MPVLib.propString["path"].collectAsState()
+  val currentStreamFilename by MPVLib.propString["stream-open-filename"].collectAsState()
+  val mediaPath = currentPath?.takeIf { it.isNotBlank() } ?: currentStreamFilename
+
+  val albumArtBitmap = rememberAudioAlbumArt(mediaPath)
+
+  var lastValidTitle by remember { mutableStateOf(mediaTitle?.takeIf { it.isNotBlank() } ?: "Audio Track") }
+  LaunchedEffect(mediaTitle) {
+    if (!mediaTitle.isNullOrBlank()) {
+      lastValidTitle = mediaTitle
+    }
+  }
+
+  val audioPreferences = koinInject<AudioPreferences>()
+  val appearancePreferences = koinInject<AppearancePreferences>()
+  val audioVisualizerStyle by audioPreferences.audioVisualizerStyle.collectAsState()
+  val appTheme by appearancePreferences.appTheme.collectAsState()
+  val darkMode by appearancePreferences.darkMode.collectAsState()
+  val amoledMode by appearancePreferences.amoledMode.collectAsState()
+  val useDarkTheme = when (darkMode) {
+    DarkMode.Dark -> true
+    DarkMode.Light -> false
+    DarkMode.System -> isSystemInDarkTheme()
+  }
+  val palette = remember(appTheme, useDarkTheme) {
+    appTheme.toVisualizerPalette(useDarkTheme = true, amoledMode = true)
+  }
+
+  val isPlaying = paused == false
+  val currentPosSec = if (precisePosition > 0f) precisePosition else position?.toFloat() ?: 0f
+  val currentDurSec = if (preciseDuration > 0f) preciseDuration else duration?.toFloat() ?: 0f
+
+  val repeatMode by viewModel.repeatMode.collectAsState()
+  val shuffleEnabled by viewModel.shuffleEnabled.collectAsState()
+  val playlistModeEnabled = viewModel.hasPlaylistSupport()
+  val showVisualizer by viewModel.showVisualizerInAudioPlayer.collectAsState()
+
+  Box(
+    modifier = modifier
+      .fillMaxSize()
+      .background(
+        Brush.verticalGradient(
+          colorStops = arrayOf(
+            0.0f to Color.Black.copy(alpha = 0.85f),
+            0.3f to Color.Black.copy(alpha = 0.40f),
+            0.7f to Color.Black.copy(alpha = 0.60f),
+            1.0f to Color.Black.copy(alpha = 0.95f),
+          )
+        )
+      )
+      .statusBarsPadding()
+      .navigationBarsPadding()
+      .padding(horizontal = 24.dp, vertical = 16.dp)
+  ) {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      // 1. Top Header Bar (Close on left, NOW PLAYING center, Playlist on top-right)
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(top = 8.dp)
+      ) {
+        IconButton(
+          onClick = onBackPress,
+          modifier = Modifier.align(Alignment.CenterStart)
+        ) {
+          Icon(
+            imageVector = Icons.RoundedFilled.ExpandMore,
+            contentDescription = stringResource(R.string.ui_close),
+            tint = Color.White,
+            modifier = Modifier.size(32.dp)
+          )
+        }
+
+        Text(
+          text = stringResource(R.string.ui_now_playing),
+          style = MaterialTheme.typography.labelSmall,
+          color = Color.White.copy(alpha = 0.7f),
+          letterSpacing = 2.sp,
+          modifier = Modifier.align(Alignment.Center)
+        )
+
+        Row(
+          modifier = Modifier.align(Alignment.CenterEnd),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          IconButton(
+            onClick = { onOpenSheet(Sheets.Playlist) },
+            enabled = playlistModeEnabled
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.QueueMusic,
+              contentDescription = stringResource(R.string.ui_playlist),
+              tint = if (playlistModeEnabled) Color.White else Color.White.copy(alpha = 0.4f),
+              modifier = Modifier.size(28.dp)
+            )
+          }
+        }
+      }
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      // 2. Center View (Album Art Box OR Visualizer Overlay)
+      Box(
+        modifier = Modifier
+          .weight(1f)
+          .fillMaxWidth(),
+        contentAlignment = Alignment.Center
+      ) {
+        AnimatedContent(
+          targetState = showVisualizer,
+          transitionSpec = { fadeIn(tween(400)) togetherWith fadeOut(tween(400)) },
+          label = "visualizer_toggle",
+          modifier = Modifier.fillMaxSize(),
+        ) { isVisualizerActive ->
+          if (isVisualizerActive) {
+            // ONLY the visualizer shows, NO album art box, border, or container!
+            Box(
+              modifier = Modifier.fillMaxSize(),
+              contentAlignment = Alignment.Center
+            ) {
+              when (audioVisualizerStyle) {
+                AudioVisualizerStyle.Galaxy -> GalaxyOverlay(
+                  isPlaying = isPlaying,
+                  palette = palette,
+                  modifier = Modifier.fillMaxSize()
+                )
+                AudioVisualizerStyle.Blob -> BlobOverlay(
+                  isPlaying = isPlaying,
+                  palette = palette,
+                  modifier = Modifier.fillMaxSize()
+                )
+              }
+            }
+          } else {
+            // Album Art Box Container
+            val coverShape = RoundedCornerShape(32.dp)
+            Box(
+              modifier = Modifier.fillMaxSize(),
+              contentAlignment = Alignment.Center
+            ) {
+              Surface(
+                modifier = Modifier
+                  .aspectRatio(1f)
+                  .shadow(
+                    elevation = 24.dp,
+                    shape = coverShape,
+                    spotColor = Color.Black
+                  )
+                  .clip(coverShape),
+                shape = coverShape,
+                color = Color.Black,
+              ) {
+                Crossfade(
+                  targetState = albumArtBitmap,
+                  animationSpec = tween(300),
+                  label = "cover_crossfade",
+                  modifier = Modifier.fillMaxSize(),
+                ) { currentBitmap ->
+                  if (currentBitmap != null) {
+                    Image(
+                      bitmap = currentBitmap.asImageBitmap(),
+                      contentDescription = null,
+                      contentScale = ContentScale.Crop,
+                      modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                          scaleX = 1.05f
+                          scaleY = 1.05f
+                        }
+                    )
+                  } else {
+                    Box(
+                      modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                      contentAlignment = Alignment.Center
+                    ) {
+                      Icon(
+                        imageVector = Icons.RoundedFilled.Audiotrack,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(64.dp)
+                      )
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      // Track Title & Metadata
+      Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.Start
+      ) {
+        val titleText = lastValidTitle
+        Text(
+          text = titleText,
+          style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
+          color = Color.White,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        val playlistInfo = viewModel.getPlaylistInfo()
+        Text(
+          text = if (playlistInfo != null) "Track $playlistInfo" else "Audio Media",
+          style = MaterialTheme.typography.titleMedium,
+          color = Color.White.copy(alpha = 0.7f),
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis
+        )
+      }
+
+      Spacer(modifier = Modifier.height(20.dp))
+
+      // 3. Audio Transport Controls (Seekbar + Progress Timers)
+      var sliderValue by remember(currentPosSec) { mutableFloatStateOf(currentPosSec) }
+      var isDragging by remember { mutableStateOf(false) }
+
+      Column(modifier = Modifier.fillMaxWidth()) {
+        Slider(
+          value = if (isDragging) sliderValue else currentPosSec,
+          onValueChange = { value ->
+            sliderValue = value
+            isDragging = true
+          },
+          onValueChangeFinished = {
+            viewModel.seekTo(sliderValue.toInt())
+            isDragging = false
+          },
+          valueRange = 0f..currentDurSec.coerceAtLeast(1f),
+          modifier = Modifier.fillMaxWidth(),
+          colors = SliderDefaults.colors(
+            thumbColor = Color.White,
+            activeTrackColor = Color.White,
+            inactiveTrackColor = Color.White.copy(alpha = 0.3f),
+          ),
+          thumb = {
+            Box(modifier = Modifier.size(16.dp).background(Color.White, CircleShape))
+          },
+          track = { sliderState ->
+            Canvas(modifier = Modifier.fillMaxWidth().height(3.dp)) {
+              val thumbRadiusPx = 8.dp.toPx()
+              val trackStart = thumbRadiusPx
+              val trackEnd = size.width - thumbRadiusPx
+              val trackRange = trackEnd - trackStart
+              val h = size.height
+              val cornerR = CornerRadius(h / 2f, h / 2f)
+              val rangeSpan = (sliderState.valueRange.endInclusive - sliderState.valueRange.start).coerceAtLeast(1f)
+              val progress = (sliderState.value - sliderState.valueRange.start) / rangeSpan
+              val thumbCenterX = trackStart + progress * trackRange
+
+              drawRoundRect(
+                color = Color.White.copy(alpha = 0.2f),
+                topLeft = Offset(trackStart, 0f),
+                size = Size(trackRange, h),
+                cornerRadius = cornerR,
+              )
+
+              drawRoundRect(
+                color = Color.White,
+                topLeft = Offset(trackStart, 0f),
+                size = Size((thumbCenterX - trackStart).coerceAtLeast(0f), h),
+                cornerRadius = cornerR,
+              )
+            }
+          }
+        )
+
+        Row(
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+          horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+          Text(
+            text = formatSec(currentPosSec.toLong()),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.7f),
+          )
+          Text(
+            text = formatSec(currentDurSec.toLong()),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.7f),
+          )
+        }
+      }
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      // Main Playback Controls Row (Skip Previous, Seek -30s, Play/Pause, Seek +30s, Skip Next)
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        IconButton(
+          onClick = { viewModel.playPrevious() },
+          enabled = playlistModeEnabled
+        ) {
+          Icon(
+            imageVector = Icons.RoundedFilled.SkipPrevious,
+            contentDescription = null,
+            tint = if (playlistModeEnabled) Color.White.copy(alpha = 0.85f) else Color.White.copy(alpha = 0.35f),
+            modifier = Modifier.size(28.dp)
+          )
+        }
+
+        IconButton(onClick = { viewModel.seekBy(-30) }) {
+          Icon(
+            imageVector = Icons.RoundedFilled.FastRewind,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(34.dp)
+          )
+        }
+
+        Surface(
+          onClick = { viewModel.pauseUnpause() },
+          shape = CircleShape,
+          color = Color.White,
+          modifier = Modifier.size(76.dp),
+          shadowElevation = 8.dp,
+        ) {
+          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Icon(
+              imageVector = if (isPlaying) Icons.RoundedFilled.Pause else Icons.RoundedFilled.PlayArrow,
+              contentDescription = null,
+              tint = Color.Black,
+              modifier = Modifier.size(38.dp)
+            )
+          }
+        }
+
+        IconButton(onClick = { viewModel.seekBy(30) }) {
+          Icon(
+            imageVector = Icons.RoundedFilled.FastForward,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(34.dp)
+          )
+        }
+
+        IconButton(
+          onClick = { viewModel.playNext() },
+          enabled = playlistModeEnabled
+        ) {
+          Icon(
+            imageVector = Icons.RoundedFilled.SkipNext,
+            contentDescription = null,
+            tint = if (playlistModeEnabled) Color.White.copy(alpha = 0.85f) else Color.White.copy(alpha = 0.35f),
+            modifier = Modifier.size(28.dp)
+          )
+        }
+      }
+
+      Spacer(modifier = Modifier.height(24.dp))
+
+      // 4. Bottom Action Pill Bar (Shuffle, Repeat, Visualizer Toggle, Audio Delay/Equalizer)
+      Row(
+        modifier = Modifier
+          .clip(RoundedCornerShape(50))
+          .background(Color.White.copy(alpha = 0.12f))
+          .padding(horizontal = 12.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+      ) {
+        IconButton(
+          onClick = viewModel::toggleShuffle,
+          enabled = playlistModeEnabled
+        ) {
+          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Icon(
+              imageVector = if (shuffleEnabled) Icons.RoundedFilled.ShuffleOn else Icons.RoundedFilled.Shuffle,
+              contentDescription = null,
+              tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+            )
+          }
+        }
+
+        IconButton(onClick = viewModel::cycleRepeatMode) {
+          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Icon(
+              imageVector = when (repeatMode) {
+                RepeatMode.OFF -> Icons.RoundedFilled.Repeat
+                RepeatMode.ONE -> Icons.RoundedFilled.RepeatOne
+                RepeatMode.ALL -> Icons.RoundedFilled.RepeatOn
+              },
+              contentDescription = null,
+              tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+            )
+          }
+        }
+
+        IconButton(onClick = viewModel::toggleAudioVisualizer) {
+          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Icon(
+              imageVector = if (showVisualizer) Icons.RoundedFilled.AutoAwesome else Icons.RoundedFilled.Audiotrack,
+              contentDescription = null,
+              tint = if (showVisualizer) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+private fun formatSec(totalSeconds: Long): String {
+  val secs = totalSeconds.coerceAtLeast(0L)
+  val hours = secs / 3600
+  val minutes = (secs % 3600) / 60
+  val remainingSecs = secs % 60
+  return if (hours > 0) {
+    String.format(Locale.US, "%d:%02d:%02d", hours, minutes, remainingSecs)
+  } else {
+    String.format(Locale.US, "%d:%02d", minutes, remainingSecs)
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -70,6 +70,7 @@ import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.preferences.AppearancePreferences
 import app.gyrolet.mpvrx.preferences.AudioPreferences
 import app.gyrolet.mpvrx.preferences.AudioVisualizerStyle
+import app.gyrolet.mpvrx.preferences.PlayerPreferences
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
@@ -77,7 +78,11 @@ import app.gyrolet.mpvrx.ui.player.Panels
 import app.gyrolet.mpvrx.ui.player.PlayerViewModel
 import app.gyrolet.mpvrx.ui.player.RepeatMode
 import app.gyrolet.mpvrx.ui.player.Sheets
+import app.gyrolet.mpvrx.ui.player.controls.components.SeekbarWithTimers
 import app.gyrolet.mpvrx.ui.player.visualizer.BlobOverlay
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import org.koin.compose.koinInject
 import app.gyrolet.mpvrx.ui.player.visualizer.GalaxyOverlay
 import app.gyrolet.mpvrx.ui.theme.DarkMode
 import `is`.xyz.mpv.MPVLib
@@ -195,6 +200,15 @@ fun AudioPlayerControls(
   val shuffleEnabled by viewModel.shuffleEnabled.collectAsState()
   val playlistModeEnabled = viewModel.hasPlaylistSupport()
   val showVisualizer by viewModel.showVisualizerInAudioPlayer.collectAsState()
+
+  val playerPreferences = koinInject<PlayerPreferences>()
+  val seekbarStyle by appearancePreferences.seekbarStyle.collectAsState()
+  val invertDuration by playerPreferences.invertDuration.collectAsState()
+  val showChapterIndicators by playerPreferences.showChapterIndicators.collectAsState()
+  val chapters by viewModel.chapters.collectAsState()
+  val seekbarChapters = remember(chapters, showChapterIndicators) {
+    if (showChapterIndicators) chapters.toImmutableList() else persistentListOf()
+  }
 
   Box(
     modifier = modifier
@@ -403,79 +417,29 @@ fun AudioPlayerControls(
 
       Spacer(modifier = Modifier.height(16.dp))
 
-      // 3. Audio Transport Controls (Seekbar + Progress Timers)
-      var sliderValue by remember(currentPosSec) { mutableFloatStateOf(currentPosSec) }
-      var isDragging by remember { mutableStateOf(false) }
-
-      Column(modifier = Modifier.fillMaxWidth()) {
-        Slider(
-          value = if (isDragging) sliderValue else currentPosSec,
-          onValueChange = { value ->
-            sliderValue = value
-            isDragging = true
-          },
-          onValueChangeFinished = {
-            viewModel.seekTo(sliderValue.toInt())
-            isDragging = false
-          },
-          valueRange = 0f..currentDurSec.coerceAtLeast(1f),
-          modifier = Modifier.fillMaxWidth(),
-          colors = SliderDefaults.colors(
-            thumbColor = Color.White,
-            activeTrackColor = Color.White,
-            inactiveTrackColor = Color.White.copy(alpha = 0.3f),
-          ),
-          thumb = {
-            Box(modifier = Modifier.size(16.dp).background(Color.White, CircleShape))
-          },
-          track = { sliderState ->
-            Canvas(modifier = Modifier.fillMaxWidth().height(3.dp)) {
-              val thumbRadiusPx = 8.dp.toPx()
-              val trackStart = thumbRadiusPx
-              val trackEnd = size.width - thumbRadiusPx
-              val trackRange = trackEnd - trackStart
-              val h = size.height
-              val cornerR = CornerRadius(h / 2f, h / 2f)
-              val rangeSpan = (sliderState.valueRange.endInclusive - sliderState.valueRange.start).coerceAtLeast(1f)
-              val progress = (sliderState.value - sliderState.valueRange.start) / rangeSpan
-              val thumbCenterX = trackStart + progress * trackRange
-
-              drawRoundRect(
-                color = Color.White.copy(alpha = 0.2f),
-                topLeft = Offset(trackStart, 0f),
-                size = Size(trackRange, h),
-                cornerRadius = cornerR,
-              )
-
-              drawRoundRect(
-                color = Color.White,
-                topLeft = Offset(trackStart, 0f),
-                size = Size((thumbCenterX - trackStart).coerceAtLeast(0f), h),
-                cornerRadius = cornerR,
-              )
-            }
-          }
-        )
-
-        Row(
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 0.dp),
-          horizontalArrangement = Arrangement.SpaceBetween,
-          verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Text(
-            text = formatSec(currentPosSec.toLong()),
-            style = MaterialTheme.typography.labelSmall,
-            color = Color.White.copy(alpha = 0.7f),
-          )
-          Text(
-            text = formatSec(currentDurSec.toLong()),
-            style = MaterialTheme.typography.labelSmall,
-            color = Color.White.copy(alpha = 0.7f),
-          )
-        }
-      }
+      // 3. Audio Transport Controls (Video player seekbar component & style)
+      SeekbarWithTimers(
+        position = currentPosSec,
+        committedPosition = currentPosSec,
+        duration = currentDurSec.coerceAtLeast(1f),
+        onValueChange = { value ->
+          viewModel.seekTo(value.toInt(), fast = true)
+        },
+        onValueChangeFinished = { targetPosition ->
+          viewModel.seekTo(targetPosition.toInt(), fast = false)
+        },
+        timersInverted = Pair(false, invertDuration),
+        durationTimerOnCLick = {
+          playerPreferences.invertDuration.set(!invertDuration)
+        },
+        positionTimerOnClick = {},
+        chapters = seekbarChapters,
+        skipSegments = persistentListOf(),
+        paused = paused ?: false,
+        seekbarStyle = seekbarStyle,
+        isPortrait = true,
+        modifier = Modifier.fillMaxWidth()
+      )
 
       Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -78,6 +79,10 @@ import app.gyrolet.mpvrx.ui.player.Panels
 import app.gyrolet.mpvrx.ui.player.PlayerViewModel
 import app.gyrolet.mpvrx.ui.player.RepeatMode
 import app.gyrolet.mpvrx.ui.player.Sheets
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.foundation.clickable
+import app.gyrolet.mpvrx.ui.player.controls.components.AbLoopIcon
 import app.gyrolet.mpvrx.ui.player.controls.components.SeekbarWithTimers
 import app.gyrolet.mpvrx.ui.player.visualizer.BlobOverlay
 import kotlinx.collections.immutable.persistentListOf
@@ -201,6 +206,10 @@ fun AudioPlayerControls(
   val playlistModeEnabled = viewModel.hasPlaylistSupport()
   val showVisualizer by viewModel.showVisualizerInAudioPlayer.collectAsState()
 
+  val abLoop by viewModel.abLoopState.collectAsState()
+  val abLoopA = abLoop.a
+  val abLoopB = abLoop.b
+
   val playerPreferences = koinInject<PlayerPreferences>()
   val seekbarStyle by appearancePreferences.seekbarStyle.collectAsState()
   val invertDuration by playerPreferences.invertDuration.collectAsState()
@@ -213,16 +222,7 @@ fun AudioPlayerControls(
   Box(
     modifier = modifier
       .fillMaxSize()
-      .background(
-        Brush.verticalGradient(
-          colorStops = arrayOf(
-            0.0f to Color.Black.copy(alpha = 0.85f),
-            0.3f to Color.Black.copy(alpha = 0.40f),
-            0.7f to Color.Black.copy(alpha = 0.60f),
-            1.0f to Color.Black.copy(alpha = 0.95f),
-          )
-        )
-      )
+      .background(MaterialTheme.colorScheme.surface)
       .statusBarsPadding()
       .navigationBarsPadding()
       .padding(horizontal = 24.dp, vertical = 16.dp)
@@ -244,7 +244,7 @@ fun AudioPlayerControls(
           Icon(
             imageVector = Icons.RoundedFilled.ExpandMore,
             contentDescription = stringResource(R.string.ui_close),
-            tint = Color.White,
+            tint = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.size(32.dp)
           )
         }
@@ -252,7 +252,7 @@ fun AudioPlayerControls(
         Text(
           text = stringResource(R.string.ui_now_playing),
           style = MaterialTheme.typography.labelSmall,
-          color = Color.White.copy(alpha = 0.7f),
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
           letterSpacing = 2.sp,
           modifier = Modifier.align(Alignment.Center)
         )
@@ -267,7 +267,7 @@ fun AudioPlayerControls(
             Icon(
               imageVector = Icons.RoundedFilled.Info,
               contentDescription = stringResource(R.string.player_sheets_more_title),
-              tint = Color.White,
+              tint = MaterialTheme.colorScheme.onSurface,
               modifier = Modifier.size(28.dp)
             )
           }
@@ -278,8 +278,8 @@ fun AudioPlayerControls(
         Spacer(modifier = Modifier.height(4.dp))
         Surface(
           shape = RoundedCornerShape(4.dp),
-          color = Color.White.copy(alpha = 0.15f),
-          border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.3f)),
+          color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+          border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
         ) {
           Text(
             text = if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS",
@@ -288,7 +288,7 @@ fun AudioPlayerControls(
               fontSize = 8.5.sp,
               letterSpacing = 0.8.sp
             ),
-            color = Color.White.copy(alpha = 0.9f),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
           )
         }
@@ -296,13 +296,19 @@ fun AudioPlayerControls(
 
       Spacer(modifier = Modifier.height(16.dp))
 
-      // 2. Center View (Album Art Box OR Visualizer Overlay)
-      Box(
+      // 2. Center View (Album Art Box OR Dynamic Visualizer Overlay)
+      BoxWithConstraints(
         modifier = Modifier
           .weight(1f)
           .fillMaxWidth(),
         contentAlignment = Alignment.Center
       ) {
+        val maxW = maxWidth
+        val maxH = maxHeight
+        val visualizerScale = remember(maxW, maxH) {
+          (maxH / maxW.coerceAtLeast(1.dp)).coerceIn(1.20f, 1.50f)
+        }
+
         AnimatedContent(
           targetState = showVisualizer,
           transitionSpec = { fadeIn(tween(400)) togetherWith fadeOut(tween(400)) },
@@ -310,9 +316,20 @@ fun AudioPlayerControls(
           modifier = Modifier.fillMaxSize(),
         ) { isVisualizerActive ->
           if (isVisualizerActive) {
-            // ONLY the visualizer shows, NO album art box, border, or container!
+            // Themed background layer — adapts to any theme, sits behind the GL surface
             Box(
-              modifier = Modifier.fillMaxSize(),
+              modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+            )
+            // Dynamic, larger visualizer scaling dynamically according to screen size
+            Box(
+              modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                  scaleX = visualizerScale
+                  scaleY = visualizerScale
+                },
               contentAlignment = Alignment.Center
             ) {
               when (audioVisualizerStyle) {
@@ -341,11 +358,11 @@ fun AudioPlayerControls(
                   .shadow(
                     elevation = 24.dp,
                     shape = coverShape,
-                    spotColor = Color.Black
+                    spotColor = MaterialTheme.colorScheme.scrim
                   )
                   .clip(coverShape),
                 shape = coverShape,
-                color = Color.Black,
+                color = MaterialTheme.colorScheme.surfaceContainer,
               ) {
                 Crossfade(
                   targetState = albumArtBitmap,
@@ -390,7 +407,6 @@ fun AudioPlayerControls(
       Spacer(modifier = Modifier.height(16.dp))
 
       // Track Title & Metadata
-      // Track Title & Metadata
       Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.Start
@@ -399,20 +415,120 @@ fun AudioPlayerControls(
         Text(
           text = titleText,
           style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
-          color = Color.White,
+          color = MaterialTheme.colorScheme.onSurface,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
           modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE)
         )
         Spacer(modifier = Modifier.height(4.dp))
         val playlistInfo = viewModel.getPlaylistInfo()
-        Text(
-          text = if (playlistInfo != null) "Track $playlistInfo" else "Audio Media",
-          style = MaterialTheme.typography.titleMedium,
-          color = Color.White.copy(alpha = 0.7f),
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis
-        )
+        val trackText = if (playlistInfo != null) "Track $playlistInfo" else "Audio Media"
+
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+          Text(
+            text = trackText,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+          )
+
+          Text(
+            text = "|",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+          )
+
+          // A-B Loop Control from video player
+          AnimatedContent(
+            targetState = abLoop.isExpanded,
+            transitionSpec = {
+              (fadeIn(animationSpec = tween(200)) + expandHorizontally(animationSpec = tween(250)))
+                .togetherWith(fadeOut(animationSpec = tween(200)) + shrinkHorizontally(animationSpec = tween(250)))
+            },
+            label = "AudioABLoopExpand",
+          ) { expanded ->
+            if (expanded) {
+              Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+              ) {
+                Surface(
+                  shape = CircleShape,
+                  color = if (abLoopA != null) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+                  modifier = Modifier
+                    .height(30.dp)
+                    .clip(CircleShape)
+                    .clickable(onClick = { viewModel.setLoopA() }),
+                ) {
+                  Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(horizontal = 10.dp)) {
+                    Text(
+                      text = if (abLoopA != null) formatSec(abLoopA.toLong()) else "A",
+                      style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                      color = if (abLoopA != null) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                  }
+                }
+
+                Surface(
+                  shape = CircleShape,
+                  color = MaterialTheme.colorScheme.surfaceVariant,
+                  modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .clickable(onClick = {
+                      viewModel.clearABLoop()
+                      viewModel.toggleABLoopExpanded()
+                    }),
+                ) {
+                  Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                      imageVector = Icons.RoundedFilled.Close,
+                      contentDescription = "Clear A-B Loop",
+                      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                      modifier = Modifier.size(16.dp),
+                    )
+                  }
+                }
+
+                Surface(
+                  shape = CircleShape,
+                  color = if (abLoopB != null) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+                  modifier = Modifier
+                    .height(30.dp)
+                    .clip(CircleShape)
+                    .clickable(onClick = { viewModel.setLoopB() }),
+                ) {
+                  Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(horizontal = 10.dp)) {
+                    Text(
+                      text = if (abLoopB != null) formatSec(abLoopB.toLong()) else "B",
+                      style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                      color = if (abLoopB != null) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                  }
+                }
+              }
+            } else {
+              Surface(
+                shape = CircleShape,
+                color = Color.Transparent,
+                modifier = Modifier
+                  .clip(CircleShape)
+                  .clickable(onClick = viewModel::toggleABLoopExpanded)
+              ) {
+                AbLoopIcon(
+                  modifier = Modifier.size(30.dp),
+                  tint = if (abLoopA != null || abLoopB != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                  isASet = abLoopA != null,
+                  isBSet = abLoopB != null,
+                )
+              }
+            }
+          }
+        }
       }
 
       Spacer(modifier = Modifier.height(16.dp))
@@ -437,7 +553,10 @@ fun AudioPlayerControls(
         skipSegments = persistentListOf(),
         paused = paused ?: false,
         seekbarStyle = seekbarStyle,
+        loopStart = abLoopA?.toFloat(),
+        loopEnd = abLoopB?.toFloat(),
         isPortrait = true,
+        applyHorizontalPadding = false,
         modifier = Modifier.fillMaxWidth()
       )
 
@@ -456,7 +575,7 @@ fun AudioPlayerControls(
           Icon(
             imageVector = Icons.RoundedFilled.SkipPrevious,
             contentDescription = null,
-            tint = if (playlistModeEnabled) Color.White.copy(alpha = 0.85f) else Color.White.copy(alpha = 0.35f),
+            tint = if (playlistModeEnabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             modifier = Modifier.size(28.dp)
           )
         }
@@ -465,7 +584,7 @@ fun AudioPlayerControls(
           Icon(
             imageVector = Icons.RoundedFilled.FastRewind,
             contentDescription = null,
-            tint = Color.White,
+            tint = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.size(34.dp)
           )
         }
@@ -473,7 +592,7 @@ fun AudioPlayerControls(
         Surface(
           onClick = { viewModel.pauseUnpause() },
           shape = CircleShape,
-          color = Color.White,
+          color = MaterialTheme.colorScheme.primary,
           modifier = Modifier.size(76.dp),
           shadowElevation = 8.dp,
         ) {
@@ -481,7 +600,7 @@ fun AudioPlayerControls(
             Icon(
               imageVector = if (isPlaying) Icons.RoundedFilled.Pause else Icons.RoundedFilled.PlayArrow,
               contentDescription = null,
-              tint = Color.Black,
+              tint = MaterialTheme.colorScheme.onPrimary,
               modifier = Modifier.size(38.dp)
             )
           }
@@ -491,7 +610,7 @@ fun AudioPlayerControls(
           Icon(
             imageVector = Icons.RoundedFilled.FastForward,
             contentDescription = null,
-            tint = Color.White,
+            tint = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.size(34.dp)
           )
         }
@@ -503,7 +622,7 @@ fun AudioPlayerControls(
           Icon(
             imageVector = Icons.RoundedFilled.SkipNext,
             contentDescription = null,
-            tint = if (playlistModeEnabled) Color.White.copy(alpha = 0.85f) else Color.White.copy(alpha = 0.35f),
+            tint = if (playlistModeEnabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             modifier = Modifier.size(28.dp)
           )
         }
@@ -522,14 +641,14 @@ fun AudioPlayerControls(
           onClick = { onOpenSheet(Sheets.Equalizer) },
           modifier = Modifier
             .clip(CircleShape)
-            .background(Color.White.copy(alpha = 0.12f))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f))
             .size(48.dp)
         ) {
           Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
             Icon(
               imageVector = Icons.RoundedFilled.Equalizer,
               contentDescription = "Equalizer",
-              tint = Color.White.copy(alpha = 0.85f),
+              tint = MaterialTheme.colorScheme.onSurface,
               modifier = Modifier.size(24.dp)
             )
           }
@@ -539,7 +658,7 @@ fun AudioPlayerControls(
         Row(
           modifier = Modifier
             .clip(RoundedCornerShape(50))
-            .background(Color.White.copy(alpha = 0.12f))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f))
             .padding(horizontal = 12.dp, vertical = 4.dp),
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -552,7 +671,7 @@ fun AudioPlayerControls(
               Icon(
                 imageVector = if (shuffleEnabled) Icons.RoundedFilled.ShuffleOn else Icons.RoundedFilled.Shuffle,
                 contentDescription = null,
-                tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+                tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
               )
             }
           }
@@ -566,7 +685,7 @@ fun AudioPlayerControls(
                   RepeatMode.ALL -> Icons.RoundedFilled.RepeatOn
                 },
                 contentDescription = null,
-                tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+                tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
               )
             }
           }
@@ -576,7 +695,7 @@ fun AudioPlayerControls(
               Icon(
                 imageVector = if (showVisualizer) Icons.RoundedFilled.AutoAwesome else Icons.RoundedFilled.Audiotrack,
                 contentDescription = null,
-                tint = if (showVisualizer) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+                tint = if (showVisualizer) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
               )
             }
           }
@@ -587,14 +706,14 @@ fun AudioPlayerControls(
           onClick = { onOpenSheet(Sheets.Playlist) },
           modifier = Modifier
             .clip(CircleShape)
-            .background(Color.White.copy(alpha = 0.12f))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f))
             .size(48.dp)
         ) {
           Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
             Icon(
               imageVector = Icons.RoundedFilled.QueueMusic,
               contentDescription = "Playlist",
-              tint = Color.White.copy(alpha = 0.85f),
+              tint = MaterialTheme.colorScheme.onSurface,
               modifier = Modifier.size(24.dp)
             )
           }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -175,10 +176,17 @@ fun AudioPlayerControls(
 
   val albumArtBitmap = rememberAudioAlbumArt(mediaPath)
 
-  var lastValidTitle by remember { mutableStateOf(mediaTitle?.takeIf { it.isNotBlank() } ?: "Audio Track") }
+  fun String.stripAudioExtension(): String {
+    val dotIndex = lastIndexOf('.')
+    if (dotIndex <= 0) return this
+    val ext = substring(dotIndex + 1)
+    return if (ext.length in 2..5 && ext.none { it.isWhitespace() }) substring(0, dotIndex) else this
+  }
+
+  var lastValidTitle by remember { mutableStateOf(mediaTitle?.takeIf { it.isNotBlank() }?.stripAudioExtension() ?: "Audio Track") }
   LaunchedEffect(mediaTitle) {
     if (!mediaTitle.isNullOrBlank()) {
-      lastValidTitle = mediaTitle
+      lastValidTitle = mediaTitle.stripAudioExtension()
     }
   }
 
@@ -193,8 +201,8 @@ fun AudioPlayerControls(
     DarkMode.Light -> false
     DarkMode.System -> isSystemInDarkTheme()
   }
-  val palette = remember(appTheme, useDarkTheme) {
-    appTheme.toVisualizerPalette(useDarkTheme = true, amoledMode = true)
+  val palette = remember(appTheme, useDarkTheme, amoledMode) {
+    appTheme.toVisualizerPalette(useDarkTheme = useDarkTheme, amoledMode = amoledMode)
   }
 
   val isPlaying = paused == false
@@ -225,7 +233,7 @@ fun AudioPlayerControls(
       .background(MaterialTheme.colorScheme.surface)
       .statusBarsPadding()
       .navigationBarsPadding()
-      .padding(horizontal = 24.dp, vertical = 16.dp)
+      .padding(start = 24.dp, end = 24.dp, top = 6.dp, bottom = 16.dp)
   ) {
     Column(
       modifier = Modifier.fillMaxSize(),
@@ -235,7 +243,6 @@ fun AudioPlayerControls(
       Box(
         modifier = Modifier
           .fillMaxWidth()
-          .padding(top = 8.dp)
       ) {
         IconButton(
           onClick = onBackPress,
@@ -300,7 +307,8 @@ fun AudioPlayerControls(
       BoxWithConstraints(
         modifier = Modifier
           .weight(1f)
-          .fillMaxWidth(),
+          .fillMaxWidth()
+          .clipToBounds(),
         contentAlignment = Alignment.Center
       ) {
         val maxW = maxWidth
@@ -316,12 +324,6 @@ fun AudioPlayerControls(
           modifier = Modifier.fillMaxSize(),
         ) { isVisualizerActive ->
           if (isVisualizerActive) {
-            // Themed background layer — adapts to any theme, sits behind the GL surface
-            Box(
-              modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.surface),
-            )
             // Dynamic, larger visualizer scaling dynamically according to screen size
             Box(
               modifier = Modifier

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.sp
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.preferences.AppearancePreferences
 import app.gyrolet.mpvrx.preferences.AudioPreferences
@@ -85,10 +86,12 @@ import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import java.util.Locale
 
+import app.gyrolet.mpvrx.domain.thumbnail.EmbeddedArtworkResolver
+
 @Composable
 private fun rememberAudioAlbumArt(pathOrUri: String?): Bitmap? {
   val context = LocalContext.current
-  var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+  var bitmap by remember(pathOrUri) { mutableStateOf<Bitmap?>(null) }
   LaunchedEffect(pathOrUri) {
     if (pathOrUri.isNullOrBlank()) {
       bitmap = null
@@ -107,11 +110,9 @@ private fun rememberAudioAlbumArt(pathOrUri: String?): Bitmap? {
         } else {
           retriever.setDataSource(context, Uri.parse(pathOrUri))
         }
-        val art = retriever.embeddedPicture
+        val art = EmbeddedArtworkResolver.decodeEmbeddedArtwork(cleanPath, retriever)
         retriever.release()
-        if (art != null) {
-          BitmapFactory.decodeByteArray(art, 0, art.size)
-        } else null
+        art
       }.onSuccess { loadedBitmap ->
         bitmap = loadedBitmap
       }.onFailure {
@@ -141,6 +142,26 @@ fun AudioPlayerControls(
   val currentPath by MPVLib.propString["path"].collectAsState()
   val currentStreamFilename by MPVLib.propString["stream-open-filename"].collectAsState()
   val mediaPath = currentPath?.takeIf { it.isNotBlank() } ?: currentStreamFilename
+
+  val audioCodec by MPVLib.propString["audio-codec-name"].collectAsState()
+  val sampleRate by MPVLib.propInt["audio-params/samplerate"].collectAsState()
+
+  val isLosslessCodecOrExt = remember(audioCodec, mediaPath) {
+    val codec = audioCodec?.lowercase().orEmpty()
+    val ext = mediaPath?.substringBefore('?')?.substringBefore('#')?.substringAfterLast('.', "")?.lowercase().orEmpty()
+    codec.contains("flac") ||
+      codec.contains("alac") ||
+      codec.contains("pcm") ||
+      codec.contains("wavpack") ||
+      codec.contains("ape") ||
+      codec.contains("dsd") ||
+      codec.contains("tak") ||
+      ext in setOf("flac", "wav", "aiff", "aif", "alac", "ape", "dsf", "dff")
+  }
+
+  val isHiRes = remember(sampleRate, isLosslessCodecOrExt) {
+    isLosslessCodecOrExt && (sampleRate ?: 0) >= 88200
+  }
 
   val albumArtBitmap = rememberAudioAlbumArt(mediaPath)
 
@@ -340,15 +361,42 @@ fun AudioPlayerControls(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.Start
       ) {
-        val titleText = lastValidTitle
-        Text(
-          text = titleText,
-          style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
-          color = Color.White,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
-          modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE)
-        )
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          modifier = Modifier.fillMaxWidth()
+        ) {
+          val titleText = lastValidTitle
+          Text(
+            text = titleText,
+            style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
+            color = Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+              .weight(1f, fill = false)
+              .basicMarquee(iterations = Int.MAX_VALUE)
+          )
+
+          if (isLosslessCodecOrExt) {
+            Surface(
+              shape = RoundedCornerShape(4.dp),
+              color = Color.White.copy(alpha = 0.15f),
+              border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.3f)),
+            ) {
+              Text(
+                text = if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS",
+                style = MaterialTheme.typography.labelSmall.copy(
+                  fontWeight = FontWeight.Bold,
+                  fontSize = 9.sp,
+                  letterSpacing = 0.8.sp
+                ),
+                color = Color.White.copy(alpha = 0.9f),
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+              )
+            }
+          }
+        }
         Spacer(modifier = Modifier.height(4.dp))
         val playlistInfo = viewModel.getPlaylistInfo()
         Text(
@@ -505,48 +553,91 @@ fun AudioPlayerControls(
 
       Spacer(modifier = Modifier.height(24.dp))
 
-      // 4. Bottom Action Pill Bar (Shuffle, Repeat, Visualizer Toggle, Audio Delay/Equalizer)
+      // 4. Bottom Action Row (Equalizer on Left, Center Pill Bar, Playlist on Right)
       Row(
-        modifier = Modifier
-          .clip(RoundedCornerShape(50))
-          .background(Color.White.copy(alpha = 0.12f))
-          .padding(horizontal = 12.dp, vertical = 4.dp),
+        modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.SpaceBetween
       ) {
+        // Bottom Left: Equalizer Button
         IconButton(
-          onClick = viewModel::toggleShuffle,
-          enabled = playlistModeEnabled
+          onClick = { onOpenSheet(Sheets.Equalizer) },
+          modifier = Modifier
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = 0.12f))
+            .size(48.dp)
         ) {
           Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
             Icon(
-              imageVector = if (shuffleEnabled) Icons.RoundedFilled.ShuffleOn else Icons.RoundedFilled.Shuffle,
-              contentDescription = null,
-              tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+              imageVector = Icons.RoundedFilled.Equalizer,
+              contentDescription = "Equalizer",
+              tint = Color.White.copy(alpha = 0.85f),
+              modifier = Modifier.size(24.dp)
             )
           }
         }
 
-        IconButton(onClick = viewModel::cycleRepeatMode) {
-          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-            Icon(
-              imageVector = when (repeatMode) {
-                RepeatMode.OFF -> Icons.RoundedFilled.Repeat
-                RepeatMode.ONE -> Icons.RoundedFilled.RepeatOne
-                RepeatMode.ALL -> Icons.RoundedFilled.RepeatOn
-              },
-              contentDescription = null,
-              tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
-            )
+        // Center Pill Bar (Shuffle, Repeat, Visualizer)
+        Row(
+          modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(Color.White.copy(alpha = 0.12f))
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+          IconButton(
+            onClick = viewModel::toggleShuffle,
+            enabled = playlistModeEnabled
+          ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+              Icon(
+                imageVector = if (shuffleEnabled) Icons.RoundedFilled.ShuffleOn else Icons.RoundedFilled.Shuffle,
+                contentDescription = null,
+                tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+              )
+            }
+          }
+
+          IconButton(onClick = viewModel::cycleRepeatMode) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+              Icon(
+                imageVector = when (repeatMode) {
+                  RepeatMode.OFF -> Icons.RoundedFilled.Repeat
+                  RepeatMode.ONE -> Icons.RoundedFilled.RepeatOne
+                  RepeatMode.ALL -> Icons.RoundedFilled.RepeatOn
+                },
+                contentDescription = null,
+                tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+              )
+            }
+          }
+
+          IconButton(onClick = viewModel::toggleAudioVisualizer) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+              Icon(
+                imageVector = if (showVisualizer) Icons.RoundedFilled.AutoAwesome else Icons.RoundedFilled.Audiotrack,
+                contentDescription = null,
+                tint = if (showVisualizer) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+              )
+            }
           }
         }
 
-        IconButton(onClick = viewModel::toggleAudioVisualizer) {
+        // Bottom Right: Playlist Button
+        IconButton(
+          onClick = { onOpenSheet(Sheets.Playlist) },
+          modifier = Modifier
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = 0.12f))
+            .size(48.dp)
+        ) {
           Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
             Icon(
-              imageVector = if (showVisualizer) Icons.RoundedFilled.AutoAwesome else Icons.RoundedFilled.Audiotrack,
-              contentDescription = null,
-              tint = if (showVisualizer) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+              imageVector = Icons.RoundedFilled.QueueMusic,
+              contentDescription = "Playlist",
+              tint = Color.White.copy(alpha = 0.85f),
+              modifier = Modifier.size(24.dp)
             )
           }
         }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -6,10 +6,18 @@ import android.media.MediaMetadataRetriever
 import android.net.Uri
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -23,7 +31,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -60,7 +72,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -183,11 +198,64 @@ fun AudioPlayerControls(
     return if (ext.length in 2..5 && ext.none { it.isWhitespace() }) substring(0, dotIndex) else this
   }
 
+  fun cleanSongTitle(title: String, artist: String?): String {
+    val titleWithoutExt = title.stripAudioExtension()
+    if (!artist.isNullOrBlank() && artist != "Unknown Artist") {
+      val prefixes = listOf("$artist - ", "$artist – ", "$artist — ", "$artist- ", "$artist : ")
+      for (prefix in prefixes) {
+        if (titleWithoutExt.startsWith(prefix, ignoreCase = true)) {
+          return titleWithoutExt.substring(prefix.length).trim()
+        }
+      }
+      val suffixes = listOf(" - $artist", " – $artist", " — $artist", " -$artist")
+      for (suffix in suffixes) {
+        if (titleWithoutExt.endsWith(suffix, ignoreCase = true)) {
+          return titleWithoutExt.substring(0, titleWithoutExt.length - suffix.length).trim()
+        }
+      }
+    }
+    return titleWithoutExt
+  }
+
   var lastValidTitle by remember { mutableStateOf(mediaTitle?.takeIf { it.isNotBlank() }?.stripAudioExtension() ?: "Audio Track") }
   LaunchedEffect(mediaTitle) {
     if (!mediaTitle.isNullOrBlank()) {
       lastValidTitle = mediaTitle.stripAudioExtension()
     }
+  }
+
+  val context = LocalContext.current
+  val rawArtist by MPVLib.propString["metadata/by-key/Artist"].collectAsState()
+  val rawArtistAlt by MPVLib.propString["metadata/artist"].collectAsState()
+  val rawAlbumArtist by MPVLib.propString["metadata/by-key/album_artist"].collectAsState()
+  val rawPerformer by MPVLib.propString["metadata/by-key/PERFORMER"].collectAsState()
+
+  var retrievedArtist by remember(mediaPath) { mutableStateOf<String?>(null) }
+  LaunchedEffect(mediaPath) {
+    if (!mediaPath.isNullOrBlank()) {
+      withContext(Dispatchers.IO) {
+        runCatching {
+          val retriever = MediaMetadataRetriever()
+          if (mediaPath.startsWith("content://")) {
+            retriever.setDataSource(context, Uri.parse(mediaPath))
+          } else {
+            retriever.setDataSource(mediaPath.removePrefix("file://"))
+          }
+          val art = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
+            ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
+            ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_AUTHOR)
+            ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COMPOSER)
+          retriever.release()
+          art
+        }.getOrNull()?.let { retrievedArtist = it }
+      }
+    }
+  }
+
+  val displayArtist = remember(rawArtist, rawArtistAlt, rawAlbumArtist, rawPerformer, retrievedArtist) {
+    sequenceOf(rawArtist, rawArtistAlt, rawAlbumArtist, rawPerformer, retrievedArtist)
+      .filterNotNull()
+      .firstOrNull { it.isNotBlank() } ?: "Unknown Artist"
   }
 
   val audioPreferences = koinInject<AudioPreferences>()
@@ -227,24 +295,19 @@ fun AudioPlayerControls(
     if (showChapterIndicators) chapters.toImmutableList() else persistentListOf()
   }
 
+  val configuration = LocalConfiguration.current
+  val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+
   Box(
     modifier = modifier
       .fillMaxSize()
       .background(MaterialTheme.colorScheme.surface)
-      .statusBarsPadding()
-      .navigationBarsPadding()
-      .padding(start = 24.dp, end = 24.dp, top = 6.dp, bottom = 16.dp)
+      .windowInsetsPadding(WindowInsets.safeDrawing)
+      .padding(start = 16.dp, end = 16.dp, top = 6.dp, bottom = 12.dp)
   ) {
-    Column(
-      modifier = Modifier.fillMaxSize(),
-      horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-      // 1. Top Header Bar (Close on left, NOW PLAYING center, Info on top-right)
-      Box(
-        modifier = Modifier
-          .fillMaxWidth()
-      ) {
-        IconButton(
+    val headerBar = @Composable {
+      Box(modifier = Modifier.fillMaxWidth()) {
+        ReactiveIconButton(
           onClick = onBackPress,
           modifier = Modifier.align(Alignment.CenterStart)
         ) {
@@ -268,9 +331,7 @@ fun AudioPlayerControls(
           modifier = Modifier.align(Alignment.CenterEnd),
           verticalAlignment = Alignment.CenterVertically
         ) {
-          IconButton(
-            onClick = { onOpenSheet(Sheets.AudioProperties) }
-          ) {
+          ReactiveIconButton(onClick = { onOpenSheet(Sheets.AudioProperties) }) {
             Icon(
               imageVector = Icons.RoundedFilled.Info,
               contentDescription = stringResource(R.string.player_sheets_more_title),
@@ -280,9 +341,10 @@ fun AudioPlayerControls(
           }
         }
       }
+    }
 
+    val losslessBadge = @Composable {
       if (isLosslessCodecOrExt) {
-        Spacer(modifier = Modifier.height(4.dp))
         Surface(
           shape = RoundedCornerShape(4.dp),
           color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
@@ -300,15 +362,11 @@ fun AudioPlayerControls(
           )
         }
       }
+    }
 
-      Spacer(modifier = Modifier.height(16.dp))
-
-      // 2. Center View (Album Art Box OR Dynamic Visualizer Overlay)
+    val centerVisualizerView = @Composable { visualizerModifier: Modifier ->
       BoxWithConstraints(
-        modifier = Modifier
-          .weight(1f)
-          .fillMaxWidth()
-          .clipToBounds(),
+        modifier = visualizerModifier.clipToBounds(),
         contentAlignment = Alignment.Center
       ) {
         val maxW = maxWidth
@@ -324,7 +382,6 @@ fun AudioPlayerControls(
           modifier = Modifier.fillMaxSize(),
         ) { isVisualizerActive ->
           if (isVisualizerActive) {
-            // Dynamic, larger visualizer scaling dynamically according to screen size
             Box(
               modifier = Modifier
                 .fillMaxSize()
@@ -348,7 +405,6 @@ fun AudioPlayerControls(
               }
             }
           } else {
-            // Album Art Box Container
             val coverShape = RoundedCornerShape(32.dp)
             Box(
               modifier = Modifier.fillMaxSize(),
@@ -357,14 +413,9 @@ fun AudioPlayerControls(
               Surface(
                 modifier = Modifier
                   .aspectRatio(1f)
-                  .shadow(
-                    elevation = 24.dp,
-                    shape = coverShape,
-                    spotColor = MaterialTheme.colorScheme.scrim
-                  )
                   .clip(coverShape),
                 shape = coverShape,
-                color = MaterialTheme.colorScheme.surfaceContainer,
+                color = Color.Transparent,
               ) {
                 Crossfade(
                   targetState = albumArtBitmap,
@@ -377,18 +428,11 @@ fun AudioPlayerControls(
                       bitmap = currentBitmap.asImageBitmap(),
                       contentDescription = null,
                       contentScale = ContentScale.Crop,
-                      modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer {
-                          scaleX = 1.05f
-                          scaleY = 1.05f
-                        }
+                      modifier = Modifier.fillMaxSize()
                     )
                   } else {
                     Box(
-                      modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                      modifier = Modifier.fillMaxSize(),
                       contentAlignment = Alignment.Center
                     ) {
                       Icon(
@@ -405,24 +449,40 @@ fun AudioPlayerControls(
           }
         }
       }
+    }
 
-      Spacer(modifier = Modifier.height(16.dp))
-
-      // Track Title & Metadata
+    val trackMetadataView = @Composable {
       Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.Start
       ) {
-        val titleText = lastValidTitle
+        val displayTitle = remember(lastValidTitle, displayArtist) {
+          cleanSongTitle(lastValidTitle, displayArtist)
+        }
+
+        // 1. Song Title Only
         Text(
-          text = titleText,
+          text = displayTitle,
           style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
           color = MaterialTheme.colorScheme.onSurface,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
           modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE)
         )
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(2.dp))
+
+        // 2. Singer / Artist Name
+        Text(
+          text = displayArtist,
+          style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Medium),
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE)
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+
+        // 3. Track Info | A-B Loop Control
         val playlistInfo = viewModel.getPlaylistInfo()
         val trackText = if (playlistInfo != null) "Track $playlistInfo" else "Audio Media"
 
@@ -432,19 +492,16 @@ fun AudioPlayerControls(
         ) {
           Text(
             text = trackText,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
           )
-
           Text(
             text = "|",
-            style = MaterialTheme.typography.titleMedium,
+            style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
           )
-
-          // A-B Loop Control from video player
           AnimatedContent(
             targetState = abLoop.isExpanded,
             transitionSpec = {
@@ -461,10 +518,7 @@ fun AudioPlayerControls(
                 Surface(
                   shape = CircleShape,
                   color = if (abLoopA != null) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
-                  modifier = Modifier
-                    .height(30.dp)
-                    .clip(CircleShape)
-                    .clickable(onClick = { viewModel.setLoopA() }),
+                  modifier = Modifier.height(30.dp).clip(CircleShape).clickable(onClick = { viewModel.setLoopA() }),
                 ) {
                   Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(horizontal = 10.dp)) {
                     Text(
@@ -474,35 +528,19 @@ fun AudioPlayerControls(
                     )
                   }
                 }
-
                 Surface(
                   shape = CircleShape,
                   color = MaterialTheme.colorScheme.surfaceVariant,
-                  modifier = Modifier
-                    .size(30.dp)
-                    .clip(CircleShape)
-                    .clickable(onClick = {
-                      viewModel.clearABLoop()
-                      viewModel.toggleABLoopExpanded()
-                    }),
+                  modifier = Modifier.size(30.dp).clip(CircleShape).clickable(onClick = { viewModel.clearABLoop(); viewModel.toggleABLoopExpanded() }),
                 ) {
                   Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                      imageVector = Icons.RoundedFilled.Close,
-                      contentDescription = "Clear A-B Loop",
-                      tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                      modifier = Modifier.size(16.dp),
-                    )
+                    Icon(imageVector = Icons.RoundedFilled.Close, contentDescription = "Clear A-B Loop", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(16.dp))
                   }
                 }
-
                 Surface(
                   shape = CircleShape,
                   color = if (abLoopB != null) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
-                  modifier = Modifier
-                    .height(30.dp)
-                    .clip(CircleShape)
-                    .clickable(onClick = { viewModel.setLoopB() }),
+                  modifier = Modifier.height(30.dp).clip(CircleShape).clickable(onClick = { viewModel.setLoopB() }),
                 ) {
                   Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(horizontal = 10.dp)) {
                     Text(
@@ -517,9 +555,7 @@ fun AudioPlayerControls(
               Surface(
                 shape = CircleShape,
                 color = Color.Transparent,
-                modifier = Modifier
-                  .clip(CircleShape)
-                  .clickable(onClick = viewModel::toggleABLoopExpanded)
+                modifier = Modifier.clip(CircleShape).clickable(onClick = viewModel::toggleABLoopExpanded)
               ) {
                 AbLoopIcon(
                   modifier = Modifier.size(30.dp),
@@ -532,24 +568,17 @@ fun AudioPlayerControls(
           }
         }
       }
+    }
 
-      Spacer(modifier = Modifier.height(16.dp))
-
-      // 3. Audio Transport Controls (Video player seekbar component & style)
+    val seekbarView = @Composable {
       SeekbarWithTimers(
         position = currentPosSec,
         committedPosition = currentPosSec,
         duration = currentDurSec.coerceAtLeast(1f),
-        onValueChange = { value ->
-          viewModel.seekTo(value.toInt(), fast = true)
-        },
-        onValueChangeFinished = { targetPosition ->
-          viewModel.seekTo(targetPosition.toInt(), fast = false)
-        },
+        onValueChange = { value -> viewModel.seekTo(value.toInt(), fast = true) },
+        onValueChangeFinished = { targetPosition -> viewModel.seekTo(targetPosition.toInt(), fast = false) },
         timersInverted = Pair(false, invertDuration),
-        durationTimerOnCLick = {
-          playerPreferences.invertDuration.set(!invertDuration)
-        },
+        durationTimerOnCLick = { playerPreferences.invertDuration.set(!invertDuration) },
         positionTimerOnClick = {},
         chapters = seekbarChapters,
         skipSegments = persistentListOf(),
@@ -557,23 +586,19 @@ fun AudioPlayerControls(
         seekbarStyle = seekbarStyle,
         loopStart = abLoopA?.toFloat(),
         loopEnd = abLoopB?.toFloat(),
-        isPortrait = true,
+        isPortrait = isPortrait,
         applyHorizontalPadding = false,
         modifier = Modifier.fillMaxWidth()
       )
+    }
 
-      Spacer(modifier = Modifier.height(16.dp))
-
-      // Main Playback Controls Row (Skip Previous, Seek -30s, Play/Pause, Seek +30s, Skip Next)
+    val playbackControlsRow = @Composable {
       Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically,
       ) {
-        IconButton(
-          onClick = { viewModel.playPrevious() },
-          enabled = playlistModeEnabled
-        ) {
+        ReactiveIconButton(onClick = { viewModel.playPrevious() }, enabled = playlistModeEnabled) {
           Icon(
             imageVector = Icons.RoundedFilled.SkipPrevious,
             contentDescription = null,
@@ -581,21 +606,14 @@ fun AudioPlayerControls(
             modifier = Modifier.size(28.dp)
           )
         }
-
-        IconButton(onClick = { viewModel.seekBy(-30) }) {
-          Icon(
-            imageVector = Icons.RoundedFilled.FastRewind,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(34.dp)
-          )
+        ReactiveIconButton(onClick = { viewModel.seekBy(-30) }) {
+          Icon(imageVector = Icons.RoundedFilled.FastRewind, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(34.dp))
         }
-
-        Surface(
+        ReactiveSurfaceButton(
           onClick = { viewModel.pauseUnpause() },
           shape = CircleShape,
           color = MaterialTheme.colorScheme.primary,
-          modifier = Modifier.size(76.dp),
+          modifier = Modifier.size(if (isPortrait) 76.dp else 64.dp),
           shadowElevation = 8.dp,
         ) {
           Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
@@ -603,24 +621,14 @@ fun AudioPlayerControls(
               imageVector = if (isPlaying) Icons.RoundedFilled.Pause else Icons.RoundedFilled.PlayArrow,
               contentDescription = null,
               tint = MaterialTheme.colorScheme.onPrimary,
-              modifier = Modifier.size(38.dp)
+              modifier = Modifier.size(if (isPortrait) 44.dp else 36.dp)
             )
           }
         }
-
-        IconButton(onClick = { viewModel.seekBy(30) }) {
-          Icon(
-            imageVector = Icons.RoundedFilled.FastForward,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(34.dp)
-          )
+        ReactiveIconButton(onClick = { viewModel.seekBy(30) }) {
+          Icon(imageVector = Icons.RoundedFilled.FastForward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(34.dp))
         }
-
-        IconButton(
-          onClick = { viewModel.playNext() },
-          enabled = playlistModeEnabled
-        ) {
+        ReactiveIconButton(onClick = { viewModel.playNext() }, enabled = playlistModeEnabled) {
           Icon(
             imageVector = Icons.RoundedFilled.SkipNext,
             contentDescription = null,
@@ -629,96 +637,92 @@ fun AudioPlayerControls(
           )
         }
       }
+    }
 
-      Spacer(modifier = Modifier.height(24.dp))
-
-      // 4. Bottom Action Row (Equalizer on Left, Center Pill Bar, Playlist on Right)
+    val bottomActionRow = @Composable {
       Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
       ) {
-        // Bottom Left: Equalizer Button
-        IconButton(
+        ReactiveIconButton(
           onClick = { onOpenSheet(Sheets.Equalizer) },
-          modifier = Modifier
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f))
-            .size(48.dp)
+          modifier = Modifier.clip(CircleShape).background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f)).size(48.dp)
         ) {
           Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-            Icon(
-              imageVector = Icons.RoundedFilled.Equalizer,
-              contentDescription = "Equalizer",
-              tint = MaterialTheme.colorScheme.onSurface,
-              modifier = Modifier.size(24.dp)
-            )
+            Icon(imageVector = Icons.RoundedFilled.Equalizer, contentDescription = "Equalizer", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(24.dp))
           }
         }
-
-        // Center Pill Bar (Shuffle, Repeat, Visualizer)
         Row(
-          modifier = Modifier
-            .clip(RoundedCornerShape(50))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f))
-            .padding(horizontal = 12.dp, vertical = 4.dp),
+          modifier = Modifier.clip(RoundedCornerShape(50)).background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f)).padding(horizontal = 12.dp, vertical = 4.dp),
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-          IconButton(
-            onClick = viewModel::toggleShuffle,
-            enabled = playlistModeEnabled
-          ) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-              Icon(
-                imageVector = if (shuffleEnabled) Icons.RoundedFilled.ShuffleOn else Icons.RoundedFilled.Shuffle,
-                contentDescription = null,
-                tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-              )
-            }
+          ReactiveIconButton(onClick = viewModel::toggleShuffle, enabled = playlistModeEnabled) {
+            Icon(imageVector = if (shuffleEnabled) Icons.RoundedFilled.ShuffleOn else Icons.RoundedFilled.Shuffle, contentDescription = null, tint = if (shuffleEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant)
           }
-
-          IconButton(onClick = viewModel::cycleRepeatMode) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-              Icon(
-                imageVector = when (repeatMode) {
-                  RepeatMode.OFF -> Icons.RoundedFilled.Repeat
-                  RepeatMode.ONE -> Icons.RoundedFilled.RepeatOne
-                  RepeatMode.ALL -> Icons.RoundedFilled.RepeatOn
-                },
-                contentDescription = null,
-                tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-              )
-            }
-          }
-
-          IconButton(onClick = viewModel::toggleAudioVisualizer) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
-              Icon(
-                imageVector = if (showVisualizer) Icons.RoundedFilled.AutoAwesome else Icons.RoundedFilled.Audiotrack,
-                contentDescription = null,
-                tint = if (showVisualizer) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-              )
-            }
-          }
-        }
-
-        // Bottom Right: Playlist Button
-        IconButton(
-          onClick = { onOpenSheet(Sheets.Playlist) },
-          modifier = Modifier
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f))
-            .size(48.dp)
-        ) {
-          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+          ReactiveIconButton(onClick = viewModel::cycleRepeatMode) {
             Icon(
-              imageVector = Icons.RoundedFilled.QueueMusic,
-              contentDescription = "Playlist",
-              tint = MaterialTheme.colorScheme.onSurface,
-              modifier = Modifier.size(24.dp)
+              imageVector = when (repeatMode) {
+                RepeatMode.OFF -> Icons.RoundedFilled.Repeat
+                RepeatMode.ONE -> Icons.RoundedFilled.RepeatOne
+                RepeatMode.ALL -> Icons.RoundedFilled.RepeatOn
+              },
+              contentDescription = null,
+              tint = if (repeatMode != RepeatMode.OFF) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
             )
           }
+          ReactiveIconButton(onClick = viewModel::toggleAudioVisualizer) {
+            Icon(imageVector = if (showVisualizer) Icons.RoundedFilled.AutoAwesome else Icons.RoundedFilled.Audiotrack, contentDescription = null, tint = if (showVisualizer) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant)
+          }
+        }
+        ReactiveIconButton(
+          onClick = { onOpenSheet(Sheets.Playlist) },
+          modifier = Modifier.clip(CircleShape).background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.65f)).size(48.dp)
+        ) {
+          Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Icon(imageVector = Icons.RoundedFilled.QueueMusic, contentDescription = "Playlist", tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(24.dp))
+          }
+        }
+      }
+    }
+
+    if (isPortrait) {
+      Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        headerBar()
+        losslessBadge()
+        Spacer(modifier = Modifier.height(16.dp))
+        centerVisualizerView(Modifier.weight(1f).fillMaxWidth())
+        Spacer(modifier = Modifier.height(16.dp))
+        trackMetadataView()
+        Spacer(modifier = Modifier.height(16.dp))
+        seekbarView()
+        Spacer(modifier = Modifier.height(16.dp))
+        playbackControlsRow()
+        Spacer(modifier = Modifier.height(24.dp))
+        bottomActionRow()
+      }
+    } else {
+      Row(
+        modifier = Modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        centerVisualizerView(Modifier.weight(1f).fillMaxHeight())
+        Column(
+          modifier = Modifier.weight(1.2f).fillMaxHeight(),
+          verticalArrangement = Arrangement.SpaceBetween,
+          horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          headerBar()
+          losslessBadge()
+          trackMetadataView()
+          seekbarView()
+          playbackControlsRow()
+          bottomActionRow()
         }
       }
     }
@@ -734,5 +738,77 @@ private fun formatSec(totalSeconds: Long): String {
     String.format(Locale.US, "%d:%02d:%02d", hours, minutes, remainingSecs)
   } else {
     String.format(Locale.US, "%d:%02d", minutes, remainingSecs)
+  }
+}
+
+@Composable
+private fun ReactiveIconButton(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  content: @Composable () -> Unit,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  val isPressed by interactionSource.collectIsPressedAsState()
+  val haptic = LocalHapticFeedback.current
+
+  val scale by animateFloatAsState(
+    targetValue = if (isPressed) 0.82f else 1f,
+    animationSpec = spring(dampingRatio = 0.55f, stiffness = 900f),
+    label = "reactive_icon_button_scale",
+  )
+
+  IconButton(
+    onClick = {
+      haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+      onClick()
+    },
+    enabled = enabled,
+    interactionSource = interactionSource,
+    modifier = modifier.graphicsLayer {
+      scaleX = scale
+      scaleY = scale
+    },
+  ) {
+    content()
+  }
+}
+
+@Composable
+private fun ReactiveSurfaceButton(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  shape: Shape = CircleShape,
+  color: Color = MaterialTheme.colorScheme.primary,
+  shadowElevation: Dp = 0.dp,
+  enabled: Boolean = true,
+  content: @Composable () -> Unit,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  val isPressed by interactionSource.collectIsPressedAsState()
+  val haptic = LocalHapticFeedback.current
+
+  val scale by animateFloatAsState(
+    targetValue = if (isPressed) 0.88f else 1f,
+    animationSpec = spring(dampingRatio = 0.55f, stiffness = 900f),
+    label = "reactive_surface_button_scale",
+  )
+
+  Surface(
+    onClick = {
+      haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+      onClick()
+    },
+    shape = shape,
+    color = color,
+    shadowElevation = shadowElevation,
+    enabled = enabled,
+    interactionSource = interactionSource,
+    modifier = modifier.graphicsLayer {
+      scaleX = scale
+      scaleY = scale
+    },
+  ) {
+    content()
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
@@ -297,6 +297,83 @@ fun PlayerControls(
     }
   }
 
+  val isAudioOnly by viewModel.isAudioOnly.collectAsState()
+  if (isAudioOnly) {
+    val rawMediaTitle by MPVLib.propString["media-title"].collectAsState()
+    val activity = LocalActivity.current as? PlayerActivity
+    val mediaTitle = remember(rawMediaTitle, activity) {
+      rawMediaTitle?.takeIf { it.isNotBlank() } ?: activity?.getTitleForControls()
+    }
+
+    val sheetShown by viewModel.sheetShown.collectAsState()
+    val subtitles by viewModel.subtitleTracks.collectAsState(persistentListOf())
+    val audioTracks by viewModel.audioTracks.collectAsState(persistentListOf())
+    val sleepTimerTimeRemaining by viewModel.remainingTime.collectAsState()
+    val speedPresets by playerPreferences.speedPresets.collectAsState()
+    val sortedSpeedPresets = remember(speedPresets) { speedPresets.map { it.toFloat() }.sorted() }
+
+    Box(modifier = modifier.fillMaxSize()) {
+      AudioPlayerControls(
+        viewModel = viewModel,
+        mediaTitle = mediaTitle,
+        onBackPress = onBackPress,
+        onOpenSheet = onOpenSheet,
+        onOpenPanel = onOpenPanel,
+      )
+
+      PlayerSheets(
+        viewModel = viewModel,
+        sheetShown = sheetShown,
+        subtitles = subtitles.toImmutableList(),
+        onAddSubtitle = viewModel::addSubtitle,
+        onToggleSubtitle = viewModel::toggleSubtitle,
+        isSubtitleSelected = viewModel::isSubtitleSelected,
+        subtitleSelectionIndicator = viewModel::subtitleSelectionIndicator,
+        onRemoveSubtitle = viewModel::removeSubtitle,
+        audioTracks = audioTracks.toImmutableList(),
+        onAddAudio = viewModel::addAudio,
+        onSelectAudio = {
+          if (getTrackSelectionId("aid") == it.id) {
+            setTrackSelectionId("aid", null)
+          } else {
+            setTrackSelectionId("aid", it.id)
+          }
+        },
+        chapter = chapters.getOrNull(currentChapter ?: 0),
+        chapters = chapters.toImmutableList(),
+        onSeekToChapter = {
+          MPVLib.setPropertyInt("chapter", it)
+          viewModel.unpause()
+        },
+        decoder = decoder,
+        onUpdateDecoder = { MPVLib.setPropertyString("hwdec", it.value) },
+        speed = playbackSpeed ?: playerPreferences.defaultSpeed.get(),
+        onSpeedChange = { MPVLib.setPropertyFloat("speed", it.toFixed(2)) },
+        onMakeDefaultSpeed = { playerPreferences.defaultSpeed.set(it.toFixed(2)) },
+        onAddSpeedPreset = { playerPreferences.speedPresets += it.toFixed(2).toString() },
+        onRemoveSpeedPreset = { playerPreferences.speedPresets -= it.toFixed(2).toString() },
+        onResetSpeedPresets = playerPreferences.speedPresets::delete,
+        speedPresets = sortedSpeedPresets,
+        onResetDefaultSpeed = {
+          MPVLib.setPropertyFloat("speed", playerPreferences.defaultSpeed.deleteAndGet().toFixed(2))
+        },
+        sleepTimerTimeRemaining = sleepTimerTimeRemaining,
+        onStartSleepTimer = viewModel::startTimer,
+        onOpenPanel = onOpenPanel,
+        onShowSheet = onOpenSheet,
+        onDismissRequest = { onOpenSheet(Sheets.None) },
+      )
+
+      val panel by viewModel.panelShown.collectAsState()
+      PlayerPanels(
+        panelShown = panel,
+        viewModel = viewModel,
+        onDismissRequest = { onOpenPanel(Panels.None) },
+      )
+    }
+    return
+  }
+
   val topRightControlsPref by appearancePreferences.topRightControls.collectAsState()
   val bottomRightControlsPref by appearancePreferences.bottomRightControls.collectAsState()
   val bottomLeftControlsPref by appearancePreferences.bottomLeftControls.collectAsState()
@@ -328,8 +405,9 @@ fun PlayerControls(
     resetControlsTimestamp,
     areControlsLocked,
     isUnlockSliderDragging,
+    isAudioOnly,
   ) {
-    if (controlsShown && paused == false && !isSeeking && !isUnlockSliderDragging) {
+    if (!isAudioOnly && controlsShown && paused == false && !isSeeking && !isUnlockSliderDragging) {
       // Use 2 second delay when controls are locked, otherwise use user preference
       val delayTime = if (areControlsLocked) 2000L else playerTimeToDisappear.toLong()
       delay(delayTime)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
@@ -410,5 +410,17 @@ fun PlayerSheets(
         onDismissRequest = onDismissRequest
       )
     }
+
+    Sheets.Equalizer -> {
+      val equalizerState by viewModel.equalizerState.collectAsState()
+      app.gyrolet.mpvrx.ui.player.controls.components.sheets.EqualizerSheet(
+        state = equalizerState,
+        onEnabledChanged = viewModel::setEqualizerEnabled,
+        onPresetSelected = viewModel::applyEqualizerPreset,
+        onBandChanged = viewModel::setEqualizerBandGain,
+        onVolumeBoostChanged = viewModel::setEqualizerVolumeBoost,
+        onDismissRequest = onDismissRequest
+      )
+    }
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
@@ -367,13 +367,23 @@ fun PlayerSheets(
 
       // Observe playlist updates
       val playlist by viewModel.playlistItems.collectAsState()
+      val isAudioOnly by viewModel.isAudioOnly.collectAsState()
       val playerPreferences = koinInject<app.gyrolet.mpvrx.preferences.PlayerPreferences>()
       val isPlaylistSwipeActive by viewModel.isPlaylistSwipeActive.collectAsState()
       val playlistSwipeOffset by viewModel.playlistSwipeOffset.collectAsState()
 
-      if (playlist.isNotEmpty()) {
-        val playlistImmutable = playlist.toImmutableList()
-        val totalCount = viewModel.getPlaylistTotalCount()
+      val filteredPlaylist = remember(playlist, isAudioOnly) {
+        if (isAudioOnly) {
+          val audioOnly = playlist.filter { it.isAudio || isAudioOnly }
+          audioOnly.ifEmpty { playlist }
+        } else {
+          playlist
+        }
+      }
+
+      if (filteredPlaylist.isNotEmpty()) {
+        val playlistImmutable = filteredPlaylist.toImmutableList()
+        val totalCount = filteredPlaylist.size
         val isM3U = viewModel.isPlaylistM3U()
         PlaylistSheet(
           playlist = playlistImmutable,
@@ -389,6 +399,7 @@ fun PlayerSheets(
           playerPreferences = playerPreferences,
           isSwipeActive = isPlaylistSwipeActive,
           swipeOffset = playlistSwipeOffset,
+          isAudioOnly = isAudioOnly,
         )
       }
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
@@ -422,5 +422,13 @@ fun PlayerSheets(
         onDismissRequest = onDismissRequest
       )
     }
+
+    Sheets.AudioProperties -> {
+      val properties = remember { viewModel.getAudioPropertiesData() }
+      app.gyrolet.mpvrx.ui.player.controls.components.sheets.AudioPropertiesSheet(
+        properties = properties,
+        onDismissRequest = onDismissRequest
+      )
+    }
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/Seekbar.kt
@@ -236,6 +236,7 @@ fun SeekbarWithTimers(
   loopEnd: Float? = null,
   bufferDuration: Float? = null,
   isPortrait: Boolean = false,
+  applyHorizontalPadding: Boolean = true,
   modifier: Modifier = Modifier,
 ) {
   val clickEvent = LocalPlayerButtonsClickEvent.current
@@ -267,7 +268,7 @@ fun SeekbarWithTimers(
     Column(
       modifier = modifier
         .fillMaxWidth()
-        .padding(horizontal = MaterialTheme.spacing.large),
+        .then(if (applyHorizontalPadding) Modifier.padding(horizontal = MaterialTheme.spacing.large) else Modifier),
       verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
       SeekbarContent(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/AudioPropertiesSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/AudioPropertiesSheet.kt
@@ -1,0 +1,98 @@
+package app.gyrolet.mpvrx.ui.player.controls.components.sheets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.gyrolet.mpvrx.ui.player.PlayerViewModel
+
+data class AudioPropertyItem(
+  val label: String,
+  val value: String,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AudioPropertiesSheet(
+  properties: List<AudioPropertyItem>,
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+  ModalBottomSheet(
+    onDismissRequest = onDismissRequest,
+    sheetState = sheetState,
+    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    dragHandle = null,
+    modifier = modifier,
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .verticalScroll(rememberScrollState())
+        .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 48.dp)
+    ) {
+      Text(
+        text = "AUDIO PROPERTIES",
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        letterSpacing = 2.sp,
+        fontWeight = FontWeight.SemiBold,
+      )
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      properties.forEachIndexed { index, prop ->
+        Column(
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f))
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+          Text(
+            text = prop.label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.sp
+          )
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+            text = prop.value.ifBlank { "Unknown" },
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis
+          )
+        }
+        if (index < properties.lastIndex) {
+          Spacer(modifier = Modifier.height(8.dp))
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/EqualizerSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/EqualizerSheet.kt
@@ -1,0 +1,328 @@
+package app.gyrolet.mpvrx.ui.player.controls.components.sheets
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.roundToInt
+
+enum class EqualizerPreset(val displayName: String, val gains: List<Int>) {
+  FLAT("Flat", listOf(0, 0, 0, 0, 0)),
+  ROCK("Rock", listOf(4, 2, -1, 2, 4)),
+  POP("Pop", listOf(-1, 2, 4, 2, -1)),
+  JAZZ("Jazz", listOf(3, 2, -1, 2, 3)),
+  CLASSICAL("Classical", listOf(3, 1, -1, 2, 3)),
+  ELECTRONIC("Electronic", listOf(5, 3, 0, 2, 4)),
+  BASS_BOOST("Bass Boost", listOf(5, 3, 0, -1, -2)),
+  TREBLE_BOOST("Treble Boost", listOf(-2, -1, 0, 3, 5)),
+  VOICE_BOOST("Voice Boost", listOf(2, 4, 5, 3, 1)),
+  LOUDNESS("Loudness", listOf(4, 2, 0, 2, 4)),
+  CUSTOM("Custom", listOf(0, 0, 0, 0, 0));
+
+  companion object {
+    val MUSIC = listOf(
+      FLAT,
+      ROCK,
+      POP,
+      JAZZ,
+      CLASSICAL,
+      ELECTRONIC,
+      BASS_BOOST,
+      TREBLE_BOOST,
+      VOICE_BOOST,
+      LOUDNESS,
+    )
+  }
+}
+
+val EQ_BAND_LABELS = listOf("60Hz", "230Hz", "910Hz", "3.6kHz", "14kHz")
+const val EQ_MIN_DB = -15
+const val EQ_MAX_DB = 15
+
+data class EqualizerState(
+  val isEnabled: Boolean = false,
+  val currentPreset: EqualizerPreset = EqualizerPreset.FLAT,
+  val bandGains: List<Int> = List(5) { 0 },
+  val volumeBoostDb: Int = 0,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EqualizerSheet(
+  state: EqualizerState,
+  onEnabledChanged: (Boolean) -> Unit,
+  onPresetSelected: (EqualizerPreset) -> Unit,
+  onBandChanged: (bandIndex: Int, gainDb: Int) -> Unit,
+  onVolumeBoostChanged: (Int) -> Unit,
+  onDismissRequest: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+  ModalBottomSheet(
+    onDismissRequest = onDismissRequest,
+    sheetState = sheetState,
+    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    dragHandle = null,
+    modifier = modifier,
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .verticalScroll(rememberScrollState())
+        .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 48.dp)
+    ) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = "EQUALIZER",
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          letterSpacing = 2.sp,
+          fontWeight = FontWeight.SemiBold,
+        )
+        Switch(
+          checked = state.isEnabled,
+          onCheckedChange = onEnabledChanged,
+          colors = SwitchDefaults.colors(
+            checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+            checkedTrackColor = MaterialTheme.colorScheme.primary,
+            uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+            uncheckedTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            uncheckedBorderColor = MaterialTheme.colorScheme.outline,
+          ),
+          modifier = Modifier.scale(0.8f),
+        )
+      }
+
+      Spacer(modifier = Modifier.height(16.dp))
+
+      val presetsToShow = if (state.currentPreset == EqualizerPreset.CUSTOM) {
+        listOf(EqualizerPreset.CUSTOM) + EqualizerPreset.MUSIC
+      } else {
+        EqualizerPreset.MUSIC
+      }
+
+      LazyRow(
+        contentPadding = PaddingValues(horizontal = 0.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        items(presetsToShow, key = { it.name }) { preset ->
+          PresetChip(
+            preset = preset,
+            isSelected = preset == state.currentPreset,
+            onClick = if (preset != EqualizerPreset.CUSTOM) {
+              { onPresetSelected(preset) }
+            } else null,
+          )
+        }
+      }
+
+      Spacer(modifier = Modifier.height(32.dp))
+
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(220.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        state.bandGains.forEachIndexed { index, gain ->
+          BandColumn(
+            label = EQ_BAND_LABELS.getOrElse(index) { "" },
+            gainDb = gain,
+            isEnabled = state.isEnabled,
+            onGainChanged = { db -> onBandChanged(index, db) },
+            modifier = Modifier.weight(1f),
+          )
+        }
+      }
+
+      HorizontalDivider(
+        modifier = Modifier.padding(vertical = 24.dp),
+        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+      )
+
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = "VOLUME BOOST",
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          letterSpacing = 2.sp,
+          fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+          text = if (state.volumeBoostDb > 0) "+${state.volumeBoostDb} dB" else "Off",
+          style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+          color = if (state.volumeBoostDb > 0) MaterialTheme.colorScheme.primary
+          else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      Slider(
+        value = state.volumeBoostDb.toFloat(),
+        onValueChange = { onVolumeBoostChanged(it.roundToInt()) },
+        valueRange = 0f..10f,
+        steps = 9,
+        modifier = Modifier.fillMaxWidth(),
+      )
+
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+      ) {
+        Text(
+          text = "0 dB",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+          text = "+10 dB",
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun PresetChip(
+  preset: EqualizerPreset,
+  isSelected: Boolean,
+  onClick: (() -> Unit)?,
+) {
+  Box(
+    contentAlignment = Alignment.Center,
+    modifier = Modifier
+      .clip(RoundedCornerShape(50))
+      .background(
+        if (isSelected) MaterialTheme.colorScheme.primaryContainer
+        else Color.Transparent
+      )
+      .border(
+        BorderStroke(
+          1.dp,
+          if (isSelected) Color.Transparent
+          else MaterialTheme.colorScheme.outlineVariant,
+        ),
+        RoundedCornerShape(50),
+      )
+      .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+      .padding(horizontal = 16.dp, vertical = 8.dp),
+  ) {
+    Text(
+      text = preset.displayName,
+      style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Medium),
+      color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+      else MaterialTheme.colorScheme.onSurface,
+    )
+  }
+}
+
+@Composable
+private fun BandColumn(
+  label: String,
+  gainDb: Int,
+  isEnabled: Boolean,
+  onGainChanged: (Int) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier.fillMaxHeight(),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    val gainText = if (gainDb > 0) "+$gainDb" else "$gainDb"
+    Text(
+      text = gainText,
+      style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+      color = if (isEnabled) MaterialTheme.colorScheme.primary
+      else MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+
+    Slider(
+      value = gainDb.toFloat(),
+      onValueChange = { onGainChanged(it.roundToInt()) },
+      valueRange = EQ_MIN_DB.toFloat()..EQ_MAX_DB.toFloat(),
+      enabled = isEnabled,
+      modifier = Modifier
+        .weight(1f)
+        .padding(vertical = 12.dp)
+        .layout { measurable, constraints ->
+          val placeable = measurable.measure(
+            Constraints(
+              minWidth = constraints.minHeight,
+              maxWidth = constraints.maxHeight,
+              minHeight = constraints.minWidth,
+              maxHeight = constraints.maxWidth,
+            )
+          )
+          layout(placeable.height, placeable.width) {
+            placeable.place(
+              x = -(placeable.width / 2 - placeable.height / 2),
+              y = -(placeable.height / 2 - placeable.width / 2),
+            )
+          }
+        }
+        .graphicsLayer {
+          rotationZ = -90f
+          transformOrigin = TransformOrigin.Center
+        },
+    )
+
+    Text(
+      text = label,
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/EqualizerSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/EqualizerSheet.kt
@@ -29,8 +29,13 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
@@ -153,6 +158,7 @@ fun EqualizerSheet(
           PresetChip(
             preset = preset,
             isSelected = preset == state.currentPreset,
+            isEnabled = state.isEnabled,
             onClick = if (preset != EqualizerPreset.CUSTOM) {
               { onPresetSelected(preset) }
             } else null,
@@ -192,25 +198,34 @@ fun EqualizerSheet(
         Text(
           text = "VOLUME BOOST",
           style = MaterialTheme.typography.labelMedium,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          color = if (state.isEnabled) MaterialTheme.colorScheme.onSurfaceVariant
+          else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
           letterSpacing = 2.sp,
           fontWeight = FontWeight.SemiBold,
         )
         Text(
           text = if (state.volumeBoostDb > 0) "+${state.volumeBoostDb} dB" else "Off",
           style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
-          color = if (state.volumeBoostDb > 0) MaterialTheme.colorScheme.primary
-          else MaterialTheme.colorScheme.onSurfaceVariant,
+          color = if (state.isEnabled) {
+            if (state.volumeBoostDb > 0) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurfaceVariant
+          } else {
+            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+          },
         )
       }
 
       Spacer(modifier = Modifier.height(8.dp))
 
+      var volumeBoostValue by remember(state.volumeBoostDb) { mutableFloatStateOf(state.volumeBoostDb.toFloat()) }
       Slider(
-        value = state.volumeBoostDb.toFloat(),
-        onValueChange = { onVolumeBoostChanged(it.roundToInt()) },
+        value = volumeBoostValue,
+        onValueChange = { newValue ->
+          volumeBoostValue = newValue
+          onVolumeBoostChanged(newValue.roundToInt())
+        },
         valueRange = 0f..10f,
-        steps = 9,
+        enabled = state.isEnabled,
         modifier = Modifier.fillMaxWidth(),
       )
 
@@ -221,12 +236,14 @@ fun EqualizerSheet(
         Text(
           text = "0 dB",
           style = MaterialTheme.typography.labelSmall,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          color = if (state.isEnabled) MaterialTheme.colorScheme.onSurfaceVariant
+          else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
         )
         Text(
           text = "+10 dB",
           style = MaterialTheme.typography.labelSmall,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          color = if (state.isEnabled) MaterialTheme.colorScheme.onSurfaceVariant
+          else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
         )
       }
     }
@@ -237,11 +254,13 @@ fun EqualizerSheet(
 private fun PresetChip(
   preset: EqualizerPreset,
   isSelected: Boolean,
+  isEnabled: Boolean,
   onClick: (() -> Unit)?,
 ) {
   Box(
     contentAlignment = Alignment.Center,
     modifier = Modifier
+      .alpha(if (isEnabled) 1f else 0.38f)
       .clip(RoundedCornerShape(50))
       .background(
         if (isSelected) MaterialTheme.colorScheme.primaryContainer
@@ -255,7 +274,7 @@ private fun PresetChip(
         ),
         RoundedCornerShape(50),
       )
-      .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+      .then(if (isEnabled && onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
       .padding(horizontal = 16.dp, vertical = 8.dp),
   ) {
     Text(
@@ -275,11 +294,14 @@ private fun BandColumn(
   onGainChanged: (Int) -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  var sliderValue by remember(gainDb) { mutableFloatStateOf(gainDb.toFloat()) }
+
   Column(
     modifier = modifier.fillMaxHeight(),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    val gainText = if (gainDb > 0) "+$gainDb" else "$gainDb"
+    val displayGain = sliderValue.roundToInt()
+    val gainText = if (displayGain > 0) "+$displayGain" else "$displayGain"
     Text(
       text = gainText,
       style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
@@ -289,8 +311,11 @@ private fun BandColumn(
     )
 
     Slider(
-      value = gainDb.toFloat(),
-      onValueChange = { onGainChanged(it.roundToInt()) },
+      value = sliderValue,
+      onValueChange = { newValue ->
+        sliderValue = newValue
+        onGainChanged(newValue.roundToInt())
+      },
       valueRange = EQ_MIN_DB.toFloat()..EQ_MAX_DB.toFloat(),
       enabled = isEnabled,
       modifier = Modifier

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/PlaylistSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/PlaylistSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -115,15 +116,18 @@ private fun PlaylistThumbnail(
       resolution = item.resolution,
     )
   }
-  val thumbnailKey = remember(video) {
-    thumbnailRepository.thumbnailKey(video, PLAYLIST_THUMBNAIL_WIDTH, PLAYLIST_THUMBNAIL_HEIGHT)
+  val (thumbWidth, thumbHeight) = remember(item.isAudio) {
+    if (item.isAudio) 512 to 512 else PLAYLIST_THUMBNAIL_WIDTH to PLAYLIST_THUMBNAIL_HEIGHT
+  }
+  val thumbnailKey = remember(video, thumbWidth, thumbHeight) {
+    thumbnailRepository.thumbnailKey(video, thumbWidth, thumbHeight)
   }
   var bitmap by remember(thumbnailKey) {
     mutableStateOf(
       thumbnailRepository.getThumbnailFromMemory(
         video,
-        PLAYLIST_THUMBNAIL_WIDTH,
-        PLAYLIST_THUMBNAIL_HEIGHT,
+        thumbWidth,
+        thumbHeight,
       ),
     )
   }
@@ -133,8 +137,8 @@ private fun PlaylistThumbnail(
       bitmap = withContext(Dispatchers.IO) {
         thumbnailRepository.getThumbnail(
           video,
-          PLAYLIST_THUMBNAIL_WIDTH,
-          PLAYLIST_THUMBNAIL_HEIGHT,
+          thumbWidth,
+          thumbHeight,
         )
       }
     }
@@ -172,6 +176,7 @@ fun PlaylistSheet(
   playerPreferences: app.gyrolet.mpvrx.preferences.PlayerPreferences,
   isSwipeActive: Boolean = false,
   swipeOffset: Float = 0f,
+  isAudioOnly: Boolean = false,
   modifier: Modifier = Modifier,
 ) {
   val configuration = LocalConfiguration.current
@@ -315,7 +320,8 @@ fun PlaylistSheet(
 
           LazyColumn(
             state = lazyListState,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(bottom = 16.dp),
           ) {
             items(playlist.size, key = { index -> playlist[index].uri.toString() }) { index ->
               val item = playlist[index]
@@ -327,6 +333,7 @@ fun PlaylistSheet(
                     onClick = { onItemClick(item) },
                     skipThumbnail = false,
                     accentColor = accentColor,
+                    isAudioOnly = isAudioOnly,
                     dragHandle = {
                       DragHandle(scope = this, isDragging = isDragging)
                     }
@@ -338,7 +345,8 @@ fun PlaylistSheet(
                   thumbnailRepository = thumbnailRepository,
                   onClick = { onItemClick(item) },
                   skipThumbnail = false,
-                  accentColor = accentColor
+                  accentColor = accentColor,
+                  isAudioOnly = isAudioOnly,
                 )
               }
             }
@@ -361,6 +369,7 @@ fun PlaylistSheet(
                   onItemClick(item)
                 },
                 skipThumbnail = false,
+                isAudioOnly = isAudioOnly,
               )
             }
           }
@@ -413,13 +422,19 @@ fun PlaylistTrackListItem(
   onClick: () -> Unit,
   skipThumbnail: Boolean = false,
   accentColor: Color,
+  isAudioOnly: Boolean = false,
   modifier: Modifier = Modifier,
   dragHandle: @Composable () -> Unit = {},
 ) {
+  val isAudioItem = item.isAudio || isAudioOnly
+  val effectiveItem = remember(item, isAudioItem) {
+    if (item.isAudio != isAudioItem) item.copy(isAudio = isAudioItem) else item
+  }
+
   // Use theme colors dynamically
   val accentSecondary = MaterialTheme.colorScheme.tertiary
 
-  val borderModifier = if (item.isPlaying) {
+  val borderModifier = if (effectiveItem.isPlaying) {
     Modifier.border(
       width = 2.dp,
       brush = Brush.linearGradient(listOf(accentColor, accentSecondary)),
@@ -439,7 +454,7 @@ fun PlaylistTrackListItem(
       .clip(RoundedCornerShape(12.dp))
       .then(borderModifier)
       .clickable(onClick = onClick),
-    color = if (item.isPlaying) {
+    color = if (effectiveItem.isPlaying) {
       MaterialTheme.colorScheme.tertiary.copy(alpha = 0.15f)
     } else {
       Color.Transparent
@@ -456,21 +471,26 @@ fun PlaylistTrackListItem(
       // Thumbnail with simple background, episode number, and progress
       Box(
         modifier = Modifier
-          .width(100.dp)
-          .height(56.dp)
+          .then(
+            if (isAudioItem) {
+              Modifier.size(56.dp)
+            } else {
+              Modifier.width(100.dp).height(56.dp)
+            }
+          )
           .clip(RoundedCornerShape(8.dp))
           .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         contentAlignment = Alignment.Center,
       ) {
         Icon(
-          imageVector = if (item.isAudio) Icons.RoundedFilled.Audiotrack else Icons.RoundedFilled.Videocam,
+          imageVector = if (isAudioItem) Icons.RoundedFilled.Audiotrack else Icons.RoundedFilled.Videocam,
           contentDescription = null,
           tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
           modifier = Modifier.size(24.dp),
         )
         if (!skipThumbnail) {
           PlaylistThumbnail(
-            item = item,
+            item = effectiveItem,
             thumbnailRepository = thumbnailRepository,
             contentDescription = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.ui_thumbnail),
             modifier = Modifier.matchParentSize(),
@@ -595,13 +615,19 @@ fun PlaylistTrackGridItem(
   thumbnailRepository: ThumbnailRepository,
   onClick: () -> Unit,
   skipThumbnail: Boolean = false,
+  isAudioOnly: Boolean = false,
   modifier: Modifier = Modifier,
 ) {
+  val isAudioItem = item.isAudio || isAudioOnly
+  val effectiveItem = remember(item, isAudioItem) {
+    if (item.isAudio != isAudioItem) item.copy(isAudio = isAudioItem) else item
+  }
+
   // Use theme colors dynamically
   val accentColor = MaterialTheme.colorScheme.primary
   val accentSecondary = MaterialTheme.colorScheme.tertiary
 
-  val borderModifier = if (item.isPlaying) {
+  val borderModifier = if (effectiveItem.isPlaying) {
     Modifier.border(
       width = 2.dp,
       brush = Brush.linearGradient(listOf(accentColor, accentSecondary)),
@@ -625,24 +651,30 @@ fun PlaylistTrackGridItem(
       modifier = Modifier.padding(MaterialTheme.spacing.smaller),
       verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
     ) {
-      // Thumbnail with 16:9 aspect ratio
+      // Thumbnail with 1:1 aspect ratio for audio, fixed height for video
       Box(
         modifier = Modifier
           .fillMaxWidth()
-          .height(112.dp)
+          .then(
+            if (isAudioItem) {
+              Modifier.aspectRatio(1f)
+            } else {
+              Modifier.height(112.dp)
+            }
+          )
           .clip(RoundedCornerShape(8.dp))
           .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         contentAlignment = Alignment.Center,
       ) {
         Icon(
-          imageVector = if (item.isAudio) Icons.RoundedFilled.Audiotrack else Icons.RoundedFilled.Videocam,
+          imageVector = if (isAudioItem) Icons.RoundedFilled.Audiotrack else Icons.RoundedFilled.Videocam,
           contentDescription = null,
           tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
           modifier = Modifier.size(32.dp),
         )
         if (!skipThumbnail) {
           PlaylistThumbnail(
-            item = item,
+            item = effectiveItem,
             thumbnailRepository = thumbnailRepository,
             contentDescription = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.ui_thumbnail),
             modifier = Modifier.matchParentSize(),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/PlaylistSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/PlaylistSheet.kt
@@ -222,7 +222,10 @@ fun PlaylistSheet(
   }
 
   val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-  val sheetWidth = if (isListMode) {
+  val isEdgeToEdge = isAudioOnly
+  val sheetWidth = if (isEdgeToEdge) {
+    screenWidth
+  } else if (isListMode) {
     if (LocalConfiguration.current.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE) {
       640.dp
     } else {
@@ -235,8 +238,8 @@ fun PlaylistSheet(
   PlayerSheet(
     onDismissRequest = onDismissRequest,
     modifier = Modifier.fillMaxWidth(),
-    customMaxWidth = sheetWidth,
-    customMaxHeight = if (isPortrait) LocalConfiguration.current.screenHeightDp.dp * 0.5f else null,
+    customMaxWidth = if (isEdgeToEdge) screenWidth else sheetWidth,
+    customMaxHeight = if (isEdgeToEdge) LocalConfiguration.current.screenHeightDp.dp * 0.95f else (if (isPortrait) LocalConfiguration.current.screenHeightDp.dp * 0.5f else null),
     isSwipeActive = isSwipeActive,
     swipeOffset = swipeOffset,
   ) {
@@ -244,8 +247,8 @@ fun PlaylistSheet(
       modifier = Modifier.fillMaxWidth(),
       color = Color.Transparent,
       shape = RoundedCornerShape(
-        topStart = 16.dp,
-        topEnd = 16.dp,
+        topStart = if (isEdgeToEdge) 24.dp else 16.dp,
+        topEnd = if (isEdgeToEdge) 24.dp else 16.dp,
         bottomStart = 0.dp,
         bottomEnd = 0.dp
       ),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobRenderer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobRenderer.kt
@@ -516,6 +516,7 @@ internal class BlobRenderer(
         primaryRgb = next.primaryRgb()
         secondaryRgb = next.secondaryRgb()
         tertiaryRgb = next.tertiaryRgb()
+        GLES30.glClearColor(0f, 0f, 0f, 0f)
         if (appliedPalette == null) {
             smoothR = primaryRgb[0]
             smoothG = primaryRgb[1]

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobRenderer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobRenderer.kt
@@ -130,7 +130,7 @@ internal class BlobRenderer(
     }
 
     override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?) {
-        GLES30.glClearColor(0f, 0f, 0f, 1f)
+        GLES30.glClearColor(0f, 0f, 0f, 0f)
         GLES30.glDisable(GLES30.GL_CULL_FACE)
         GLES30.glDisable(GLES30.GL_DEPTH_TEST)
 
@@ -300,9 +300,9 @@ internal class BlobRenderer(
         Matrix.rotateM(model, 0, if (reducedMotionEnabled) 0f else pitch + time * 1.7f, 1f, 0f, 0f)
         val reactiveScale =
             if (reducedMotionEnabled) {
-                0.94f + audio.energy * 0.025f
+                1.05f + audio.energy * 0.025f
             } else {
-                0.84f + audio.energy * 0.10f + audio.bass * 0.085f + audio.beat * 0.055f
+                1.00f + audio.energy * 0.12f + audio.bass * 0.09f + audio.beat * 0.06f
             }
         val scale = pinchScale * reactiveScale
         Matrix.scaleM(model, 0, scale, scale, scale)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobVisualizerView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobVisualizerView.kt
@@ -25,7 +25,6 @@ internal class BlobVisualizerView(
         setEGLContextClientVersion(3)
         setEGLConfigChooser(8, 8, 8, 8, 16, 0)
         holder.setFormat(PixelFormat.TRANSLUCENT)
-        setZOrderMediaOverlay(true)
         preserveEGLContextOnPause = true
         setRenderer(blobRenderer)
         renderMode = RENDERMODE_CONTINUOUSLY

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobVisualizerView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobVisualizerView.kt
@@ -1,6 +1,7 @@
 package app.gyrolet.mpvrx.ui.player.visualizer
 
 import android.content.Context
+import android.graphics.PixelFormat
 import android.opengl.GLSurfaceView
 import android.view.MotionEvent
 
@@ -22,7 +23,9 @@ internal class BlobVisualizerView(
 
     init {
         setEGLContextClientVersion(3)
-        setEGLConfigChooser(8, 8, 8, 8, 0, 0)
+        setEGLConfigChooser(8, 8, 8, 8, 16, 0)
+        holder.setFormat(PixelFormat.TRANSLUCENT)
+        setZOrderMediaOverlay(true)
         preserveEGLContextOnPause = true
         setRenderer(blobRenderer)
         renderMode = RENDERMODE_CONTINUOUSLY

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyRenderer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyRenderer.kt
@@ -272,7 +272,7 @@ internal class GalaxyRenderer(
         tertiaryR = Color.red(palette.tertiary) / 255f
         tertiaryG = Color.green(palette.tertiary) / 255f
         tertiaryB = Color.blue(palette.tertiary) / 255f
-        GLES30.glClearColor(backgroundR, backgroundG, backgroundB, 0f)
+        GLES30.glClearColor(0f, 0f, 0f, 0f)
     }
 
     private fun updateAdaptiveDrawCount() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyRenderer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyRenderer.kt
@@ -272,7 +272,7 @@ internal class GalaxyRenderer(
         tertiaryR = Color.red(palette.tertiary) / 255f
         tertiaryG = Color.green(palette.tertiary) / 255f
         tertiaryB = Color.blue(palette.tertiary) / 255f
-        GLES30.glClearColor(backgroundR, backgroundG, backgroundB, 1f)
+        GLES30.glClearColor(backgroundR, backgroundG, backgroundB, 0f)
     }
 
     private fun updateAdaptiveDrawCount() {
@@ -316,7 +316,7 @@ internal class GalaxyRenderer(
         const val FRAME_TIME_EMA_WEIGHT = 0.025f
         const val TOUCH_EASING = 0.075f
         const val GALAXY_TILT_DEGREES = 56f
-        const val BASE_SCALE = 0.92f
+        const val BASE_SCALE = 1.10f
         const val MIN_RADIUS = 0.035f
         const val GALAXY_RADIUS = 3.25f
         const val SPIRAL_TWIST = 1.72f

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyVisualizerView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyVisualizerView.kt
@@ -25,7 +25,6 @@ internal class GalaxyVisualizerView(
         setEGLContextClientVersion(3)
         setEGLConfigChooser(8, 8, 8, 8, 16, 0)
         holder.setFormat(PixelFormat.TRANSLUCENT)
-        setZOrderMediaOverlay(true)
         preserveEGLContextOnPause = true
         setRenderer(galaxyRenderer)
         renderMode = RENDERMODE_CONTINUOUSLY

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyVisualizerView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/GalaxyVisualizerView.kt
@@ -1,6 +1,7 @@
 package app.gyrolet.mpvrx.ui.player.visualizer
 
 import android.content.Context
+import android.graphics.PixelFormat
 import android.opengl.GLSurfaceView
 import android.view.MotionEvent
 
@@ -22,7 +23,9 @@ internal class GalaxyVisualizerView(
 
     init {
         setEGLContextClientVersion(3)
-        setEGLConfigChooser(8, 8, 8, 8, 0, 0)
+        setEGLConfigChooser(8, 8, 8, 8, 16, 0)
+        holder.setFormat(PixelFormat.TRANSLUCENT)
+        setZOrderMediaOverlay(true)
         preserveEGLContextOnPause = true
         setRenderer(galaxyRenderer)
         renderMode = RENDERMODE_CONTINUOUSLY

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/AudioEqualizerManager.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/AudioEqualizerManager.kt
@@ -1,0 +1,77 @@
+package app.gyrolet.mpvrx.utils.media
+
+import android.media.audiofx.Equalizer
+import android.media.audiofx.LoudnessEnhancer
+import android.util.Log
+
+class AudioEqualizerManager {
+  private var equalizer: Equalizer? = null
+  private var loudnessEnhancer: LoudnessEnhancer? = null
+  private var isInitialized = false
+
+  fun initSession(sessionId: Int = 0) {
+    release()
+    try {
+      val eq = Equalizer(0, sessionId)
+      equalizer = eq
+      isInitialized = true
+      Log.d("AudioEqualizerManager", "Hardware Equalizer attached to audio session $sessionId")
+    } catch (e: Exception) {
+      Log.e("AudioEqualizerManager", "Failed to attach hardware Equalizer: ${e.message}")
+    }
+
+    try {
+      val enhancer = LoudnessEnhancer(sessionId)
+      loudnessEnhancer = enhancer
+      Log.d("AudioEqualizerManager", "Hardware LoudnessEnhancer attached to audio session $sessionId")
+    } catch (e: Exception) {
+      Log.e("AudioEqualizerManager", "Failed to attach LoudnessEnhancer: ${e.message}")
+    }
+  }
+
+  fun updateState(enabled: Boolean, bandGains: List<Int>, volumeBoostDb: Int) {
+    if (!isInitialized) {
+      initSession(0)
+    }
+
+    try {
+      equalizer?.let { eq ->
+        eq.enabled = enabled
+        if (enabled) {
+          val numBands = eq.numberOfBands.toInt()
+          bandGains.forEachIndexed { index, db ->
+            if (index < numBands) {
+              val minMB = eq.bandLevelRange[0]
+              val maxMB = eq.bandLevelRange[1]
+              val targetMB = (db * 100).coerceIn(minMB.toInt(), maxMB.toInt()).toShort()
+              eq.setBandLevel(index.toShort(), targetMB)
+            }
+          }
+        }
+      }
+    } catch (e: Exception) {
+      Log.e("AudioEqualizerManager", "Failed to set equalizer levels: ${e.message}")
+    }
+
+    try {
+      loudnessEnhancer?.let { enhancer ->
+        if (enabled && volumeBoostDb > 0) {
+          enhancer.setTargetGain(volumeBoostDb * 100)
+          enhancer.enabled = true
+        } else {
+          enhancer.enabled = false
+        }
+      }
+    } catch (e: Exception) {
+      Log.e("AudioEqualizerManager", "Failed to set LoudnessEnhancer gain: ${e.message}")
+    }
+  }
+
+  fun release() {
+    runCatching { equalizer?.release() }
+    runCatching { loudnessEnhancer?.release() }
+    equalizer = null
+    loudnessEnhancer = null
+    isInitialized = false
+  }
+}


### PR DESCRIPTION
Redesign the audio-only player interface with a modern, polished look

UI / Layout
-----------
- Replace gradient background with solid colorScheme.surface for
  consistent theming across light, dark, and AMOLED modes
- Reduce top padding above the Now Playing header (16dp → 6dp)
- Reuse the video player seekbar (WaveformSeekbar) in the music player
- Display standalone AbLoopIcon (no text label) at 30dp beside track
  info with a separator
  
Track Info
----------
- Strip file extension from music title (mp3, flac, opus, m4a, etc.)
- Show Lossless / Hi-Res badge where applicable
- Show audio properties (codec, sample rate, bitrate, channels) in info sheet

A-B Loop Control
----------------
- Port A-B loop button from video player to music player
- Animate expand/collapse of A-B control panel inline with track info

Visualizer
----------
- Add Galaxy and Blob OpenGL visualizer views to the music player
- Make visualizer size dynamic and screen-adaptive (clipped to bounds
  to prevent overflow into the Now Playing header)
- Use fully transparent glClearColor (0,0,0,0) and remove
  setZOrderMediaOverlay so the GL surface composites against the
  Compose background and adapts to any theme
- Build VisualizerPalette from real useDarkTheme + amoledMode prefs
  instead of hardcoded AMOLED black; apply backgroundRgb to glClearColor
  in BlobRenderer so background matches the player surface color

Playlist Sheet
--------------
- Expand playlist sheet to edge-to-edge layout in audio-only mode
  (full width, 95% screen height)
- Add 16dp bottom content padding to the playlist LazyColumn
- Add isAudioOnly flag to PlaylistTrackListItem for audio-aware rendering
- Switch to index-based items() to support drag-to-reorder from upstream

Startup
-------
- Seed isAudioOnly StateFlow with host.isCurrentMediaKnownAudio() as
  the initial value, so the audio player UI renders on the first frame
  without flashing the video player or album art view

Credits
-------
Design and UX inspiration from AFinity:
https://github.com/MakD/AFinity
