### PR TITLE
feat: add in-app video picker for Playlists and Secure Folder

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistAddVideosScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistAddVideosScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistAddVideosScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistAddVideosScreen.kt
@@ -1,0 +1,265 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.browser.playlist
+
+import android.app.Application
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import app.gyrolet.mpvrx.R
+import app.gyrolet.mpvrx.domain.media.model.Video
+import app.gyrolet.mpvrx.domain.media.model.VideoFolder
+import app.gyrolet.mpvrx.preferences.BrowserPreferences
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
+import app.gyrolet.mpvrx.presentation.Screen
+import app.gyrolet.mpvrx.ui.browser.cards.FolderCard
+import app.gyrolet.mpvrx.ui.browser.cards.VideoCard
+import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
+import app.gyrolet.mpvrx.ui.browser.dialogs.FolderSortDialog
+import app.gyrolet.mpvrx.ui.browser.dialogs.VideoSortDialog
+import app.gyrolet.mpvrx.ui.browser.folderlist.FolderListViewModel
+import app.gyrolet.mpvrx.ui.browser.selection.rememberSelectionManager
+import app.gyrolet.mpvrx.ui.browser.states.EmptyState
+import app.gyrolet.mpvrx.ui.browser.videolist.VideoListViewModel
+import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.utils.LocalBackStack
+import app.gyrolet.mpvrx.ui.utils.popSafely
+import app.gyrolet.mpvrx.utils.sort.SortUtils
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import org.koin.compose.koinInject
+
+/**
+ * In-app file picker for adding videos to a playlist: browse storage folders (same folder
+ * browsing/sort experience as [app.gyrolet.mpvrx.ui.browser.folderlist.FolderListScreen]), drill
+ * into one and multi-select videos using the app's own [rememberSelectionManager] + [BrowserTopBar]
+ * (same as [app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen]), then add them to the
+ * playlist via [PlaylistDetailViewModel.addVideosToPlaylist] — mirrors
+ * [app.gyrolet.mpvrx.ui.securefolder.SecureFolderAddFilesScreen] for the Secure Folder flow.
+ */
+@Serializable
+data class PlaylistAddVideosScreen(
+  val playlistId: Int,
+) : Screen {
+  @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+  @Composable
+  override fun Content() {
+    val context = LocalContext.current
+    val application = context.applicationContext as Application
+    val backstack = LocalBackStack.current
+    val scope = rememberCoroutineScope()
+
+    val browserPreferences = koinInject<BrowserPreferences>()
+
+    val playlistDetailViewModel: PlaylistDetailViewModel =
+      viewModel(
+        key = "PlaylistDetailViewModel_$playlistId",
+        factory = PlaylistDetailViewModel.factory(application, playlistId),
+      )
+
+    // Folder list step (mirrors FolderListScreen's browsing + sort)
+    val folderListViewModel: FolderListViewModel =
+      viewModel(factory = FolderListViewModel.factory(application))
+    val videoFolders by folderListViewModel.videoFolders.collectAsState()
+    val folderSortType by browserPreferences.folderSortType.collectAsState()
+    val folderSortOrder by browserPreferences.folderSortOrder.collectAsState()
+    val sortedFolders = remember(videoFolders, folderSortType, folderSortOrder) {
+      SortUtils.sortFolders(videoFolders, folderSortType, folderSortOrder)
+    }
+
+    var selectedFolder by remember { mutableStateOf<VideoFolder?>(null) }
+    val folder = selectedFolder
+
+    var sortDialogOpen by remember { mutableStateOf(false) }
+
+    // Video list step (mirrors VideoListScreen's browsing, sort and selection)
+    val videoListViewModel: VideoListViewModel? =
+      if (folder != null) {
+        viewModel(
+          key = "PlaylistAddVideosVideos_${folder.bucketId}",
+          factory = VideoListViewModel.factory(application, folder.bucketId),
+        )
+      } else {
+        null
+      }
+    val currentVideos: List<Video> =
+      if (videoListViewModel != null) {
+        videoListViewModel.videos.collectAsState().value
+      } else {
+        emptyList()
+      }
+    val videoSortType by browserPreferences.videoSortType.collectAsState()
+    val videoSortOrder by browserPreferences.videoSortOrder.collectAsState()
+    val sortedVideos = remember(currentVideos, videoSortType, videoSortOrder) {
+      SortUtils.sortVideos(currentVideos, videoSortType, videoSortOrder)
+    }
+
+    val selectionManager =
+      if (folder != null) {
+        key(folder.bucketId) {
+          rememberSelectionManager(
+            items = sortedVideos,
+            getId = { it.id },
+            onDeleteItems = { _, _ -> 0 to 0 },
+          )
+        }
+      } else {
+        null
+      }
+
+    fun addSelectedToPlaylist() {
+      val videos = selectionManager?.getSelectedItems() ?: emptyList()
+      if (videos.isEmpty()) return
+      scope.launch {
+        playlistDetailViewModel.addVideosToPlaylist(videos)
+        Toast
+          .makeText(
+            context,
+            context.getString(R.string.playlist_add_videos_success, videos.size),
+            Toast.LENGTH_SHORT,
+          ).show()
+        selectionManager?.clear()
+        backstack.popSafely()
+      }
+    }
+
+    BackHandler {
+      when {
+        selectionManager?.isInSelectionMode == true -> selectionManager.clear()
+        folder != null -> selectedFolder = null
+        else -> backstack.popSafely()
+      }
+    }
+
+    Scaffold(
+      topBar = {
+        if (folder == null) {
+          BrowserTopBar(
+            title = stringResource(R.string.playlist_add_videos_title),
+            isInSelectionMode = false,
+            selectedCount = 0,
+            totalCount = sortedFolders.size,
+            onCancelSelection = {},
+            onBackClick = { backstack.popSafely() },
+            onSortClick = { sortDialogOpen = true },
+          )
+        } else {
+          BrowserTopBar(
+            title = folder.name,
+            isInSelectionMode = selectionManager?.isInSelectionMode == true,
+            selectedCount = selectionManager?.selectedCount ?: 0,
+            totalCount = sortedVideos.size,
+            onCancelSelection = { selectionManager?.clear() },
+            onBackClick = { selectedFolder = null },
+            onSortClick = { sortDialogOpen = true },
+            onSelectAll = { selectionManager?.selectAll() },
+            onInvertSelection = { selectionManager?.invertSelection() },
+            onDeselectAll = { selectionManager?.clear() },
+          )
+        }
+      },
+      bottomBar = {
+        val selectedCount = selectionManager?.selectedCount ?: 0
+        if (selectedCount > 0) {
+          Surface(tonalElevation = 3.dp) {
+            Button(
+              onClick = { addSelectedToPlaylist() },
+              modifier = Modifier.fillMaxWidth().padding(16.dp),
+            ) {
+              Text(stringResource(R.string.playlist_add_videos_button, selectedCount))
+            }
+          }
+        }
+      },
+    ) { padding ->
+      if (folder == null) {
+        if (sortedFolders.isEmpty()) {
+          EmptyState(
+            icon = Icons.RoundedFilled.Folder,
+            title = stringResource(R.string.playlist_add_videos_empty_title),
+            message = stringResource(R.string.playlist_add_videos_empty_message),
+            modifier = Modifier.padding(padding),
+          )
+        } else {
+          LazyColumn(modifier = Modifier.padding(padding)) {
+            items(sortedFolders, key = { it.bucketId }) { videoFolder ->
+              FolderCard(
+                folder = videoFolder,
+                onClick = { selectedFolder = videoFolder },
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+              )
+            }
+          }
+        }
+      } else if (sortedVideos.isEmpty()) {
+        EmptyState(
+          icon = Icons.RoundedFilled.Folder,
+          title = stringResource(R.string.playlist_add_videos_empty_title),
+          message = stringResource(R.string.playlist_add_videos_empty_message),
+          modifier = Modifier.padding(padding),
+        )
+      } else {
+        LazyColumn(modifier = Modifier.padding(padding)) {
+          items(sortedVideos, key = { it.id }) { video: Video ->
+            VideoCard(
+              video = video,
+              isSelected = selectionManager?.isSelected(video) == true,
+              onClick = { selectionManager?.toggle(video) },
+              onThumbClick = { selectionManager?.toggle(video) },
+              onLongClick = { selectionManager?.handleLongClick(video) },
+              modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            )
+          }
+        }
+      }
+    }
+
+    if (folder == null) {
+      FolderSortDialog(
+        isOpen = sortDialogOpen,
+        onDismiss = { sortDialogOpen = false },
+        sortType = folderSortType,
+        sortOrder = folderSortOrder,
+        onSortTypeChange = { browserPreferences.folderSortType.set(it) },
+        onSortOrderChange = { browserPreferences.folderSortOrder.set(it) },
+      )
+    } else {
+      VideoSortDialog(
+        isOpen = sortDialogOpen,
+        onDismiss = { sortDialogOpen = false },
+        sortType = videoSortType,
+        sortOrder = videoSortOrder,
+        onSortTypeChange = { browserPreferences.videoSortType.set(it) },
+        onSortOrderChange = { browserPreferences.videoSortOrder.set(it) },
+      )
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -470,7 +471,15 @@ data class PlaylistDetailScreen(
           )
         }
       },
-      floatingActionButton = { },
+      floatingActionButton = {
+        if (!isSearching && !isReorderMode && !selectionManager.isInSelectionMode) {
+          ExtendedFloatingActionButton(
+            onClick = { backStack.add(PlaylistAddVideosScreen(playlistId)) },
+            icon = { Icon(Icons.RoundedFilled.Add, contentDescription = null) },
+            text = { Text(stringResource(R.string.playlist_add_videos)) },
+          )
+        }
+      },
     ) { padding ->
       // Show "no results" message when searching with no results
       if (isSearching && filteredVideoItems.isEmpty() && searchQuery.isNotBlank()) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistDetailViewModel.kt
@@ -206,6 +206,10 @@ class PlaylistDetailViewModel(
     playlistRepository.removeItemsFromPlaylist(itemsToRemove)
   }
 
+  suspend fun addVideosToPlaylist(videos: List<Video>) {
+    playlistRepository.addItemsToPlaylist(playlistId, videos.map { it.path to it.displayName })
+  }
+
   suspend fun updatePlayHistory(
     filePath: String,
     position: Long = 0,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderAddFilesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderAddFilesScreen.kt
@@ -1,0 +1,298 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.securefolder
+
+import android.app.Application
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import app.gyrolet.mpvrx.R
+import app.gyrolet.mpvrx.database.repository.SecureFolderRepository
+import app.gyrolet.mpvrx.domain.media.model.Video
+import app.gyrolet.mpvrx.domain.media.model.VideoFolder
+import app.gyrolet.mpvrx.preferences.BrowserPreferences
+import app.gyrolet.mpvrx.preferences.SecureFolderPreferences
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
+import app.gyrolet.mpvrx.presentation.Screen
+import app.gyrolet.mpvrx.ui.browser.cards.FolderCard
+import app.gyrolet.mpvrx.ui.browser.cards.VideoCard
+import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
+import app.gyrolet.mpvrx.ui.browser.dialogs.FolderSortDialog
+import app.gyrolet.mpvrx.ui.browser.dialogs.VideoSortDialog
+import app.gyrolet.mpvrx.ui.browser.folderlist.FolderListViewModel
+import app.gyrolet.mpvrx.ui.browser.selection.rememberSelectionManager
+import app.gyrolet.mpvrx.ui.browser.states.EmptyState
+import app.gyrolet.mpvrx.ui.browser.videolist.VideoListViewModel
+import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.utils.LocalBackStack
+import app.gyrolet.mpvrx.ui.utils.popSafely
+import app.gyrolet.mpvrx.utils.sort.SortUtils
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import org.koin.compose.koinInject
+
+/**
+ * In-app file picker for the Secure Folder: browse storage folders (same folder browsing/sort
+ * experience as [app.gyrolet.mpvrx.ui.browser.folderlist.FolderListScreen]), drill into one and
+ * multi-select videos using the app's own [rememberSelectionManager] + [BrowserTopBar] (same as
+ * [app.gyrolet.mpvrx.ui.browser.videolist.VideoListScreen]), then move them in — all without
+ * leaving the Secure Folder flow. The actual move reuses [SecureFolderRepository.moveIn] and the
+ * existing [SecureConfirmDialog] / [SecureFolderProgressDialog] flow.
+ */
+@Serializable
+data object SecureFolderAddFilesScreen : Screen {
+  @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+  @Composable
+  override fun Content() {
+    val context = LocalContext.current
+    val application = context.applicationContext as Application
+    val backstack = LocalBackStack.current
+    val scope = rememberCoroutineScope()
+
+    val secureFolderRepository = koinInject<SecureFolderRepository>()
+    val secureFolderPreferences = koinInject<SecureFolderPreferences>()
+    val browserPreferences = koinInject<BrowserPreferences>()
+
+    // Folder list step (mirrors FolderListScreen's browsing + sort)
+    val folderListViewModel: FolderListViewModel =
+      viewModel(factory = FolderListViewModel.factory(application))
+    val videoFolders by folderListViewModel.videoFolders.collectAsState()
+    val folderSortType by browserPreferences.folderSortType.collectAsState()
+    val folderSortOrder by browserPreferences.folderSortOrder.collectAsState()
+    val sortedFolders = remember(videoFolders, folderSortType, folderSortOrder) {
+      SortUtils.sortFolders(videoFolders, folderSortType, folderSortOrder)
+    }
+
+    var selectedFolder by remember { mutableStateOf<VideoFolder?>(null) }
+    val folder = selectedFolder
+
+    var sortDialogOpen by remember { mutableStateOf(false) }
+    var confirmOpen by remember { mutableStateOf(false) }
+    var progressOpen by remember { mutableStateOf(false) }
+    val progress by secureFolderRepository.progress.collectAsState()
+
+    // Video list step (mirrors VideoListScreen's browsing, sort and selection)
+    val videoListViewModel: VideoListViewModel? =
+      if (folder != null) {
+        viewModel(
+          key = "SecureFolderAddFilesVideos_${folder.bucketId}",
+          factory = VideoListViewModel.factory(application, folder.bucketId),
+        )
+      } else {
+        null
+      }
+    val currentVideos: List<Video> =
+      if (videoListViewModel != null) {
+        videoListViewModel.videos.collectAsState().value
+      } else {
+        emptyList()
+      }
+    val videoSortType by browserPreferences.videoSortType.collectAsState()
+    val videoSortOrder by browserPreferences.videoSortOrder.collectAsState()
+    val sortedVideos = remember(currentVideos, videoSortType, videoSortOrder) {
+      SortUtils.sortVideos(currentVideos, videoSortType, videoSortOrder)
+    }
+
+    val selectionManager =
+      if (folder != null) {
+        key(folder.bucketId) {
+          rememberSelectionManager(
+            items = sortedVideos,
+            getId = { it.id },
+            onDeleteItems = { _, _ -> 0 to 0 },
+          )
+        }
+      } else {
+        null
+      }
+
+    fun addSelectedToSecureFolder() {
+      val videos = selectionManager?.getSelectedItems() ?: emptyList()
+      if (videos.isEmpty()) return
+      progressOpen = true
+      scope.launch {
+        val result = secureFolderRepository.moveIn(context, videos)
+        progressOpen = false
+        result
+          .onSuccess { batch ->
+            val message =
+              if (batch.failedIds.isEmpty()) {
+                context.getString(R.string.secure_folder_moved_success, batch.succeededIds.size)
+              } else {
+                context.getString(R.string.secure_folder_moved_partial, batch.succeededIds.size, batch.failedIds.size)
+              }
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+          }.onFailure {
+            Toast.makeText(context, context.getString(R.string.secure_folder_move_failed), Toast.LENGTH_SHORT).show()
+          }
+        selectionManager?.clear()
+        backstack.popSafely()
+      }
+    }
+
+    BackHandler {
+      when {
+        selectionManager?.isInSelectionMode == true -> selectionManager.clear()
+        folder != null -> selectedFolder = null
+        else -> backstack.popSafely()
+      }
+    }
+
+    Scaffold(
+      topBar = {
+        if (folder == null) {
+          BrowserTopBar(
+            title = stringResource(R.string.secure_folder_add_files_title),
+            isInSelectionMode = false,
+            selectedCount = 0,
+            totalCount = sortedFolders.size,
+            onCancelSelection = {},
+            onBackClick = { backstack.popSafely() },
+            onSortClick = { sortDialogOpen = true },
+          )
+        } else {
+          BrowserTopBar(
+            title = folder.name,
+            isInSelectionMode = selectionManager?.isInSelectionMode == true,
+            selectedCount = selectionManager?.selectedCount ?: 0,
+            totalCount = sortedVideos.size,
+            onCancelSelection = { selectionManager?.clear() },
+            onBackClick = { selectedFolder = null },
+            onSortClick = { sortDialogOpen = true },
+            onSelectAll = { selectionManager?.selectAll() },
+            onInvertSelection = { selectionManager?.invertSelection() },
+            onDeselectAll = { selectionManager?.clear() },
+          )
+        }
+      },
+      bottomBar = {
+        val selectedCount = selectionManager?.selectedCount ?: 0
+        if (selectedCount > 0) {
+          Surface(tonalElevation = 3.dp) {
+            Button(
+              onClick = {
+                if (secureFolderPreferences.dontAskBeforeMove.get()) {
+                  addSelectedToSecureFolder()
+                } else {
+                  confirmOpen = true
+                }
+              },
+              modifier = Modifier.fillMaxWidth().padding(16.dp),
+            ) {
+              Text(stringResource(R.string.secure_folder_add_files_button, selectedCount))
+            }
+          }
+        }
+      },
+    ) { padding ->
+      if (folder == null) {
+        if (sortedFolders.isEmpty()) {
+          EmptyState(
+            icon = Icons.RoundedFilled.Folder,
+            title = stringResource(R.string.secure_folder_add_files_empty_title),
+            message = stringResource(R.string.secure_folder_add_files_empty_message),
+            modifier = Modifier.padding(padding),
+          )
+        } else {
+          LazyColumn(modifier = Modifier.padding(padding)) {
+            items(sortedFolders, key = { it.bucketId }) { videoFolder ->
+              FolderCard(
+                folder = videoFolder,
+                onClick = { selectedFolder = videoFolder },
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+              )
+            }
+          }
+        }
+      } else if (sortedVideos.isEmpty()) {
+        EmptyState(
+          icon = Icons.RoundedFilled.Folder,
+          title = stringResource(R.string.secure_folder_add_files_empty_title),
+          message = stringResource(R.string.secure_folder_add_files_empty_message),
+          modifier = Modifier.padding(padding),
+        )
+      } else {
+        LazyColumn(modifier = Modifier.padding(padding)) {
+          items(sortedVideos, key = { it.id }) { video: Video ->
+            VideoCard(
+              video = video,
+              isSelected = selectionManager?.isSelected(video) == true,
+              onClick = { selectionManager?.toggle(video) },
+              onThumbClick = { selectionManager?.toggle(video) },
+              onLongClick = { selectionManager?.handleLongClick(video) },
+              modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            )
+          }
+        }
+      }
+    }
+
+    if (folder == null) {
+      FolderSortDialog(
+        isOpen = sortDialogOpen,
+        onDismiss = { sortDialogOpen = false },
+        sortType = folderSortType,
+        sortOrder = folderSortOrder,
+        onSortTypeChange = { browserPreferences.folderSortType.set(it) },
+        onSortOrderChange = { browserPreferences.folderSortOrder.set(it) },
+      )
+    } else {
+      VideoSortDialog(
+        isOpen = sortDialogOpen,
+        onDismiss = { sortDialogOpen = false },
+        sortType = videoSortType,
+        sortOrder = videoSortOrder,
+        onSortTypeChange = { browserPreferences.videoSortType.set(it) },
+        onSortOrderChange = { browserPreferences.videoSortOrder.set(it) },
+      )
+    }
+
+    SecureConfirmDialog(
+      isOpen = confirmOpen,
+      title = stringResource(R.string.secure_folder_move_items_title, selectionManager?.selectedCount ?: 0),
+      subtitle = stringResource(R.string.secure_folder_move_items_subtitle),
+      dontAskAgain = secureFolderPreferences.dontAskBeforeMove,
+      onConfirm = {
+        confirmOpen = false
+        addSelectedToSecureFolder()
+      },
+      onDismiss = { confirmOpen = false },
+    )
+
+    SecureFolderProgressDialog(
+      isOpen = progressOpen,
+      progress = progress,
+      label = stringResource(R.string.secure_folder_moving_progress),
+      onCancel = { secureFolderRepository.cancelOperation() },
+    )
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -331,6 +332,15 @@ data object SecureFolderScreen : Screen {
       snackbarHost = {
         SnackbarHost(snackbarHostState) { data ->
           Snackbar(snackbarData = data)
+        }
+      },
+      floatingActionButton = {
+        if (!isInSelectionMode) {
+          ExtendedFloatingActionButton(
+            onClick = { backstack.add(SecureFolderAddFilesScreen) },
+            icon = { Icon(Icons.RoundedFilled.Add, contentDescription = null) },
+            text = { Text(stringResource(R.string.secure_folder_add_files)) },
+          )
         }
       },
     ) { padding ->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1186,6 +1186,12 @@
   <string name="ui_try_a_different_search_term">جرّب عبارة بحث مختلفة</string>
   <string name="ui_no_videos_in_playlist">لا توجد مقاطع فيديو في قائمة التشغيل</string>
   <string name="ui_add_videos_to_get_started">أضف مقاطع فيديو للبدء</string>
+  <string name="playlist_add_videos">إضافة مقاطع فيديو</string>
+  <string name="playlist_add_videos_title">تحديد مقاطع الفيديو للإضافة</string>
+  <string name="playlist_add_videos_button">إضافة %1$d إلى قائمة التشغيل</string>
+  <string name="playlist_add_videos_empty_title">لم يتم العثور على مقاطع فيديو</string>
+  <string name="playlist_add_videos_empty_message">لا توجد مقاطع فيديو متاحة للإضافة الآن.</string>
+  <string name="playlist_add_videos_success">تمت إضافة %1$d ملف(ات) إلى قائمة التشغيل</string>
   <string name="ui_saved">تم الحفظ</string>
   <string name="ui_stream_url">رابط البث</string>
   <string name="ui_remove_from_playlist">إزالة من قائمة التشغيل</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1589,6 +1589,11 @@
   <string name="secure_folder_sq_city">في أي مدينة ولدت؟</string>
   <string name="secure_folder_sq_nickname">ما هو لقب طفولتك؟</string>
   <string name="secure_folder_sq_movie">ما هو فيلمك المفضل؟</string>
+  <string name="secure_folder_add_files">إضافة ملفات</string>
+  <string name="secure_folder_add_files_title">تحديد الملفات للإضافة</string>
+  <string name="secure_folder_add_files_button">إضافة %1$d إلى المجلد الآمن</string>
+  <string name="secure_folder_add_files_empty_title">لم يتم العثور على مقاطع فيديو</string>
+  <string name="secure_folder_add_files_empty_message">لا توجد مقاطع فيديو متاحة للإضافة الآن.</string>
   <string name="secure_folder_empty_title">لا يوجد شيء مخفي بعد</string>
   <string name="secure_folder_empty_message">الملفات التي تنقلها إلى هنا لن تظهر في أي مكان آخر في التطبيق.</string>
   <string name="secure_folder_restore_confirm_title">استعادة %1$d عنصر؟</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1589,6 +1589,11 @@ Bitte starten Sie die App neu, damit alle Änderungen wirksam werden.</string>
   <string name="secure_folder_sq_city">In welcher Stadt wurden Sie geboren?</string>
   <string name="secure_folder_sq_nickname">Wie lautete Ihr Spitzname in der Kindheit?</string>
   <string name="secure_folder_sq_movie">Was ist Ihr Lieblingsfilm?</string>
+  <string name="secure_folder_add_files">Dateien hinzufügen</string>
+  <string name="secure_folder_add_files_title">Dateien zum Hinzufügen auswählen</string>
+  <string name="secure_folder_add_files_button">%1$d zum Sicheren Ordner hinzufügen</string>
+  <string name="secure_folder_add_files_empty_title">Keine Videos gefunden</string>
+  <string name="secure_folder_add_files_empty_message">Derzeit sind keine Videos zum Hinzufügen verfügbar.</string>
   <string name="secure_folder_empty_title">Noch nichts versteckt</string>
   <string name="secure_folder_empty_message">Dateien, die Sie hierher verschieben, werden nirgendwo sonst in der App angezeigt.</string>
   <string name="secure_folder_restore_confirm_title">%1$d Element(e) wiederherstellen?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1186,6 +1186,12 @@ Bitte starten Sie die App neu, damit alle Änderungen wirksam werden.</string>
   <string name="ui_try_a_different_search_term">Anderen Suchbegriff versuchen</string>
   <string name="ui_no_videos_in_playlist">Keine Videos in der Wiedergabeliste</string>
   <string name="ui_add_videos_to_get_started">Videos hinzufügen, um zu beginnen</string>
+  <string name="playlist_add_videos">Videos hinzufügen</string>
+  <string name="playlist_add_videos_title">Videos zum Hinzufügen auswählen</string>
+  <string name="playlist_add_videos_button">%1$d zur Wiedergabeliste hinzufügen</string>
+  <string name="playlist_add_videos_empty_title">Keine Videos gefunden</string>
+  <string name="playlist_add_videos_empty_message">Derzeit sind keine Videos zum Hinzufügen verfügbar.</string>
+  <string name="playlist_add_videos_success">%1$d Datei(en) zur Wiedergabeliste hinzugefügt</string>
   <string name="ui_saved">Gespeichert</string>
   <string name="ui_stream_url">Stream-URL</string>
   <string name="ui_remove_from_playlist">Aus Wiedergabeliste entfernen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1186,6 +1186,12 @@ Reinicia la aplicación para que se apliquen todos los cambios.</string>
   <string name="ui_try_a_different_search_term">Prueba con otro término de búsqueda</string>
   <string name="ui_no_videos_in_playlist">No hay videos en la lista de reproducción</string>
   <string name="ui_add_videos_to_get_started">Añade videos para empezar</string>
+  <string name="playlist_add_videos">Añadir videos</string>
+  <string name="playlist_add_videos_title">Seleccionar videos para añadir</string>
+  <string name="playlist_add_videos_button">Añadir %1$d a la lista de reproducción</string>
+  <string name="playlist_add_videos_empty_title">No se encontraron videos</string>
+  <string name="playlist_add_videos_empty_message">No hay videos disponibles para añadir en este momento.</string>
+  <string name="playlist_add_videos_success">Se añadieron %1$d video(s) a la lista de reproducción</string>
   <string name="ui_saved">Guardado</string>
   <string name="ui_stream_url">URL de transmisión</string>
   <string name="ui_remove_from_playlist">Eliminar de la lista de reproducción</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1589,6 +1589,11 @@ Reinicia la aplicación para que se apliquen todos los cambios.</string>
   <string name="secure_folder_sq_city">¿En qué ciudad naciste?</string>
   <string name="secure_folder_sq_nickname">¿Cuál era tu apodo de la infancia?</string>
   <string name="secure_folder_sq_movie">¿Cuál es tu película favorita?</string>
+  <string name="secure_folder_add_files">Añadir archivos</string>
+  <string name="secure_folder_add_files_title">Seleccionar archivos para añadir</string>
+  <string name="secure_folder_add_files_button">Añadir %1$d a Carpeta segura</string>
+  <string name="secure_folder_add_files_empty_title">No se encontraron vídeos</string>
+  <string name="secure_folder_add_files_empty_message">No hay vídeos disponibles para añadir en este momento.</string>
   <string name="secure_folder_empty_title">Nada oculto todavía</string>
   <string name="secure_folder_empty_message">Los archivos que muevas aquí no aparecerán en ningún otro lugar de la aplicación.</string>
   <string name="secure_folder_restore_confirm_title">¿Restaurar %1$d elemento(s)?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1186,6 +1186,12 @@ Veuillez redémarrer l’application pour appliquer toutes les modifications.</s
   <string name="ui_try_a_different_search_term">Essayez un autre terme de recherche</string>
   <string name="ui_no_videos_in_playlist">Aucune vidéo dans la liste de lecture</string>
   <string name="ui_add_videos_to_get_started">Ajoutez des vidéos pour commencer</string>
+  <string name="playlist_add_videos">Ajouter des vidéos</string>
+  <string name="playlist_add_videos_title">Sélectionner des vidéos à ajouter</string>
+  <string name="playlist_add_videos_button">Ajouter %1$d à la liste de lecture</string>
+  <string name="playlist_add_videos_empty_title">Aucune vidéo trouvée</string>
+  <string name="playlist_add_videos_empty_message">Aucune vidéo disponible à ajouter pour le moment.</string>
+  <string name="playlist_add_videos_success">%1$d vidéo(s) ajoutée(s) à la liste de lecture</string>
   <string name="ui_saved">Enregistré</string>
   <string name="ui_stream_url">URL du flux</string>
   <string name="ui_remove_from_playlist">Retirer de la liste de lecture</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1589,6 +1589,11 @@ Veuillez redémarrer l’application pour appliquer toutes les modifications.</s
   <string name="secure_folder_sq_city">Dans quelle ville êtes-vous né(e) ?</string>
   <string name="secure_folder_sq_nickname">Quel était votre surnom d\'enfance ?</string>
   <string name="secure_folder_sq_movie">Quel est votre film préféré ?</string>
+  <string name="secure_folder_add_files">Ajouter des fichiers</string>
+  <string name="secure_folder_add_files_title">Sélectionner des fichiers à ajouter</string>
+  <string name="secure_folder_add_files_button">Ajouter %1$d au Dossier sécurisé</string>
+  <string name="secure_folder_add_files_empty_title">Aucune vidéo trouvée</string>
+  <string name="secure_folder_add_files_empty_message">Aucune vidéo disponible à ajouter pour le moment.</string>
   <string name="secure_folder_empty_title">Rien de masqué pour l\'instant</string>
   <string name="secure_folder_empty_message">Les fichiers déplacés ici n\'apparaîtront nulle part ailleurs dans l\'application.</string>
   <string name="secure_folder_restore_confirm_title">Restaurer %1$d élément(s) ?</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1124,6 +1124,12 @@
   <string name="ui_try_a_different_search_term">कोई और सर्च टर्म आज़माएं</string>
   <string name="ui_no_videos_in_playlist">प्लेलिस्ट में कोई वीडियो नहीं</string>
   <string name="ui_add_videos_to_get_started">शुरू करने के लिए वीडियो जोड़ें</string>
+  <string name="playlist_add_videos">वीडियो जोड़ें</string>
+  <string name="playlist_add_videos_title">जोड़ने के लिए वीडियो चुनें</string>
+  <string name="playlist_add_videos_button">प्लेलिस्ट में %1$d जोड़ें</string>
+  <string name="playlist_add_videos_empty_title">कोई वीडियो नहीं मिला</string>
+  <string name="playlist_add_videos_empty_message">अभी जोड़ने के लिए कोई वीडियो उपलब्ध नहीं है।</string>
+  <string name="playlist_add_videos_success">प्लेलिस्ट में %1$d फाइलें जोड़ी गईं</string>
   <string name="ui_saved">सेव हुआ</string>
   <string name="ui_stream_url">स्ट्रीम URL</string>
   <string name="ui_remove_from_playlist">प्लेलिस्ट से हटाएं</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1498,6 +1498,11 @@
   <string name="secure_folder_sq_city">आप किस शहर में पैदा हुए थे?</string>
   <string name="secure_folder_sq_nickname">बचपन में आपका उपनाम क्या था?</string>
   <string name="secure_folder_sq_movie">आपकी पसंदीदा फिल्म कौन सी है?</string>
+  <string name="secure_folder_add_files">फाइलें जोड़ें</string>
+  <string name="secure_folder_add_files_title">जोड़ने के लिए फाइलें चुनें</string>
+  <string name="secure_folder_add_files_button">सिक्योर फोल्डर में %1$d जोड़ें</string>
+  <string name="secure_folder_add_files_empty_title">कोई वीडियो नहीं मिला</string>
+  <string name="secure_folder_add_files_empty_message">अभी जोड़ने के लिए कोई वीडियो उपलब्ध नहीं है।</string>
   <string name="secure_folder_empty_title">अभी तक कुछ भी छुपाया नहीं गया</string>
   <string name="secure_folder_empty_message">आप यहां जो फाइलें ले जाएंगे, वे ऐप में और कहीं नहीं दिखेंगी।</string>
   <string name="secure_folder_restore_confirm_title">%1$d आइटम रीस्टोर करें?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1186,6 +1186,12 @@
   <string name="ui_try_a_different_search_term">別の検索語をお試しください</string>
   <string name="ui_no_videos_in_playlist">プレイリストに動画がありません</string>
   <string name="ui_add_videos_to_get_started">動画を追加して始めましょう</string>
+  <string name="playlist_add_videos">動画を追加</string>
+  <string name="playlist_add_videos_title">追加する動画を選択</string>
+  <string name="playlist_add_videos_button">%1$d件をプレイリストに追加</string>
+  <string name="playlist_add_videos_empty_title">動画が見つかりません</string>
+  <string name="playlist_add_videos_empty_message">現在追加できる動画がありません。</string>
+  <string name="playlist_add_videos_success">%1$d件をプレイリストに追加しました</string>
   <string name="ui_saved">保存済み</string>
   <string name="ui_stream_url">ストリームURL</string>
   <string name="ui_remove_from_playlist">プレイリストから削除</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1589,6 +1589,11 @@
   <string name="secure_folder_sq_city">生まれた街の名前は？</string>
   <string name="secure_folder_sq_nickname">子供の頃のニックネームは？</string>
   <string name="secure_folder_sq_movie">一番好きな映画は？</string>
+  <string name="secure_folder_add_files">ファイルを追加</string>
+  <string name="secure_folder_add_files_title">追加するファイルを選択</string>
+  <string name="secure_folder_add_files_button">%1$d件を安全なフォルダに追加</string>
+  <string name="secure_folder_add_files_empty_title">動画が見つかりません</string>
+  <string name="secure_folder_add_files_empty_message">現在追加できる動画がありません。</string>
   <string name="secure_folder_empty_title">非表示のファイルはありません</string>
   <string name="secure_folder_empty_message">ここへ移動したファイルは、アプリ内の他の場所には表示されなくなります。</string>
   <string name="secure_folder_restore_confirm_title">%1$d件のアイテムを元に戻しますか？</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1186,6 +1186,12 @@ Reinicie o aplicativo para que todas as alterações entrem em vigor.</string>
   <string name="ui_try_a_different_search_term">Tente outro termo de pesquisa</string>
   <string name="ui_no_videos_in_playlist">Não há vídeos na playlist</string>
   <string name="ui_add_videos_to_get_started">Adicione vídeos para começar</string>
+  <string name="playlist_add_videos">Adicionar vídeos</string>
+  <string name="playlist_add_videos_title">Selecionar vídeos para adicionar</string>
+  <string name="playlist_add_videos_button">Adicionar %1$d à Playlist</string>
+  <string name="playlist_add_videos_empty_title">Nenhum vídeo encontrado</string>
+  <string name="playlist_add_videos_empty_message">No momento não há vídeos disponíveis para adicionar.</string>
+  <string name="playlist_add_videos_success">%1$d vídeo(s) adicionado(s) à playlist</string>
   <string name="ui_saved">Salvo</string>
   <string name="ui_stream_url">URL da transmissão</string>
   <string name="ui_remove_from_playlist">Remover da playlist</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1589,6 +1589,11 @@ Reinicie o aplicativo para que todas as alterações entrem em vigor.</string>
   <string name="secure_folder_sq_city">Em qual cidade você nasceu?</string>
   <string name="secure_folder_sq_nickname">Qual era o seu apelido de infância?</string>
   <string name="secure_folder_sq_movie">Qual é o seu filme favorito?</string>
+  <string name="secure_folder_add_files">Adicionar arquivos</string>
+  <string name="secure_folder_add_files_title">Selecionar arquivos para adicionar</string>
+  <string name="secure_folder_add_files_button">Adicionar %1$d à Pasta Segura</string>
+  <string name="secure_folder_add_files_empty_title">Nenhum vídeo encontrado</string>
+  <string name="secure_folder_add_files_empty_message">No momento não há vídeos disponíveis para adicionar.</string>
   <string name="secure_folder_empty_title">Nada oculto ainda</string>
   <string name="secure_folder_empty_message">Os arquivos movidos para cá não aparecerão em nenhum outro lugar do aplicativo.</string>
   <string name="secure_folder_restore_confirm_title">Restaurar %1$d item(ns)?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1186,6 +1186,12 @@
   <string name="ui_try_a_different_search_term">Попробуйте другой поисковый запрос</string>
   <string name="ui_no_videos_in_playlist">В плейлисте нет видео</string>
   <string name="ui_add_videos_to_get_started">Добавьте видео, чтобы начать</string>
+  <string name="playlist_add_videos">Добавить видео</string>
+  <string name="playlist_add_videos_title">Выберите видео для добавления</string>
+  <string name="playlist_add_videos_button">Добавить %1$d в плейлист</string>
+  <string name="playlist_add_videos_empty_title">Видео не найдено</string>
+  <string name="playlist_add_videos_empty_message">Сейчас нет доступных видео для добавления.</string>
+  <string name="playlist_add_videos_success">Добавлено %1$d видео в плейлист</string>
   <string name="ui_saved">Сохранено</string>
   <string name="ui_stream_url">URL потока</string>
   <string name="ui_remove_from_playlist">Удалить из плейлиста</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1589,6 +1589,11 @@
   <string name="secure_folder_sq_city">В каком городе вы родились?</string>
   <string name="secure_folder_sq_nickname">Каково было ваше детское прозвище?</string>
   <string name="secure_folder_sq_movie">Какой ваш любимый фильм?</string>
+  <string name="secure_folder_add_files">Добавить файлы</string>
+  <string name="secure_folder_add_files_title">Выберите файлы для добавления</string>
+  <string name="secure_folder_add_files_button">Добавить %1$d в Защищенную папку</string>
+  <string name="secure_folder_add_files_empty_title">Видео не найдено</string>
+  <string name="secure_folder_add_files_empty_message">Сейчас нет доступных видео для добавления.</string>
   <string name="secure_folder_empty_title">Пока ничего не скрыто</string>
   <string name="secure_folder_empty_message">Перемещенные сюда файлы не будут отображаться нигде в приложении.</string>
   <string name="secure_folder_restore_confirm_title">Восстановить %1$d объект(ов)?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1589,6 +1589,11 @@
   <string name="secure_folder_sq_city">您在哪个城市出生？</string>
   <string name="secure_folder_sq_nickname">您小时候的绰号是什么？</string>
   <string name="secure_folder_sq_movie">您最喜欢的电影是什么？</string>
+  <string name="secure_folder_add_files">添加文件</string>
+  <string name="secure_folder_add_files_title">选择要添加的文件</string>
+  <string name="secure_folder_add_files_button">添加 %1$d 个到安全文件夹</string>
+  <string name="secure_folder_add_files_empty_title">未找到视频</string>
+  <string name="secure_folder_add_files_empty_message">目前没有可添加的视频。</string>
   <string name="secure_folder_empty_title">暂无隐藏内容</string>
   <string name="secure_folder_empty_message">移动到这里的文件不会出现在应用中的其他任何地方。</string>
   <string name="secure_folder_restore_confirm_title">恢复 %1$d 个项目？</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1186,6 +1186,12 @@
   <string name="ui_try_a_different_search_term">请尝试其他搜索词</string>
   <string name="ui_no_videos_in_playlist">播放列表中没有视频</string>
   <string name="ui_add_videos_to_get_started">添加视频以开始</string>
+  <string name="playlist_add_videos">添加视频</string>
+  <string name="playlist_add_videos_title">选择要添加的视频</string>
+  <string name="playlist_add_videos_button">添加 %1$d 个到播放列表</string>
+  <string name="playlist_add_videos_empty_title">未找到视频</string>
+  <string name="playlist_add_videos_empty_message">目前没有可添加的视频。</string>
+  <string name="playlist_add_videos_success">已添加 %1$d 个文件到播放列表</string>
   <string name="ui_saved">已保存</string>
   <string name="ui_stream_url">流媒体 URL</string>
   <string name="ui_remove_from_playlist">从播放列表移除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1201,6 +1201,12 @@
   <string name="ui_try_a_different_search_term">Try a different search term</string>
   <string name="ui_no_videos_in_playlist">No videos in playlist</string>
   <string name="ui_add_videos_to_get_started">Add videos to get started</string>
+  <string name="playlist_add_videos">Add videos</string>
+  <string name="playlist_add_videos_title">Select Videos to Add</string>
+  <string name="playlist_add_videos_button">Add %1$d to Playlist</string>
+  <string name="playlist_add_videos_empty_title">No videos found</string>
+  <string name="playlist_add_videos_empty_message">There are no videos available to add right now.</string>
+  <string name="playlist_add_videos_success">Added %1$d file(s) to playlist</string>
   <string name="ui_saved">Saved</string>
   <string name="ui_stream_url">Stream URL</string>
   <string name="ui_remove_from_playlist">Remove from Playlist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1583,6 +1583,11 @@
   <string name="secure_folder_sq_movie">What is your favorite movie?</string>
 
   <!-- Secure Folder Screen -->
+  <string name="secure_folder_add_files">Add files</string>
+  <string name="secure_folder_add_files_title">Select Files to Add</string>
+  <string name="secure_folder_add_files_button">Add %1$d to Secure Folder</string>
+  <string name="secure_folder_add_files_empty_title">No videos found</string>
+  <string name="secure_folder_add_files_empty_message">There are no videos available to add right now.</string>
   <string name="secure_folder_empty_title">Nothing hidden yet</string>
   <string name="secure_folder_empty_message">Files you move here won\'t show up anywhere else in the app.</string>
   <string name="secure_folder_restore_confirm_title">Restore %1$d item(s)?</string>


### PR DESCRIPTION
## Summary
Adds an in-app video picker for both Playlists and Secure Folder, allowing users to browse and multi-select videos directly from device storage without leaving the app.

## Changes
- Add a FAB to the Playlist detail screen to import videos into playlists
- Add a FAB to the Secure Folder screen to import videos
- Reuse the existing browser UI (FolderCard, VideoCard, BrowserTopBar, selection mode, and sort dialogs) for a consistent experience
- Add `PlaylistDetailViewModel.addVideosToPlaylist()`
- Reuse `SecureFolderRepository.moveIn()` for Secure Folder imports
- Add localized `playlist_add_videos*` and `secure_folder_add_files*` strings for all supported languages

## Benefits
- Keeps users inside the app while importing videos
- Supports multi-selection for faster imports
- Maintains a consistent browsing experience across the app
- Reuses existing components instead of introducing duplicate UI