### PR TITLE
refactor(securefolder): clean up

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderAccountDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderAccountDialogs.kt
@@ -51,7 +51,7 @@ fun ChangePinDialog(
   isOpen: Boolean,
   preferences: SecureFolderPreferences,
   onDismiss: () -> Unit,
-  onChanged: () -> Unit,
+  onChanged: () -> Unit = {},
 ) {
   if (!isOpen) return
 
@@ -102,7 +102,7 @@ fun ChangePinDialog(
       Column {
         when (step) {
           AccountDialogStep.VERIFY_CURRENT_PIN ->
-            PinTextField(
+            PinField(
               value = currentPin,
               onValueChange = {
                 currentPin = it.filter(Char::isDigit).take(8)
@@ -114,7 +114,7 @@ fun ChangePinDialog(
               onDone = ::submit,
             )
           AccountDialogStep.ENTER_NEW -> {
-            PinTextField(
+            PinField(
               value = newPin,
               onValueChange = {
                 newPin = it.filter(Char::isDigit).take(8)
@@ -124,7 +124,7 @@ fun ChangePinDialog(
               onToggleShowPin = { showPin = !showPin },
               label = stringResource(R.string.secure_folder_new_pin),
             )
-            PinTextField(
+            PinField(
               value = confirmPin,
               onValueChange = {
                 confirmPin = it.filter(Char::isDigit).take(8)
@@ -171,7 +171,7 @@ fun ChangeSecurityQuestionDialog(
   isOpen: Boolean,
   preferences: SecureFolderPreferences,
   onDismiss: () -> Unit,
-  onChanged: () -> Unit,
+  onChanged: () -> Unit = {},
 ) {
   if (!isOpen) return
 
@@ -220,7 +220,7 @@ fun ChangeSecurityQuestionDialog(
       Column {
         when (step) {
           AccountDialogStep.VERIFY_CURRENT_PIN ->
-            PinTextField(
+            PinField(
               value = currentPin,
               onValueChange = {
                 currentPin = it.filter(Char::isDigit).take(8)
@@ -275,37 +275,4 @@ fun ChangeSecurityQuestionDialog(
   )
 }
 
-/** Small local PIN field — [SecureFolderGateScreen]'s `PinField` is `private`, so this mirrors it rather than reaching across files. */
-@Composable
-private fun PinTextField(
-  value: String,
-  onValueChange: (String) -> Unit,
-  showPin: Boolean,
-  onToggleShowPin: () -> Unit,
-  label: String,
-  modifier: Modifier = Modifier,
-  onDone: () -> Unit = {},
-) {
-  OutlinedTextField(
-    value = value,
-    onValueChange = onValueChange,
-    label = { Text(label) },
-    singleLine = true,
-    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword, imeAction = ImeAction.Done),
-    keyboardActions = KeyboardActions(onDone = { onDone() }),
-    visualTransformation = if (showPin) VisualTransformation.None else PasswordVisualTransformation(),
-    trailingIcon = {
-      IconButton(onClick = onToggleShowPin) {
-        Icon(
-          if (showPin) Icons.RoundedFilled.VisibilityOff else Icons.RoundedFilled.Visibility,
-          contentDescription = if (showPin) {
-            stringResource(R.string.secure_folder_hide_pin)
-          } else {
-            stringResource(R.string.secure_folder_show_pin)
-          },
-        )
-      }
-    },
-    modifier = modifier.fillMaxWidth(),
-  )
-}
+

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderGateScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderGateScreen.kt
@@ -653,7 +653,7 @@ private fun SecurityQuestionAnswerContent(
  * reveal/hide the digits (masked by default via [PasswordVisualTransformation]).
  */
 @Composable
-private fun PinField(
+internal fun PinField(
   value: String,
   onValueChange: (String) -> Unit,
   showPin: Boolean,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
@@ -72,9 +72,6 @@ import app.gyrolet.mpvrx.utils.media.MediaUtils
 import app.gyrolet.mpvrx.utils.sort.SortUtils
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
-import java.text.DecimalFormat
-import kotlin.math.ln
-import kotlin.math.pow
 import kotlin.math.roundToInt
 
 /**
@@ -170,7 +167,7 @@ data object SecureFolderScreen : Screen {
               duration = 0L,
               durationFormatted = "",
               size = entity.fileSize,
-              sizeFormatted = formatFileSize(entity.fileSize),
+              sizeFormatted = MediaUtils.formatFileSize(entity.fileSize),
               dateModified = entity.dateHidden,
               dateAdded = entity.dateHidden,
               mimeType = entity.mimeType,
@@ -538,14 +535,12 @@ data object SecureFolderScreen : Screen {
       isOpen = changePinOpen,
       preferences = viewModel.preferences,
       onDismiss = { changePinOpen = false },
-      onChanged = {},
     )
 
     ChangeSecurityQuestionDialog(
       isOpen = changeSecurityQuestionOpen,
       preferences = viewModel.preferences,
       onDismiss = { changeSecurityQuestionOpen = false },
-      onChanged = {},
     )
 
     VideoSortDialog(
@@ -562,11 +557,6 @@ data object SecureFolderScreen : Screen {
 
 private enum class PendingAction { RESTORE, DELETE }
 
-private fun formatFileSize(bytes: Long): String {
-  if (bytes <= 0) return "0 B"
-  val units = arrayOf("B", "KB", "MB", "GB")
-  val digitGroups = (ln(bytes.toDouble()) / ln(1024.0)).toInt().coerceIn(0, units.size - 1)
-  return "${DecimalFormat("#,##0.#").format(bytes / 1024.0.pow(digitGroups))} ${units[digitGroups]}"
-}
+
 
 

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
@@ -17,6 +17,7 @@ import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerLookupHints
 import `is`.xyz.mpv.Utils
 import java.io.File
+import kotlin.math.pow
 
 data class PlaybackSubtitleTrack(
   val url: String,
@@ -294,5 +295,12 @@ object MediaUtils {
         if (uris.size == 1) "Share video" else "Share ${uris.size} videos",
       ),
     )
+  }
+
+  fun formatFileSize(bytes: Long): String {
+    if (bytes <= 0) return "0 B"
+    val units = arrayOf("B", "KB", "MB", "GB")
+    val digitGroups = (kotlin.math.ln(bytes.toDouble()) / kotlin.math.ln(1024.0)).toInt().coerceIn(0, units.size - 1)
+    return "${java.text.DecimalFormat("#,##0.#").format(bytes / 1024.0.pow(digitGroups))} ${units[digitGroups]}"
   }
 }


### PR DESCRIPTION
- Remove duplicate PIN field and formatFileSizehelper
- Reuse PinField composable across secure folder account dialogs 
- Centralize formatFileSize helper in MediaUtils
- Clean up unused imports.