### PR TITLE
feat(securefolder): enhance layout options, top bar styling, and tablet responsiveness

### DIFF
--- a/app/schemas/app.gyrolet.mpvrx.database.MpvRxDatabase/11.json
+++ b/app/schemas/app.gyrolet.mpvrx.database.MpvRxDatabase/11.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 11,
-    "identityHash": "99defe51a45bb96c7ec999ebb81d0f01",
+    "identityHash": "88de2f61d2e2af9af7b4ac83eec00ccb",
     "entities": [
       {
         "tableName": "PlaybackStateEntity",
@@ -96,7 +96,7 @@
       },
       {
         "tableName": "RecentlyPlayedEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `videoTitle` TEXT, `duration` INTEGER NOT NULL, `fileSize` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `launchSource` TEXT, `playlistId` INTEGER, `isM3uItem` INTEGER NOT NULL DEFAULT 0)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `videoTitle` TEXT, `duration` INTEGER NOT NULL, `fileSize` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `launchSource` TEXT, `playlistId` INTEGER)",
         "fields": [
           {
             "fieldPath": "id",
@@ -160,13 +160,6 @@
             "fieldPath": "playlistId",
             "columnName": "playlistId",
             "affinity": "INTEGER"
-          },
-          {
-            "fieldPath": "isM3uItem",
-            "columnName": "isM3uItem",
-            "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "0"
           }
         ],
         "primaryKey": {
@@ -174,45 +167,7 @@
           "columnNames": [
             "id"
           ]
-        },
-        "indices": [
-          {
-            "name": "index_RecentlyPlayedEntity_filePath",
-            "unique": false,
-            "columnNames": [
-              "filePath"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecentlyPlayedEntity_filePath` ON `${TABLE_NAME}` (`filePath`)"
-          },
-          {
-            "name": "index_RecentlyPlayedEntity_playlistId",
-            "unique": false,
-            "columnNames": [
-              "playlistId"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecentlyPlayedEntity_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
-          },
-          {
-            "name": "index_RecentlyPlayedEntity_launchSource",
-            "unique": false,
-            "columnNames": [
-              "launchSource"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecentlyPlayedEntity_launchSource` ON `${TABLE_NAME}` (`launchSource`)"
-          },
-          {
-            "name": "index_RecentlyPlayedEntity_timestamp",
-            "unique": false,
-            "columnNames": [
-              "timestamp"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_RecentlyPlayedEntity_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
-          }
-        ]
+        }
       },
       {
         "tableName": "video_metadata_cache",
@@ -541,26 +496,6 @@
             ],
             "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistItemEntity_isFavorite` ON `${TABLE_NAME}` (`isFavorite`)"
-          },
-          {
-            "name": "index_PlaylistItemEntity_playlistId_groupTitle",
-            "unique": false,
-            "columnNames": [
-              "playlistId",
-              "groupTitle"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistItemEntity_playlistId_groupTitle` ON `${TABLE_NAME}` (`playlistId`, `groupTitle`)"
-          },
-          {
-            "name": "index_PlaylistItemEntity_playlistId_position",
-            "unique": false,
-            "columnNames": [
-              "playlistId",
-              "position"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistItemEntity_playlistId_position` ON `${TABLE_NAME}` (`playlistId`, `position`)"
           }
         ],
         "foreignKeys": [
@@ -677,11 +612,76 @@
             "createSql": "CREATE INDEX IF NOT EXISTS `index_directory_scan_index_scanKey_isNoMediaRoot` ON `${TABLE_NAME}` (`scanKey`, `isNoMediaRoot`)"
           }
         ]
+      },
+      {
+        "tableName": "secure_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `originalPath` TEXT NOT NULL, `secureFilePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `dateHidden` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalPath",
+            "columnName": "originalPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secureFilePath",
+            "columnName": "secureFilePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateHidden",
+            "columnName": "dateHidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_secure_media_secureFilePath",
+            "unique": true,
+            "columnNames": [
+              "secureFilePath"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_secure_media_secureFilePath` ON `${TABLE_NAME}` (`secureFilePath`)"
+          }
+        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '99defe51a45bb96c7ec999ebb81d0f01')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '88de2f61d2e2af9af7b4ac83eec00ccb')"
     ]
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/BrowserTopBar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/BrowserTopBar.kt
@@ -90,6 +90,7 @@ fun BrowserTopBar(
   onMoveToSecureClick: (() -> Unit)? = null,
   useRemoveIcon: Boolean = false,
   onAddToPlaylistClick: (() -> Unit)? = null,
+  onRestoreClick: (() -> Unit)? = null,
   colors: TopAppBarColors? = null,
   forceHeadlineSmall: Boolean = false,
 ) {
@@ -111,10 +112,12 @@ fun BrowserTopBar(
       onInvertSelection = onInvertSelection,
       onDeselectAll = onDeselectAll,
       onMoveToSecure = onMoveToSecureClick,
+      onRestore = onRestoreClick,
       modifier = modifier,
       useRemoveIcon = useRemoveIcon,
       onAddToPlaylist = onAddToPlaylistClick,
       colors = colors,
+      additionalActions = additionalActions,
     )
   } else {
     NormalTopBar(
@@ -272,7 +275,6 @@ private fun NormalTopBar(
       }
     },
     actions = {
-      additionalActions()
       if (onSearchClick != null) {
         IconButton(
           onClick = onSearchClick,
@@ -317,6 +319,7 @@ private fun NormalTopBar(
           )
         }
       }
+      additionalActions()
     },
     modifier = modifier,
   )
@@ -347,7 +350,9 @@ private fun SelectionTopBar(
   useRemoveIcon: Boolean = false,
   onAddToPlaylist: (() -> Unit)? = null,
   onMoveToSecure: (() -> Unit)? = null,
+  onRestore: (() -> Unit)? = null,
   colors: TopAppBarColors? = null,
+  additionalActions: @Composable RowScope.() -> Unit = { },
 ) {
   var showDropdown by remember { mutableStateOf(false) }
 
@@ -428,6 +433,20 @@ private fun SelectionTopBar(
       }
     },
     actions = {
+      additionalActions()
+      if (onRestore != null) {
+        IconButton(
+          onClick = onRestore,
+          modifier = Modifier.padding(horizontal = 2.dp),
+        ) {
+          Icon(
+            Icons.RoundedFilled.Restore,
+            contentDescription = stringResource(R.string.secure_folder_restore),
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.secondary,
+          )
+        }
+      }
       // Play icon
       if (onPlay != null) {
         IconButton(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderGateScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderGateScreen.kt
@@ -14,14 +14,14 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -33,10 +33,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -47,6 +46,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -54,12 +55,13 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.compose.ui.res.stringResource
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.presentation.Screen
 import app.gyrolet.mpvrx.presentation.components.ExposedTextDropDownMenu
+import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.theme.AppShapeScale
 import app.gyrolet.mpvrx.ui.utils.LocalBackStack
 import app.gyrolet.mpvrx.ui.utils.popSafely
 import app.gyrolet.mpvrx.ui.utils.replaceTop
@@ -98,75 +100,82 @@ data object SecureFolderGateScreen : Screen {
     val gateStep by viewModel.gateStep.collectAsState()
     val gateError by viewModel.gateError.collectAsState()
 
-    // Re-check the persisted PIN state every time this screen is entered, so a previously
-    // completed setup is never re-shown (see SecureFolderViewModel.refreshGateStep).
     androidx.compose.runtime.LaunchedEffect(Unit) {
       viewModel.refreshGateStep()
     }
 
     Scaffold(
       topBar = {
-        TopAppBar(
-          title = { Text(stringResource(R.string.secure_folder_title)) },
-          navigationIcon = {
-            IconButton(onClick = { backstack.popSafely() }) {
-              Icon(Icons.RoundedFilled.ArrowBack, contentDescription = null)
-            }
-          },
-          colors = TopAppBarDefaults.topAppBarColors(),
+        BrowserTopBar(
+          title = stringResource(R.string.secure_folder_title),
+          isInSelectionMode = false,
+          selectedCount = 0,
+          totalCount = 0,
+          onBackClick = { backstack.popSafely() },
+          onCancelSelection = {},
         )
       },
     ) { padding ->
-      Box(
-        modifier =
-          Modifier
-            .fillMaxSize()
-            .padding(padding)
-            .windowInsetsPadding(WindowInsets.systemBars),
-        contentAlignment = Alignment.Center,
+      Surface(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        color = MaterialTheme.colorScheme.background,
       ) {
-        AnimatedContent(
-          targetState = gateStep,
-          transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
-          label = "secure_folder_gate_step",
-        ) { step ->
-          when (step) {
-            SecureFolderViewModel.GateStep.ENTER_PIN ->
-              EnterPinContent(
-                error = gateError,
-                onSubmit = { pin ->
-                  if (viewModel.verifyPin(pin)) {
-                    backstack.replaceTop(SecureFolderScreen)
-                  }
-                },
-                onForgotPin = { viewModel.startForgotPinFlow() },
-              )
+        Box(
+          modifier = Modifier.fillMaxSize(),
+          contentAlignment = Alignment.Center,
+        ) {
+          Column(
+            modifier =
+              Modifier
+                .widthIn(max = 560.dp)
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            AnimatedContent(
+              targetState = gateStep,
+              transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+              label = "secure_folder_gate_step",
+            ) { step ->
+              when (step) {
+                SecureFolderViewModel.GateStep.ENTER_PIN ->
+                  EnterPinContent(
+                    error = gateError,
+                    onSubmit = { pin ->
+                      if (viewModel.verifyPin(pin)) {
+                        backstack.replaceTop(SecureFolderScreen)
+                      }
+                    },
+                    onForgotPin = { viewModel.startForgotPinFlow() },
+                  )
 
-            SecureFolderViewModel.GateStep.SETUP ->
-              SetupContent(
-                error = gateError,
-                onSubmit = { pin, question, answer ->
-                  if (viewModel.submitSetup(pin, question, answer)) {
-                    backstack.replaceTop(SecureFolderScreen)
-                  }
-                },
-              )
+                SecureFolderViewModel.GateStep.SETUP ->
+                  SetupContent(
+                    error = gateError,
+                    onSubmit = { pin, question, answer ->
+                      if (viewModel.submitSetup(pin, question, answer)) {
+                        backstack.replaceTop(SecureFolderScreen)
+                      }
+                    },
+                  )
 
-            SecureFolderViewModel.GateStep.FORGOT_PIN_QUESTION ->
-              SecurityQuestionAnswerContent(
-                question = viewModel.preferences.securityQuestion.get(),
-                error = gateError,
-                onSubmit = { answer -> viewModel.verifySecurityAnswerForRecovery(answer) },
-                onCancel = { viewModel.cancelForgotPinFlow() },
-              )
+                SecureFolderViewModel.GateStep.FORGOT_PIN_QUESTION ->
+                  SecurityQuestionAnswerContent(
+                    question = viewModel.preferences.securityQuestion.get(),
+                    error = gateError,
+                    onSubmit = { answer -> viewModel.verifySecurityAnswerForRecovery(answer) },
+                    onCancel = { viewModel.cancelForgotPinFlow() },
+                  )
 
-            SecureFolderViewModel.GateStep.FORGOT_PIN_NEW_PIN ->
-              ChoosePinContent(
-                title = stringResource(R.string.secure_folder_choose_new_pin),
-                subtitle = stringResource(R.string.secure_folder_old_pin_invalid),
-                error = gateError,
-                onSubmit = { pin -> viewModel.finishForgotPinFlow(pin) },
-              )
+                SecureFolderViewModel.GateStep.FORGOT_PIN_NEW_PIN ->
+                  ChoosePinContent(
+                    title = stringResource(R.string.secure_folder_choose_new_pin),
+                    subtitle = stringResource(R.string.secure_folder_old_pin_invalid),
+                    error = gateError,
+                    onSubmit = { pin -> viewModel.finishForgotPinFlow(pin) },
+                  )
+              }
+            }
           }
         }
       }
@@ -189,20 +198,42 @@ private fun EnterPinContent(
         .fillMaxWidth()
         .verticalScroll(rememberScrollState())
         .imePadding()
-        .padding(24.dp),
+        .padding(vertical = 16.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    Icon(
-      Icons.RoundedFilled.Lock,
-      contentDescription = null,
-      modifier = Modifier.size(48.dp),
-      tint = MaterialTheme.colorScheme.primary,
-    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // Header Icon
+    Surface(
+      modifier = Modifier.size(72.dp),
+      shape = AppShapeScale.extraLarge,
+      color = MaterialTheme.colorScheme.primaryContainer,
+      tonalElevation = 2.dp,
+    ) {
+      Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.Lock,
+          contentDescription = null,
+          modifier = Modifier.size(36.dp),
+          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+      }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
     Text(
-      stringResource(R.string.secure_folder_enter_pin),
-      style = MaterialTheme.typography.headlineSmall,
-      modifier = Modifier.padding(top = 16.dp, bottom = 24.dp),
+      text = stringResource(R.string.secure_folder_enter_pin),
+      style = MaterialTheme.typography.headlineMedium,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+      color = MaterialTheme.colorScheme.onSurface,
     )
+
+    Spacer(modifier = Modifier.height(28.dp))
 
     PinField(
       value = pin,
@@ -214,31 +245,43 @@ private fun EnterPinContent(
 
     if (error != null) {
       Text(
-        error,
+        text = error,
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.bodySmall,
         modifier = Modifier.padding(top = 8.dp),
       )
     }
 
+    Spacer(modifier = Modifier.height(28.dp))
+
     Button(
       onClick = { onSubmit(pin) },
       enabled = pin.isNotEmpty(),
-      modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+      modifier = Modifier.fillMaxWidth().height(54.dp),
+      shape = AppShapeScale.large,
     ) {
-      Text(stringResource(R.string.secure_folder_unlock))
+      Text(
+        text = stringResource(R.string.secure_folder_unlock),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+      )
     }
 
-    TextButton(onClick = onForgotPin, modifier = Modifier.padding(top = 4.dp)) {
-      Text(stringResource(R.string.secure_folder_forgot_pin))
+    Spacer(modifier = Modifier.height(8.dp))
+
+    TextButton(onClick = onForgotPin) {
+      Text(
+        text = stringResource(R.string.secure_folder_forgot_pin),
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Medium,
+      )
     }
   }
 }
 
 /**
  * First-time setup, all in one step: PIN + confirm PIN + security question (preset dropdown) +
- * answer. Everything is validated and persisted together in a single call, so there's no
- * intermediate "pending PIN" state that can be lost between steps.
+ * answer. Everything is validated and persisted together in a single call.
  */
 @Composable
 private fun SetupContent(
@@ -253,37 +296,56 @@ private fun SetupContent(
   var answer by rememberSaveable { mutableStateOf("") }
   var validationErrorRes by remember { mutableStateOf<Int?>(null) }
 
-  val errPinMin = stringResource(R.string.secure_folder_error_pin_min_digits)
-  val errPinsMatch = stringResource(R.string.secure_folder_error_pins_dont_match)
-  val errAnswerSq = stringResource(R.string.secure_folder_error_answer_question)
-
   Column(
     modifier =
       Modifier
         .fillMaxWidth()
         .verticalScroll(rememberScrollState())
         .imePadding()
-        .padding(24.dp),
+        .padding(vertical = 16.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    Icon(
-      Icons.RoundedFilled.Security,
-      contentDescription = null,
-      modifier = Modifier.size(48.dp),
-      tint = MaterialTheme.colorScheme.primary,
-    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Surface(
+      modifier = Modifier.size(72.dp),
+      shape = AppShapeScale.extraLarge,
+      color = MaterialTheme.colorScheme.primaryContainer,
+      tonalElevation = 2.dp,
+    ) {
+      Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.Security,
+          contentDescription = null,
+          modifier = Modifier.size(36.dp),
+          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+      }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
     Text(
-      stringResource(R.string.secure_folder_setup_title),
-      style = MaterialTheme.typography.headlineSmall,
-      modifier = Modifier.padding(top = 16.dp),
+      text = stringResource(R.string.secure_folder_setup_title),
+      style = MaterialTheme.typography.headlineMedium,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+      color = MaterialTheme.colorScheme.onSurface,
     )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
     Text(
-      stringResource(R.string.secure_folder_setup_subtitle),
+      text = stringResource(R.string.secure_folder_setup_subtitle),
       style = MaterialTheme.typography.bodyMedium,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
       textAlign = TextAlign.Center,
-      modifier = Modifier.padding(top = 4.dp, bottom = 24.dp),
     )
+
+    Spacer(modifier = Modifier.height(28.dp))
 
     PinField(
       value = pin,
@@ -313,7 +375,7 @@ private fun SetupContent(
       options = presets,
       label = stringResource(R.string.secure_folder_security_question),
       onValueChangedEvent = { question = it },
-      modifier = Modifier.padding(top = 20.dp),
+      modifier = Modifier.padding(top = 16.dp),
     )
 
     OutlinedTextField(
@@ -330,12 +392,14 @@ private fun SetupContent(
     val shownError = if (validationErrorRes != null) stringResource(validationErrorRes!!) else error
     if (shownError != null) {
       Text(
-        shownError,
+        text = shownError,
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.bodySmall,
         modifier = Modifier.padding(top = 8.dp),
       )
     }
+
+    Spacer(modifier = Modifier.height(28.dp))
 
     Button(
       onClick = {
@@ -346,9 +410,14 @@ private fun SetupContent(
           else -> onSubmit(pin, question, answer)
         }
       },
-      modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+      modifier = Modifier.fillMaxWidth().height(54.dp),
+      shape = AppShapeScale.large,
     ) {
-      Text(stringResource(R.string.secure_folder_finish_setup))
+      Text(
+        text = stringResource(R.string.secure_folder_finish_setup),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+      )
     }
   }
 }
@@ -371,23 +440,50 @@ private fun ChoosePinContent(
         .fillMaxWidth()
         .verticalScroll(rememberScrollState())
         .imePadding()
-        .padding(24.dp),
+        .padding(vertical = 16.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    Icon(
-      Icons.RoundedFilled.Security,
-      contentDescription = null,
-      modifier = Modifier.size(48.dp),
-      tint = MaterialTheme.colorScheme.primary,
-    )
-    Text(title, style = MaterialTheme.typography.headlineSmall, modifier = Modifier.padding(top = 16.dp))
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Surface(
+      modifier = Modifier.size(72.dp),
+      shape = AppShapeScale.extraLarge,
+      color = MaterialTheme.colorScheme.primaryContainer,
+      tonalElevation = 2.dp,
+    ) {
+      Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.Security,
+          contentDescription = null,
+          modifier = Modifier.size(36.dp),
+          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+      }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
     Text(
-      subtitle,
+      text = title,
+      style = MaterialTheme.typography.headlineMedium,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+      color = MaterialTheme.colorScheme.onSurface,
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Text(
+      text = subtitle,
       style = MaterialTheme.typography.bodyMedium,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
       textAlign = TextAlign.Center,
-      modifier = Modifier.padding(top = 4.dp, bottom = 24.dp),
     )
+
+    Spacer(modifier = Modifier.height(28.dp))
 
     PinField(
       value = pin,
@@ -415,12 +511,14 @@ private fun ChoosePinContent(
     val shownError = if (mismatchErrorRes != null) stringResource(mismatchErrorRes!!) else error
     if (shownError != null) {
       Text(
-        shownError,
+        text = shownError,
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.bodySmall,
         modifier = Modifier.padding(top = 8.dp),
       )
     }
+
+    Spacer(modifier = Modifier.height(28.dp))
 
     Button(
       onClick = {
@@ -430,9 +528,14 @@ private fun ChoosePinContent(
           else -> onSubmit(pin)
         }
       },
-      modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+      modifier = Modifier.fillMaxWidth().height(54.dp),
+      shape = AppShapeScale.large,
     ) {
-      Text(stringResource(R.string.secure_folder_next))
+      Text(
+        text = stringResource(R.string.secure_folder_next),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+      )
     }
   }
 }
@@ -452,27 +555,50 @@ private fun SecurityQuestionAnswerContent(
         .fillMaxWidth()
         .verticalScroll(rememberScrollState())
         .imePadding()
-        .padding(24.dp),
+        .padding(vertical = 16.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    Icon(
-      Icons.RoundedFilled.HelpOutline,
-      contentDescription = null,
-      modifier = Modifier.size(48.dp),
-      tint = MaterialTheme.colorScheme.primary,
-    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Surface(
+      modifier = Modifier.size(72.dp),
+      shape = AppShapeScale.extraLarge,
+      color = MaterialTheme.colorScheme.primaryContainer,
+      tonalElevation = 2.dp,
+    ) {
+      Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.HelpOutline,
+          contentDescription = null,
+          modifier = Modifier.size(36.dp),
+          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+      }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
     Text(
-      stringResource(R.string.secure_folder_answer_security_question),
-      style = MaterialTheme.typography.headlineSmall,
+      text = stringResource(R.string.secure_folder_answer_security_question),
+      style = MaterialTheme.typography.headlineMedium,
+      fontWeight = FontWeight.Bold,
       textAlign = TextAlign.Center,
-      modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
+      color = MaterialTheme.colorScheme.onSurface,
     )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
     Text(
-      question.ifBlank { stringResource(R.string.secure_folder_no_question_set) },
+      text = question.ifBlank { stringResource(R.string.secure_folder_no_question_set) },
       style = MaterialTheme.typography.bodyLarge,
       textAlign = TextAlign.Center,
-      modifier = Modifier.padding(bottom = 24.dp),
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
+
+    Spacer(modifier = Modifier.height(28.dp))
 
     OutlinedTextField(
       value = answer,
@@ -484,23 +610,40 @@ private fun SecurityQuestionAnswerContent(
 
     if (error != null) {
       Text(
-        error,
+        text = error,
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.bodySmall,
         modifier = Modifier.padding(top = 8.dp),
       )
     }
 
+    Spacer(modifier = Modifier.height(28.dp))
+
     Button(
       onClick = { onSubmit(answer) },
       enabled = answer.isNotBlank(),
-      modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+      modifier = Modifier.fillMaxWidth().height(54.dp),
+      shape = AppShapeScale.large,
     ) {
-      Text(stringResource(R.string.secure_folder_verify))
+      Text(
+        text = stringResource(R.string.secure_folder_verify),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+      )
     }
 
-    OutlinedButton(onClick = onCancel, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-      Text(stringResource(R.string.generic_cancel))
+    Spacer(modifier = Modifier.height(8.dp))
+
+    OutlinedButton(
+      onClick = onCancel,
+      modifier = Modifier.fillMaxWidth().height(54.dp),
+      shape = AppShapeScale.large,
+    ) {
+      Text(
+        text = stringResource(R.string.generic_cancel),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+      )
     }
   }
 }
@@ -542,3 +685,5 @@ private fun PinField(
     modifier = modifier.fillMaxWidth(),
   )
 }
+
+

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
@@ -7,29 +7,21 @@
 
 package app.gyrolet.mpvrx.ui.securefolder
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,56 +32,55 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.database.entities.SecureMediaEntity
 import app.gyrolet.mpvrx.domain.media.model.Video
-import app.gyrolet.mpvrx.domain.thumbnail.ThumbnailRepository
+import app.gyrolet.mpvrx.preferences.AppearancePreferences
+import app.gyrolet.mpvrx.preferences.BrowserPreferences
+import app.gyrolet.mpvrx.preferences.MediaLayoutMode
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.presentation.Screen
+import app.gyrolet.mpvrx.ui.browser.cards.VideoCard
+import app.gyrolet.mpvrx.ui.browser.cards.VideoCardUiConfig
+import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
+import app.gyrolet.mpvrx.ui.browser.components.ExpressiveScrollBar
+import app.gyrolet.mpvrx.ui.browser.components.fastScrollGlyph
+import app.gyrolet.mpvrx.ui.browser.dialogs.VideoSortDialog
 import app.gyrolet.mpvrx.ui.browser.states.EmptyState
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.ui.utils.LocalBackStack
 import app.gyrolet.mpvrx.ui.utils.popSafely
 import app.gyrolet.mpvrx.utils.media.MediaUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.withContext
+import app.gyrolet.mpvrx.utils.sort.SortUtils
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 import java.text.DecimalFormat
-import kotlin.math.roundToInt
 import kotlin.math.ln
 import kotlin.math.pow
+import kotlin.math.roundToInt
 
 /**
- * The unlocked Secure Folder: a grid of everything currently hidden away, with multi-select
- * for bulk restore/delete, plus overflow-menu actions to hide/unhide the "Secure Folder" entry
- * point from the Preferences screen and to change the PIN / security question.
- *
- * Restore and delete-forever go through [SecureConfirmDialog] first (skippable per-action via
- * "don't ask again"), and a busy operation shows [SecureFolderProgressDialog] instead of the
- * old inline progress bar.
+ * The unlocked Secure Folder: supports List and Grid layouts (reusing [VideoCard] from video list),
+ * sorting by Title/Date/Size/Duration, view options via [VideoSortDialog], multi-select
+ * for bulk restore/delete, plus overflow-menu actions to hide/unhide the entry point and change PIN.
  */
 @Serializable
 data object SecureFolderScreen : Screen {
@@ -101,6 +92,9 @@ data object SecureFolderScreen : Screen {
     val viewModel: SecureFolderViewModel =
       viewModel(factory = SecureFolderViewModel.factory(context.applicationContext as android.app.Application))
 
+    val browserPreferences = koinInject<BrowserPreferences>()
+    val appearancePreferences = koinInject<AppearancePreferences>()
+
     val media by viewModel.secureMedia.collectAsState()
     val selectedIds by viewModel.selectedIds.collectAsState()
     val isInSelectionMode by viewModel.isInSelectionMode.collectAsState()
@@ -109,17 +103,107 @@ data object SecureFolderScreen : Screen {
     val operationResult by viewModel.operationResult.collectAsState()
     val isEntryPointHidden by viewModel.preferences.isEntryPointHidden.collectAsState()
 
+    // Preferences for sorting, layout mode and video card UI config
+    val videoSortType by browserPreferences.videoSortType.collectAsState()
+    val videoSortOrder by browserPreferences.videoSortOrder.collectAsState()
+    val mediaLayoutMode by browserPreferences.folderViewVideoLayoutMode.collectAsState()
+
+    val unlimitedNameLines by appearancePreferences.unlimitedNameLines.collectAsState()
+    val showVideoThumbnails by browserPreferences.showVideoThumbnails.collectAsState()
+    val showSizeChip by browserPreferences.showSizeChip.collectAsState()
+    val showResolutionChip by browserPreferences.showResolutionChip.collectAsState()
+    val showFramerateInResolution by browserPreferences.showFramerateInResolution.collectAsState()
+    val showProgressBar by browserPreferences.showProgressBar.collectAsState()
+    val showDateChip by browserPreferences.showDateChip.collectAsState()
+    val showUnplayedOldVideoLabel by appearancePreferences.showUnplayedOldVideoLabel.collectAsState()
+    val unplayedOldVideoDays by appearancePreferences.unplayedOldVideoDays.collectAsState()
+    val showExtensionField by browserPreferences.showExtensionField.collectAsState()
+    val showDurationField by browserPreferences.showDurationField.collectAsState()
+    val centerGridTitles by browserPreferences.centerGridTitles.collectAsState()
+
+    val manualGridColumnsEnabled by browserPreferences.manualGridColumnsEnabled.collectAsState()
+    val videoGridColumnsPortrait by browserPreferences.videoGridColumnsPortrait.collectAsState()
+    val videoGridColumnsLandscape by browserPreferences.videoGridColumnsLandscape.collectAsState()
+
+    val videoCardUiConfig =
+      remember(
+        unlimitedNameLines,
+        showVideoThumbnails,
+        showSizeChip,
+        showResolutionChip,
+        showFramerateInResolution,
+        showProgressBar,
+        showDateChip,
+        showUnplayedOldVideoLabel,
+        unplayedOldVideoDays,
+        showExtensionField,
+        showDurationField,
+        centerGridTitles,
+      ) {
+        VideoCardUiConfig(
+          unlimitedNameLines = unlimitedNameLines,
+          showThumbnails = showVideoThumbnails,
+          showSizeChip = showSizeChip,
+          showResolutionChip = showResolutionChip,
+          showFramerateInResolution = showFramerateInResolution,
+          showProgressBar = showProgressBar,
+          showDateChip = showDateChip,
+          showUnplayedOldVideoLabel = showUnplayedOldVideoLabel,
+          unplayedOldVideoDays = unplayedOldVideoDays,
+          showExtensionField = showExtensionField,
+          showDurationField = showDurationField,
+          centerGridTitles = centerGridTitles,
+        )
+      }
+
+    // Convert secure media entities into Video models and sort them
+    val secureMediaVideos =
+      remember(media) {
+        media.map { entity ->
+          entity to
+            Video(
+              id = entity.id,
+              title = entity.fileName,
+              displayName = entity.fileName,
+              path = entity.secureFilePath,
+              uri = android.net.Uri.fromFile(java.io.File(entity.secureFilePath)),
+              duration = 0L,
+              durationFormatted = "",
+              size = entity.fileSize,
+              sizeFormatted = formatFileSize(entity.fileSize),
+              dateModified = entity.dateHidden,
+              dateAdded = entity.dateHidden,
+              mimeType = entity.mimeType,
+              bucketId = "secure_folder",
+              bucketDisplayName = "Secure Folder",
+              width = 0,
+              height = 0,
+              fps = 0f,
+              resolution = "--",
+              isAudio = entity.mimeType.startsWith("audio/"),
+            )
+        }
+      }
+
+    val sortedSecureMediaVideos =
+      remember(secureMediaVideos, videoSortType, videoSortOrder) {
+        val sortedVideos = SortUtils.sortVideos(secureMediaVideos.map { it.second }, videoSortType, videoSortOrder)
+        val entityByVideoId = secureMediaVideos.associate { it.second.id to it.first }
+        sortedVideos.mapNotNull { video ->
+          entityByVideoId[video.id]?.let { entity -> entity to video }
+        }
+      }
+
     val snackbarHostState = remember { SnackbarHostState() }
+    val listState = rememberLazyListState()
     val gridState = rememberLazyGridState()
 
-    // Which confirm dialog (if any) is currently open — restore/delete share one flow since
-    // only one bulk action can be pending at a time.
     var pendingAction by remember { mutableStateOf<PendingAction?>(null) }
     var changePinOpen by remember { mutableStateOf(false) }
     var changeSecurityQuestionOpen by remember { mutableStateOf(false) }
-    // Confirmed separately from restore/delete since it's not a destructive data action, but
-    // still needs a heads-up: once hidden, the only way back in is the header double-tap.
     var hideEntryPointConfirmOpen by remember { mutableStateOf(false) }
+    var sortDialogOpen by rememberSaveable { mutableStateOf(false) }
+    var isScrollbarDragging by remember { mutableStateOf(false) }
 
     LaunchedEffect(operationResult) {
       operationResult?.let {
@@ -130,41 +214,91 @@ data object SecureFolderScreen : Screen {
 
     Scaffold(
       topBar = {
-        SecureFolderTopBar(
+        BrowserTopBar(
+          title = stringResource(R.string.secure_folder_title),
           isInSelectionMode = isInSelectionMode,
           selectedCount = selectedIds.size,
           totalCount = media.size,
-          isEntryPointHidden = isEntryPointHidden,
-          isBusy = isBusy,
-          onBack = { backstack.popSafely() },
+          onBackClick = { backstack.popSafely() },
+          onCancelSelection = { viewModel.clearSelection() },
+          onSortClick = { sortDialogOpen = true },
           onSelectAll = { viewModel.selectAll() },
+          onInvertSelection = { viewModel.invertSelection() },
           onDeselectAll = { viewModel.clearSelection() },
-          onRestoreRequest = {
+          onRestoreClick = {
             if (viewModel.preferences.dontAskBeforeRestore.get()) {
               viewModel.restoreSelected()
             } else {
               pendingAction = PendingAction.RESTORE
             }
           },
-          onDeleteRequest = {
+          onDeleteClick = {
             if (viewModel.preferences.dontAskBeforeDelete.get()) {
               viewModel.deleteSelectedForever()
             } else {
               pendingAction = PendingAction.DELETE
             }
           },
-          onToggleEntryPointHidden = {
-            if (isEntryPointHidden) {
-              // Un-hiding needs no confirmation — it only makes the entry more visible again.
-              viewModel.toggleEntryPointHidden()
-            } else if (viewModel.preferences.dontAskBeforeHideEntryPoint.get()) {
-              viewModel.toggleEntryPointHidden()
-            } else {
-              hideEntryPointConfirmOpen = true
+          additionalActions = {
+            if (!isInSelectionMode) {
+              var menuExpanded by remember { mutableStateOf(false) }
+              Box {
+                IconButton(onClick = { menuExpanded = true }) {
+                  Icon(
+                    Icons.RoundedFilled.MoreVert,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.secondary,
+                  )
+                }
+                DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                  DropdownMenuItem(
+                    text = {
+                      Text(
+                        if (isEntryPointHidden) {
+                          stringResource(R.string.secure_folder_show_in_preferences)
+                        } else {
+                          stringResource(R.string.secure_folder_hide_from_preferences)
+                        }
+                      )
+                    },
+                    leadingIcon = {
+                      Icon(
+                        if (isEntryPointHidden) Icons.RoundedFilled.Visibility else Icons.RoundedFilled.VisibilityOff,
+                        contentDescription = null,
+                      )
+                    },
+                    onClick = {
+                      if (isEntryPointHidden) {
+                        viewModel.toggleEntryPointHidden()
+                      } else if (viewModel.preferences.dontAskBeforeHideEntryPoint.get()) {
+                        viewModel.toggleEntryPointHidden()
+                      } else {
+                        hideEntryPointConfirmOpen = true
+                      }
+                      menuExpanded = false
+                    },
+                  )
+                  DropdownMenuItem(
+                    text = { Text(stringResource(R.string.secure_folder_change_pin)) },
+                    leadingIcon = { Icon(Icons.RoundedFilled.Lock, contentDescription = null) },
+                    onClick = {
+                      changePinOpen = true
+                      menuExpanded = false
+                    },
+                  )
+                  DropdownMenuItem(
+                    text = { Text(stringResource(R.string.secure_folder_change_security_question)) },
+                    leadingIcon = { Icon(Icons.RoundedFilled.HelpOutline, contentDescription = null) },
+                    onClick = {
+                      changeSecurityQuestionOpen = true
+                      menuExpanded = false
+                    },
+                  )
+                }
+              }
             }
           },
-          onChangePin = { changePinOpen = true },
-          onChangeSecurityQuestion = { changeSecurityQuestionOpen = true },
         )
       },
       snackbarHost = {
@@ -173,14 +307,13 @@ data object SecureFolderScreen : Screen {
         }
       },
     ) { padding ->
-      Column(
+      Box(
         modifier =
           Modifier
             .fillMaxSize()
-            .padding(padding)
-            .windowInsetsPadding(WindowInsets.systemBars),
+            .padding(padding),
       ) {
-        if (media.isEmpty()) {
+        if (sortedSecureMediaVideos.isEmpty()) {
           Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             EmptyState(
               icon = Icons.RoundedFilled.Lock,
@@ -189,33 +322,169 @@ data object SecureFolderScreen : Screen {
             )
           }
         } else {
-          LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = 110.dp),
-            state = gridState,
-            contentPadding = PaddingValues(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxSize(),
-          ) {
-            items(media, key = { it.id }) { entity ->
-              SecureMediaCard(
-                entity = entity,
-                isSelected = selectedIds.contains(entity.id),
-                isInSelectionMode = isInSelectionMode,
-                onClick = {
-                  if (isInSelectionMode) {
-                    viewModel.toggleSelection(entity.id)
-                  } else {
-                    MediaUtils.playFile(
-                      entity.secureFilePath,
-                      context,
-                      launchSource = "secure_folder",
-                      title = entity.fileName,
+          BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val configuration = LocalConfiguration.current
+            val density = LocalDensity.current
+            val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+            val videoGridColumnsPref = if (isLandscape) videoGridColumnsLandscape else videoGridColumnsPortrait
+            val contentHorizontalPadding = 8.dp
+            val itemSpacing = 4.dp
+            val usableWidth = maxWidth - (contentHorizontalPadding * 2) - itemSpacing
+            val videoGridColumns =
+              if (manualGridColumnsEnabled) {
+                videoGridColumnsPref.coerceAtLeast(1)
+              } else {
+                val videoMinWidth = 130.dp
+                (usableWidth / videoMinWidth).toInt().coerceAtLeast(1)
+              }
+
+            val thumbWidthDp =
+              if (mediaLayoutMode == MediaLayoutMode.GRID) {
+                (usableWidth / videoGridColumns)
+              } else {
+                128.dp
+              }
+            val thumbWidthPx = with(density) { thumbWidthDp.roundToPx() }
+            val aspect = 16f / 9f
+            val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
+
+            val hasEnoughItems = sortedSecureMediaVideos.size > 10
+            val scrollbarAlpha by animateFloatAsState(
+              targetValue = if (hasEnoughItems) 1f else 0f,
+              animationSpec =
+                app.gyrolet.mpvrx.ui.theme.AppMotion.Effect.Alpha.let {
+                  androidx.compose.animation.core.spring(
+                    dampingRatio = it.dampingRatio,
+                    stiffness = it.stiffness,
+                  )
+                },
+              label = "scrollbarAlpha",
+            )
+
+            if (mediaLayoutMode == MediaLayoutMode.GRID) {
+              Box(modifier = Modifier.fillMaxSize()) {
+                LazyVerticalGrid(
+                  columns = GridCells.Fixed(videoGridColumns),
+                  state = gridState,
+                  contentPadding = PaddingValues(start = 8.dp, end = 8.dp, bottom = 16.dp),
+                  horizontalArrangement = Arrangement.spacedBy(4.dp),
+                  verticalArrangement = Arrangement.spacedBy(4.dp),
+                  modifier = Modifier.fillMaxSize(),
+                ) {
+                  items(sortedSecureMediaVideos, key = { it.first.id }) { (entity, video) ->
+                    VideoCard(
+                      video = video,
+                      isSelected = selectedIds.contains(entity.id),
+                      onClick = {
+                        if (isInSelectionMode) {
+                          viewModel.toggleSelection(entity.id)
+                        } else {
+                          MediaUtils.playFile(
+                            entity.secureFilePath,
+                            context,
+                            launchSource = "secure_folder",
+                            title = entity.fileName,
+                          )
+                        }
+                      },
+                      onLongClick = { viewModel.handleLongClick(entity.id) },
+                      onThumbClick = {
+                        if (isInSelectionMode) {
+                          viewModel.toggleSelection(entity.id)
+                        } else {
+                          MediaUtils.playFile(
+                            entity.secureFilePath,
+                            context,
+                            launchSource = "secure_folder",
+                            title = entity.fileName,
+                          )
+                        }
+                      },
+                      isGridMode = true,
+                      gridColumns = videoGridColumns,
+                      thumbnailWidthPx = thumbWidthPx,
+                      thumbnailHeightPx = thumbHeightPx,
+                      allowThumbnailGeneration = true,
+                      allowThumbnailLoading = !isScrollbarDragging,
+                      uiConfig = videoCardUiConfig,
                     )
                   }
-                },
-                onLongClick = { viewModel.handleLongClick(entity.id) },
-              )
+                }
+
+                if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                  ExpressiveScrollBar(
+                    gridState = gridState,
+                    dragLabelProvider = { index ->
+                      fastScrollGlyph(sortedSecureMediaVideos.getOrNull(index)?.second?.displayName)
+                    },
+                    onDragStateChanged = { isDragging -> isScrollbarDragging = isDragging },
+                    modifier =
+                      Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 2.dp, top = 6.dp, bottom = 6.dp)
+                        .graphicsLayer { alpha = scrollbarAlpha },
+                  )
+                }
+              }
+            } else {
+              Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                  state = listState,
+                  contentPadding = PaddingValues(start = 8.dp, end = 8.dp, bottom = 16.dp),
+                  modifier = Modifier.fillMaxSize(),
+                ) {
+                  items(sortedSecureMediaVideos, key = { it.first.id }) { (entity, video) ->
+                    VideoCard(
+                      video = video,
+                      isSelected = selectedIds.contains(entity.id),
+                      onClick = {
+                        if (isInSelectionMode) {
+                          viewModel.toggleSelection(entity.id)
+                        } else {
+                          MediaUtils.playFile(
+                            entity.secureFilePath,
+                            context,
+                            launchSource = "secure_folder",
+                            title = entity.fileName,
+                          )
+                        }
+                      },
+                      onLongClick = { viewModel.handleLongClick(entity.id) },
+                      onThumbClick = {
+                        if (isInSelectionMode) {
+                          viewModel.toggleSelection(entity.id)
+                        } else {
+                          MediaUtils.playFile(
+                            entity.secureFilePath,
+                            context,
+                            launchSource = "secure_folder",
+                            title = entity.fileName,
+                          )
+                        }
+                      },
+                      isGridMode = false,
+                      allowThumbnailGeneration = true,
+                      allowThumbnailLoading = !isScrollbarDragging,
+                      uiConfig = videoCardUiConfig,
+                    )
+                  }
+                }
+
+                if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                  ExpressiveScrollBar(
+                    listState = listState,
+                    dragLabelProvider = { index ->
+                      fastScrollGlyph(sortedSecureMediaVideos.getOrNull(index)?.second?.displayName)
+                    },
+                    onDragStateChanged = { isDragging -> isScrollbarDragging = isDragging },
+                    modifier =
+                      Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 2.dp, top = 6.dp, bottom = 6.dp)
+                        .graphicsLayer { alpha = scrollbarAlpha },
+                  )
+                }
+              }
             }
           }
         }
@@ -269,10 +538,7 @@ data object SecureFolderScreen : Screen {
       isOpen = changePinOpen,
       preferences = viewModel.preferences,
       onDismiss = { changePinOpen = false },
-      onChanged = {
-        // No separate ViewModel state to update — SecureFolderPreferences already
-        // persisted the new hash, and the gate re-reads it on next entry.
-      },
+      onChanged = {},
     )
 
     ChangeSecurityQuestionDialog(
@@ -281,278 +547,20 @@ data object SecureFolderScreen : Screen {
       onDismiss = { changeSecurityQuestionOpen = false },
       onChanged = {},
     )
+
+    VideoSortDialog(
+      isOpen = sortDialogOpen,
+      onDismiss = { sortDialogOpen = false },
+      sortType = videoSortType,
+      sortOrder = videoSortOrder,
+      onSortTypeChange = { browserPreferences.videoSortType.set(it) },
+      onSortOrderChange = { browserPreferences.videoSortOrder.set(it) },
+      isFolderView = true,
+    )
   }
 }
 
 private enum class PendingAction { RESTORE, DELETE }
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SecureFolderTopBar(
-  isInSelectionMode: Boolean,
-  selectedCount: Int,
-  totalCount: Int,
-  isEntryPointHidden: Boolean,
-  isBusy: Boolean,
-  onBack: () -> Unit,
-  onSelectAll: () -> Unit,
-  onDeselectAll: () -> Unit,
-  onRestoreRequest: () -> Unit,
-  onDeleteRequest: () -> Unit,
-  onToggleEntryPointHidden: () -> Unit,
-  onChangePin: () -> Unit,
-  onChangeSecurityQuestion: () -> Unit,
-) {
-  if (isInSelectionMode) {
-    TopAppBar(
-      title = { Text(stringResource(R.string.secure_folder_selected_count, selectedCount)) },
-      navigationIcon = {
-        IconButton(onClick = onDeselectAll) {
-          Icon(Icons.RoundedFilled.Close, contentDescription = stringResource(R.string.secure_folder_cancel_selection))
-        }
-      },
-      actions = {
-        IconButton(onClick = onSelectAll, enabled = !isBusy && selectedCount < totalCount) {
-          Icon(Icons.RoundedFilled.SelectAll, contentDescription = stringResource(R.string.select_all))
-        }
-        IconButton(onClick = onRestoreRequest, enabled = !isBusy && selectedCount > 0) {
-          Icon(Icons.RoundedFilled.Restore, contentDescription = stringResource(R.string.secure_folder_restore))
-        }
-        IconButton(onClick = onDeleteRequest, enabled = !isBusy && selectedCount > 0) {
-          Icon(Icons.RoundedFilled.Delete, contentDescription = stringResource(R.string.secure_folder_delete_forever), tint = MaterialTheme.colorScheme.error)
-        }
-      },
-    )
-  } else {
-    var menuExpanded by remember { mutableStateOf(false) }
-    TopAppBar(
-      title = { Text(stringResource(R.string.secure_folder_title)) },
-      navigationIcon = {
-        IconButton(onClick = onBack) {
-          Icon(Icons.RoundedFilled.ArrowBack, contentDescription = null)
-        }
-      },
-      actions = {
-        Box {
-          IconButton(onClick = { menuExpanded = true }) {
-            Icon(Icons.RoundedFilled.MoreVert, contentDescription = null)
-          }
-          DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
-            DropdownMenuItem(
-              text = {
-                Text(
-                  if (isEntryPointHidden) {
-                    stringResource(R.string.secure_folder_show_in_preferences)
-                  } else {
-                    stringResource(R.string.secure_folder_hide_from_preferences)
-                  }
-                )
-              },
-              leadingIcon = {
-                Icon(
-                  if (isEntryPointHidden) Icons.RoundedFilled.Visibility else Icons.RoundedFilled.VisibilityOff,
-                  contentDescription = null,
-                )
-              },
-              onClick = {
-                onToggleEntryPointHidden()
-                menuExpanded = false
-              },
-            )
-            DropdownMenuItem(
-              text = { Text(stringResource(R.string.secure_folder_change_pin)) },
-              leadingIcon = { Icon(Icons.RoundedFilled.Lock, contentDescription = null) },
-              onClick = {
-                onChangePin()
-                menuExpanded = false
-              },
-            )
-            DropdownMenuItem(
-              text = { Text(stringResource(R.string.secure_folder_change_security_question)) },
-              leadingIcon = { Icon(Icons.RoundedFilled.HelpOutline, contentDescription = null) },
-              onClick = {
-                onChangeSecurityQuestion()
-                menuExpanded = false
-              },
-            )
-          }
-        }
-      },
-      colors = TopAppBarDefaults.topAppBarColors(),
-    )
-  }
-}
-
-@Composable
-private fun SecureMediaCard(
-  entity: SecureMediaEntity,
-  isSelected: Boolean,
-  isInSelectionMode: Boolean,
-  onClick: () -> Unit,
-  onLongClick: () -> Unit,
-) {
-  // Secure files live in app-private storage, outside MediaStore, so they aren't backed by a
-  // real Video row anywhere. ThumbnailRepository only needs a local file path though (it uses
-  // MediaMetadataRetriever.setDataSource(video.path) for anything without a "://" scheme), so
-  // a minimal Video wrapper around the secure file path lets us reuse the same thumbnail
-  // pipeline/cache as every other screen instead of building a separate one.
-  val thumbnailRepository = koinInject<ThumbnailRepository>()
-  val isAudio = entity.mimeType.startsWith("audio/")
-  val video =
-    remember(entity.id, entity.secureFilePath) {
-      Video(
-        id = entity.id,
-        title = entity.fileName,
-        displayName = entity.fileName,
-        path = entity.secureFilePath,
-        uri = android.net.Uri.fromFile(java.io.File(entity.secureFilePath)),
-        duration = 0L,
-        durationFormatted = "",
-        size = entity.fileSize,
-        sizeFormatted = "",
-        dateModified = entity.dateHidden,
-        dateAdded = entity.dateHidden,
-        mimeType = entity.mimeType,
-        bucketId = "",
-        bucketDisplayName = "",
-        width = 0,
-        height = 0,
-        fps = 0f,
-        resolution = "--",
-        isAudio = isAudio,
-      )
-    }
-
-  val thumbWidthPx = with(LocalDensity.current) { 160.dp.roundToPx() }
-  val aspect = if (isAudio) 1f else 16f / 9f
-  val thumbHeightPx = (thumbWidthPx / aspect).roundToInt()
-
-  val thumbnailKey =
-    remember(video.id, video.dateModified, video.size, thumbWidthPx, thumbHeightPx) {
-      thumbnailRepository.thumbnailKey(video, thumbWidthPx, thumbHeightPx)
-    }
-
-  var thumbnail by
-    remember(thumbnailKey) {
-      mutableStateOf(thumbnailRepository.getThumbnailFromMemory(video, thumbWidthPx, thumbHeightPx))
-    }
-
-  LaunchedEffect(thumbnailKey) {
-    thumbnailRepository.thumbnailReadyKeys
-      .filter { key -> thumbnailRepository.isThumbnailKeyForVideo(key, video) }
-      .collect {
-        thumbnail =
-          withContext(Dispatchers.IO) {
-            thumbnailRepository.getCachedThumbnail(video, thumbWidthPx, thumbHeightPx)
-          }
-      }
-  }
-
-  LaunchedEffect(thumbnailKey) {
-    if (thumbnail == null && !isAudio) {
-      thumbnail =
-        withContext(Dispatchers.IO) {
-          thumbnailRepository.getThumbnail(video, thumbWidthPx, thumbHeightPx)
-        }
-    }
-  }
-
-  Card(
-    modifier =
-      Modifier
-        .fillMaxWidth()
-        .aspectRatio(0.8f)
-        .combinedClickable(
-          interactionSource = remember { MutableInteractionSource() },
-          indication = null,
-          onClick = onClick,
-          onLongClick = onLongClick,
-        ),
-    colors =
-      CardDefaults.cardColors(
-        containerColor =
-          if (isSelected) {
-            MaterialTheme.colorScheme.primaryContainer
-          } else {
-            MaterialTheme.colorScheme.surfaceVariant
-          },
-      ),
-  ) {
-    Box(modifier = Modifier.fillMaxSize()) {
-      Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-      ) {
-        Box(
-          modifier =
-            Modifier
-              .fillMaxWidth()
-              .aspectRatio(aspect)
-              .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-          contentAlignment = Alignment.Center,
-        ) {
-          thumbnail?.let {
-            Image(
-              bitmap = it.asImageBitmap(),
-              contentDescription = entity.fileName,
-              modifier = Modifier.matchParentSize(),
-              contentScale = ContentScale.Crop,
-            )
-          } ?: run {
-            Icon(
-              if (entity.mimeType.startsWith("image/")) Icons.RoundedFilled.CameraAlt else Icons.RoundedFilled.Movie,
-              contentDescription = null,
-              modifier = Modifier.size(36.dp),
-              tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-          }
-        }
-
-        Column(
-          modifier = Modifier.fillMaxWidth().padding(8.dp),
-          horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-          Text(
-            entity.fileName,
-            style = MaterialTheme.typography.labelSmall,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-          )
-          Text(
-            formatFileSize(entity.fileSize),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
-      }
-
-      if (isInSelectionMode) {
-        Box(
-          modifier =
-            Modifier
-              .padding(6.dp)
-              .align(Alignment.TopEnd)
-              .size(22.dp)
-              .clip(RoundedCornerShape(50))
-              .background(
-                if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
-              ),
-          contentAlignment = Alignment.Center,
-        ) {
-          if (isSelected) {
-            Icon(
-              Icons.RoundedFilled.Check,
-              contentDescription = null,
-              modifier = Modifier.size(16.dp),
-              tint = MaterialTheme.colorScheme.onPrimary,
-            )
-          }
-        }
-      }
-    }
-  }
-}
 
 private fun formatFileSize(bytes: Long): String {
   if (bytes <= 0) return "0 B"
@@ -560,3 +568,5 @@ private fun formatFileSize(bytes: Long): String {
   val digitGroups = (ln(bytes.toDouble()) / ln(1024.0)).toInt().coerceIn(0, units.size - 1)
   return "${DecimalFormat("#,##0.#").format(bytes / 1024.0.pow(digitGroups))} ${units[digitGroups]}"
 }
+
+


### PR DESCRIPTION
- Integrate List and Grid view modes in Secure Folder using VideoCard.
- Add VideoSortDialog and sort action button for sorting secure media.
- Unify top bar styling by adopting BrowserTopBar with correct action ordering (3-dot overflow menu to the right of sort icon).
- Remove redundant system bar inset padding to eliminate header-to-content gap.
- Make Secure Folder gate screens (PIN setup/entry & recovery) responsive on tablets matching PermissionDeniedState layout (560dp max width constraint & Surface header icons).