### PR TITLE
fix(ui): fix navbar bottom inset padding and smooth selection toolbar animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ git push origin v1.3.1-preview.1
 - [Next Player](https://github.com/anilbeesetti/nextplayer)
 - [Gramophone](https://github.com/FoedusProgramme/Gramophone)
 - [hdr-toys](https://github.com/natural-harmonia-gropius/hdr-toys)
+- [AFinity](https://github.com/MakD/AFinity)
 - [**SunnyVishnu3**](https://github.com/SunnyVishnu3) for the `yt-dlp` native integration and SDK 29+ bypass logic.
 
 ---

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -252,15 +252,15 @@ object MainScreen : Screen {
               dampingRatio = AppMotion.Spatial.ExpressiveDp.dampingRatio,
               stiffness = AppMotion.Spatial.ExpressiveDp.stiffness,
             ),
-            initialOffsetY = { fullHeight -> fullHeight }
-          ),
+            initialOffsetY = { fullHeight -> fullHeight * 2 }
+          ) + fadeIn(),
           exit = slideOutVertically(
             animationSpec = spring(
-              dampingRatio = AppMotion.Spatial.StandardDp.dampingRatio,
-              stiffness = AppMotion.Spatial.StandardDp.stiffness,
+              dampingRatio = androidx.compose.animation.core.Spring.DampingRatioNoBouncy,
+              stiffness = androidx.compose.animation.core.Spring.StiffnessMedium,
             ),
-            targetOffsetY = { fullHeight -> fullHeight }
-          ),
+            targetOffsetY = { fullHeight -> fullHeight * 2 }
+          ) + fadeOut(),
           modifier = Modifier
             .fillMaxWidth()
             .align(Alignment.BottomStart)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/FloatingBottomBar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/FloatingBottomBar.kt
@@ -71,8 +71,20 @@ fun BrowserBottomBar(
   AnimatedVisibility(
     visible = isSelectionMode,
     modifier = modifier,
-    enter = fadeIn(),
-    exit = fadeOut(),
+    enter = androidx.compose.animation.slideInVertically(
+      animationSpec = androidx.compose.animation.core.spring(
+        dampingRatio = app.gyrolet.mpvrx.ui.theme.AppMotion.Spatial.ExpressiveDp.dampingRatio,
+        stiffness = app.gyrolet.mpvrx.ui.theme.AppMotion.Spatial.ExpressiveDp.stiffness,
+      ),
+      initialOffsetY = { fullHeight -> fullHeight * 2 }
+    ) + fadeIn(),
+    exit = androidx.compose.animation.slideOutVertically(
+      animationSpec = androidx.compose.animation.core.spring(
+        dampingRatio = androidx.compose.animation.core.Spring.DampingRatioNoBouncy,
+        stiffness = androidx.compose.animation.core.Spring.StiffnessMedium,
+      ),
+      targetOffsetY = { fullHeight -> fullHeight * 2 }
+    ) + fadeOut(),
   ) {
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
       val availableWidth = maxWidth

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -843,7 +843,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
           selectedVideos.singleOrNull()?.isAudio == false && selectedFolders.isEmpty(),
         showRename = selectionManager.isSingleSelection,
         showAddToPlaylist = !BuildConfig.ENABLE_UPDATE_FEATURE && onlyVideosSelected,
-        modifier = Modifier.padding(bottom = if (app.gyrolet.mpvrx.ui.browser.NavigationBarState.shouldHideNavigationBar) 0.dp else navigationBarHeight)
+        modifier = Modifier.padding(bottom = 0.dp)
       )
     }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.key
+import androidx.compose.runtime.SideEffect
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -376,8 +377,8 @@ object FolderListScreen : Screen {
       )
     }
 
-    // Update NavigationBarState when selection mode changes
-    LaunchedEffect(selectionManager.isInSelectionMode) {
+    // Update NavigationBarState synchronously when selection mode changes
+    SideEffect {
       navBarState.updateSelectionState(
         inSelectionMode = selectionManager.isInSelectionMode,
         onlyVideos = true,
@@ -774,7 +775,7 @@ object FolderListScreen : Screen {
               showAddToPlaylist = false,
               modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = if (navBarState.shouldHideNavigationBar) 0.dp else navigationBarHeight),
+                .padding(bottom = 0.dp),
             )
           }
         }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistScreen.kt
@@ -19,6 +19,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.SideEffect
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -169,6 +170,14 @@ object PlaylistScreen : Screen {
       }
     }
 
+    // Synchronize NavigationBarState when selection mode changes
+    SideEffect {
+      app.gyrolet.mpvrx.ui.browser.NavigationBarState.updateSelectionState(
+        inSelectionMode = selectionManager.isInSelectionMode,
+        onlyVideos = true,
+      )
+    }
+
     // Track scroll for FAB visibility
     val mediaLayoutMode by browserPreferences.mediaLayoutMode.collectAsState()
     app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper.trackScrollForFabVisibility(
@@ -254,7 +263,7 @@ object PlaylistScreen : Screen {
               onClick = { showPlaylistActionSheet = true },
               icon = { Icon(Icons.RoundedFilled.Add, contentDescription = null) },
               text = { Text(androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.ui_create_playlist)) },
-              modifier = Modifier.padding(bottom = navigationBarHeight)
+              modifier = Modifier.padding(bottom = (navigationBarHeight - 16.dp).coerceAtLeast(0.dp))
             )
           }
         }
@@ -431,7 +440,6 @@ object PlaylistScreen : Screen {
         BoxWithConstraints(
           modifier = Modifier
             .fillMaxSize()
-            .padding(bottom = navigationBarHeight)
         ) {
           val configuration = androidx.compose.ui.platform.LocalConfiguration.current
           val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
@@ -453,6 +461,7 @@ object PlaylistScreen : Screen {
             contentPadding = PaddingValues(
               start = 8.dp,
               end = 8.dp,
+              bottom = if (isInSelectionMode) 88.dp else navigationBarHeight,
             ),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -481,7 +490,7 @@ object PlaylistScreen : Screen {
               },
               modifier = Modifier
                 .align(Alignment.CenterEnd)
-                .padding(end = 4.dp)
+                .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
                 .graphicsLayer { alpha = scrollbarAlpha },
             )
           }
@@ -492,7 +501,6 @@ object PlaylistScreen : Screen {
         Box(
           modifier = Modifier
             .fillMaxSize()
-            .padding(bottom = navigationBarHeight)
         ) {
           LazyColumn(
             state = listState,
@@ -500,6 +508,7 @@ object PlaylistScreen : Screen {
             contentPadding = PaddingValues(
               start = 8.dp,
               end = 8.dp,
+              bottom = if (isInSelectionMode) 88.dp else navigationBarHeight,
             ),
             verticalArrangement = Arrangement.spacedBy(0.dp),
           ) {
@@ -523,7 +532,7 @@ object PlaylistScreen : Screen {
               },
               modifier = Modifier
                 .align(Alignment.CenterEnd)
-                .padding(end = 4.dp)
+                .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
                 .graphicsLayer { alpha = scrollbarAlpha },
             )
           }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -21,6 +21,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.SideEffect
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -157,6 +158,14 @@ object RecentlyPlayedScreen : Screen {
       )
 
     // Handle back button during selection mode or FAB menu expanded
+    // Synchronize NavigationBarState when selection mode changes
+    SideEffect {
+      app.gyrolet.mpvrx.ui.browser.NavigationBarState.updateSelectionState(
+        inSelectionMode = selectionManager.isInSelectionMode,
+        onlyVideos = true,
+      )
+    }
+
     BackHandler(enabled = selectionManager.isInSelectionMode || isFabExpanded.value) {
       when {
         isFabExpanded.value -> isFabExpanded.value = false
@@ -568,7 +577,6 @@ private fun RecentItemsContent(
       BoxWithConstraints(
         modifier = Modifier
           .fillMaxSize()
-          .padding(bottom = navigationBarHeight)
       ) {
         val spansInfo = calculateResponsiveGridSpans(
           maxWidth = maxWidth,
@@ -581,7 +589,7 @@ private fun RecentItemsContent(
           contentPadding = PaddingValues(
             start = 8.dp,
             end = 8.dp,
-            bottom = if (isInSelectionMode) 88.dp else 16.dp
+            bottom = if (isInSelectionMode) 88.dp else navigationBarHeight
           ),
           horizontalArrangement = Arrangement.spacedBy(4.dp),
           verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -694,7 +702,7 @@ private fun RecentItemsContent(
             },
             modifier = Modifier
               .align(Alignment.CenterEnd)
-              .padding(end = 4.dp)
+              .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
               .graphicsLayer { alpha = scrollbarAlpha },
           )
         }
@@ -704,7 +712,6 @@ private fun RecentItemsContent(
       Box(
         modifier = Modifier
           .fillMaxSize()
-          .padding(bottom = navigationBarHeight)
       ) {
         LazyColumn(
           state = listState,
@@ -712,7 +719,7 @@ private fun RecentItemsContent(
           contentPadding = PaddingValues(
             start = 8.dp,
             end = 8.dp,
-            bottom = if (isInSelectionMode) 88.dp else 16.dp
+            bottom = if (isInSelectionMode) 88.dp else navigationBarHeight
           ),
         ) {
           items(
@@ -814,7 +821,7 @@ private fun RecentItemsContent(
             },
             modifier = Modifier
               .align(Alignment.CenterEnd)
-              .padding(end = 4.dp)
+              .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
               .graphicsLayer { alpha = scrollbarAlpha },
           )
         }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -21,6 +21,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.spring
+import androidx.compose.runtime.SideEffect
 import app.gyrolet.mpvrx.utils.media.OpenDocumentTreeContract
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
@@ -262,8 +263,8 @@ data class VideoListScreen(
       }
     }
 
-    // Update NavigationBarState when selection mode changes
-    LaunchedEffect(selectionManager.isInSelectionMode) {
+    // Update NavigationBarState synchronously when selection mode changes
+    SideEffect {
       navBarState.updateSelectionState(
         inSelectionMode = selectionManager.isInSelectionMode,
         onlyVideos = true,
@@ -441,7 +442,7 @@ data class VideoListScreen(
             showRename = selectionManager.selectedCount > 0,
             modifier = Modifier
               .align(Alignment.BottomCenter)
-              .padding(bottom = if (navBarState.shouldHideNavigationBar) 0.dp else navigationBarHeight)
+              .padding(bottom = 0.dp)
           )
         }
       }
@@ -677,9 +678,11 @@ internal fun VideoListContent(
   val appearancePreferences = koinInject<AppearancePreferences>()
   val configuration = androidx.compose.ui.platform.LocalConfiguration.current
   val isTablet = configuration.smallestScreenWidthDp >= 600
+  val density = LocalDensity.current
+  val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
   val bottomPadding = if (showFloatingBottomBar) {
     if (isTablet) 108.dp else 88.dp
-  } else 16.dp
+  } else navigationBarHeight
   val tapThumbnailToSelect by gesturePreferences.tapThumbnailToSelect.collectAsState()
   val showSubtitleIndicator by browserPreferences.showSubtitleIndicator.collectAsState()
   val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
@@ -697,8 +700,6 @@ internal fun VideoListContent(
   val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
   val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
   val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
-  val density = LocalDensity.current
-  val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
   val aspect = 16f / 9f
 
   val videoCardUiConfig =
@@ -921,8 +922,7 @@ internal fun VideoListContent(
             Box(
               modifier =
                 Modifier
-                  .fillMaxSize()
-                  .padding(bottom = if (selectionManager.isInSelectionMode) 0.dp else navigationBarHeight),
+                  .fillMaxSize(),
             ) {
               LazyVerticalGrid(
                 columns = GridCells.Fixed(columns),
@@ -988,7 +988,7 @@ internal fun VideoListContent(
                   modifier =
                     Modifier
                       .align(Alignment.CenterEnd)
-                      .padding(vertical = 6.dp)
+                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
                       .graphicsLayer { alpha = scrollbarAlpha },
                 )
               }
@@ -997,8 +997,7 @@ internal fun VideoListContent(
             Box(
               modifier =
                 Modifier
-                  .fillMaxSize()
-                  .padding(bottom = if (selectionManager.isInSelectionMode) 0.dp else navigationBarHeight),
+                  .fillMaxSize(),
             ) {
               LazyColumn(
                 state = listState,
@@ -1058,7 +1057,7 @@ internal fun VideoListContent(
                   modifier =
                     Modifier
                       .align(Alignment.CenterEnd)
-                      .padding(vertical = 6.dp)
+                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
                       .graphicsLayer { alpha = scrollbarAlpha },
                 )
               }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerPanels.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerPanels.kt
@@ -76,6 +76,7 @@ fun PlayerPanels(
           onDismissRequest = onDismissRequest,
         )
       }
+      else -> {}
     }
   }
 }


### PR DESCRIPTION
Remove outer container bottom padding (navigationBarHeight) from Media Library, Recently Played, and Playlist screens so content renders beneath the floating navbar pill, matching Folder View Home behavior.


