### PR TITLE
fix(player): stabilize decoder, surface restore and seeking

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
@@ -203,9 +203,8 @@ class MPVView(
       boostSdrToHdr = decoderPreferences.boostSdrToHdr.get(),
     )
 
-    // MediaCodec direct rendering is valid only for gpu/opengl/android. Other render backends use
-    // the copy path. Both configurations retain explicit software fallback so a broken vendor
-    // codec never leaves playback stuck on a black frame.
+    // Keep direct -> copy -> software fallback on the standard Android renderer. Backends that
+    // cannot use direct MediaCodec start at the copy path instead.
     PlaybackSession.setOptionString("hwdec", hwdecMode)
     PlaybackSession.setOptionString(
       "hwdec-codecs",
@@ -640,14 +639,14 @@ class MPVView(
       return "no"
     }
 
-    // Android MediaCodec's direct path is only supported by mpv with legacy gpu + android
-    // OpenGL context. gpu-next/Vulkan and androidvk must use the copy path instead.
+    // Direct MediaCodec is only valid with legacy gpu + Android OpenGL. Preserve the copy attempt
+    // after direct on that path, while gpu-next/Vulkan-compatible paths start with copy directly.
     return if (
       backend.vo == "gpu" &&
       backend.gpuApi == "opengl" &&
       backend.gpuContext == "android"
     ) {
-      "mediacodec,no"
+      "mediacodec,mediacodec-copy,no"
     } else {
       "mediacodec-copy,no"
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
@@ -178,7 +178,7 @@ class MPVView(
     PlaybackSession.setOptionString("profile", profile)
     val backend = selectRenderBackend()
     val useVulkan = backend.gpuApi == "vulkan"
-    val hwdecMode = preferredHwdecMode()
+    val hwdecMode = preferredHwdecMode(backend)
     PlaybackSession.setVideoOutput(backend.vo)
     PlaybackSession.setOptionString("gpu-api", backend.gpuApi)
     PlaybackSession.setOptionString("gpu-context", backend.gpuContext)
@@ -203,16 +203,21 @@ class MPVView(
       boostSdrToHdr = decoderPreferences.boostSdrToHdr.get(),
     )
 
-    // Set hwdec with fallback order: HW+ (mediacodec) -> HW (mediacodec-copy) -> SW (no)
+    // MediaCodec direct rendering is valid only for gpu/opengl/android. Other render backends use
+    // the copy path. Both configurations retain explicit software fallback so a broken vendor
+    // codec never leaves playback stuck on a black frame.
+    PlaybackSession.setOptionString("hwdec", hwdecMode)
     PlaybackSession.setOptionString(
-      "hwdec",
-      hwdecMode,
+      "hwdec-codecs",
+      "h264,vc1,hevc,vp8,vp9,av1,prores,prores_raw,ffv1,dpx,apv",
     )
-    PlaybackSession.setOptionString("hwdec-codecs", "all")
+    PlaybackSession.setOptionString("hwdec-software-fallback", "3")
 
-    // Enable direct rendering for hardware decoding (reduces memory copies)
-    PlaybackSession.setOptionString("vd-lavc-dr", "yes")
-    // Queue extra frames to absorb decode jitter on 4K content
+    // Let mpv decide whether direct rendering is actually beneficial for the active backend.
+    // Forcing DR on Android can make a decoder reconfigure fail when the Surface is changing.
+    PlaybackSession.setOptionString("vd-lavc-dr", "auto")
+    PlaybackSession.setOptionString("vd-lavc-threads", "0")
+    // Queue extra frames to absorb decode jitter on 4K content.
     PlaybackSession.setOptionString("vd-lavc-queue", "yes")
 
     if (decoderPreferences.useYUV420P.get()) {
@@ -246,12 +251,14 @@ class MPVView(
     PlaybackSession.setOptionString("hls-bitrate", "no")
     PlaybackSession.setOptionString("http-allow-redirect", "yes")
     // Drop only video-output-bound late frames when rendering cannot keep up.
-    // This prevents long-term jitter buildup without aggressively sacrificing smoothness.
+    // Software emergency handling can still escalate this later without changing the normal path.
     PlaybackSession.setOptionString("framedrop", "vo")
 
     val preciseSeek = playerPreferences.usePreciseSeeking.get()
     PlaybackSession.setOptionString("hr-seek", if (preciseSeek) "yes" else "no")
-    PlaybackSession.setOptionString("hr-seek-framedrop", if (preciseSeek) "no" else "yes")
+    // mpv defaults this to yes. Keeping it enabled is important on HEVC/long-GOP files: frames
+    // before the exact target can be dropped instead of being rendered and starving audio.
+    PlaybackSession.setOptionString("hr-seek-framedrop", "yes")
 
     // Use audio-based video sync for better frame pacing with 4K HDR content.
     // This prevents timing jitter when the display refresh rate doesn't perfectly
@@ -387,6 +394,11 @@ class MPVView(
       "video-params/w" to MPVLib.MpvFormat.MPV_FORMAT_INT64,
       "video-params/h" to MPVLib.MpvFormat.MPV_FORMAT_INT64,
       "container-fps" to MPVLib.MpvFormat.MPV_FORMAT_DOUBLE,
+      "hwdec-current" to MPVLib.MpvFormat.MPV_FORMAT_STRING,
+      "frame-drop-count" to MPVLib.MpvFormat.MPV_FORMAT_INT64,
+      "decoder-frame-drop-count" to MPVLib.MpvFormat.MPV_FORMAT_INT64,
+      "avsync" to MPVLib.MpvFormat.MPV_FORMAT_DOUBLE,
+      "estimated-vf-fps" to MPVLib.MpvFormat.MPV_FORMAT_DOUBLE,
       "eof-reached" to MPVLib.MpvFormat.MPV_FORMAT_FLAG,
       "user-data/mpvrx/show_text" to MPVLib.MpvFormat.MPV_FORMAT_STRING,
       "user-data/mpvrx/toggle_ui" to MPVLib.MpvFormat.MPV_FORMAT_STRING,
@@ -417,6 +429,10 @@ class MPVView(
     PlaybackSession.setOptionString("audio-delay", (audioPreferences.defaultAudioDelay.get() / 1000.0).toString())
     PlaybackSession.setOptionString("audio-pitch-correction", audioPreferences.audioPitchCorrection.get().toString())
     PlaybackSession.setOptionString("volume-max", (audioPreferences.volumeBoostCap.get() + 100).toString())
+    // Keep Android's audio output alive across seeks and fill seek gaps with silence. This avoids
+    // stop/start churn in AudioTrack that can otherwise produce repeated/warbled audio while
+    // scrubbing, without changing the selected track, volume, EQ, or playback speed.
+    PlaybackSession.setOptionString("audio-stream-silence", "yes")
     // Prevent automatic volume normalization when downmixing multi-channel audio
     PlaybackSession.setOptionString("audio-normalize-downmix", "no")
   }
@@ -623,12 +639,22 @@ class MPVView(
     return supported
   }
 
-  private fun preferredHwdecMode(): String {
+  private fun preferredHwdecMode(backend: RenderBackendSelection): String {
     if (!decoderPreferences.tryHWDecoding.get()) {
       return "no"
     }
 
-    return "mediacodec,mediacodec-copy,no"
+    // Android MediaCodec's direct path is only supported by mpv with legacy gpu + android
+    // OpenGL context. gpu-next/Vulkan and androidvk must use the copy path instead.
+    return if (
+      backend.vo == "gpu" &&
+      backend.gpuApi == "opengl" &&
+      backend.gpuContext == "android"
+    ) {
+      "mediacodec,no"
+    } else {
+      "mediacodec-copy,no"
+    }
   }
 
   private fun selectRenderBackend(ignoreForcedOpenGlFallback: Boolean = false): RenderBackendSelection {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
@@ -429,10 +429,6 @@ class MPVView(
     PlaybackSession.setOptionString("audio-delay", (audioPreferences.defaultAudioDelay.get() / 1000.0).toString())
     PlaybackSession.setOptionString("audio-pitch-correction", audioPreferences.audioPitchCorrection.get().toString())
     PlaybackSession.setOptionString("volume-max", (audioPreferences.volumeBoostCap.get() + 100).toString())
-    // Keep Android's audio output alive across seeks and fill seek gaps with silence. This avoids
-    // stop/start churn in AudioTrack that can otherwise produce repeated/warbled audio while
-    // scrubbing, without changing the selected track, volume, EQ, or playback speed.
-    PlaybackSession.setOptionString("audio-stream-silence", "yes")
     // Prevent automatic volume normalization when downmixing multi-channel audio
     PlaybackSession.setOptionString("audio-normalize-downmix", "no")
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -93,6 +93,15 @@ object PlaybackSession : MPVLib.EventObserver {
     val registration: NetworkStreamRegistration? = null,
   )
 
+  /**
+   * Video decoding is intentionally disabled while Android has no render surface. Keep the track
+   * id process-wide so Activity recreation (for example notification re-entry) cannot lose it.
+   */
+  private data class SuspendedVideoTrack(
+    val id: Int,
+    val generation: Long,
+  )
+
   private val nativeLock = ReentrantLock(true)
   private val observers = CopyOnWriteArraySet<MPVLib.EventObserver>()
   private val pendingGenerations = ArrayDeque<Long>()
@@ -111,6 +120,8 @@ object PlaybackSession : MPVLib.EventObserver {
   private var activeRendererConfigurationKey: String? = null
   private var activeNetworkStream: NetworkStreamRegistration? = null
   private val auxiliaryNetworkStreams = linkedMapOf<String, NetworkStreamRegistration>()
+  private var suspendedVideoTrack: SuspendedVideoTrack? = null
+  private var desiredPaused = true
 
   val isInitialized: Boolean
     get() = initialized
@@ -145,6 +156,8 @@ object PlaybackSession : MPVLib.EventObserver {
 
         applicationContext = context.applicationContext
         observedProperties.clear()
+        suspendedVideoTrack = null
+        desiredPaused = true
         updateState { it.copy(phase = PlaybackPhase.INITIALIZING, error = null) }
         try {
           MPVLib.create(context.applicationContext)
@@ -162,13 +175,15 @@ object PlaybackSession : MPVLib.EventObserver {
           observeProperties()
           initialized = true
           activeRendererConfigurationKey = rendererConfigurationKey
-          updateState { it.copy(phase = PlaybackPhase.IDLE, error = null) }
+          updateState { it.copy(phase = PlaybackPhase.IDLE, paused = true, error = null) }
           true
         } catch (error: Throwable) {
           runCatching { MPVLib.removeObserver(this) }
           runCatching { MPVLib.destroy() }
           initialized = false
           activeRendererConfigurationKey = null
+          suspendedVideoTrack = null
+          desiredPaused = true
           updateState {
             it.copy(
               phase = PlaybackPhase.ERROR,
@@ -187,7 +202,14 @@ object PlaybackSession : MPVLib.EventObserver {
   ): Boolean =
     withCore(default = false) {
       if (!surface.isValid) return@withCore false
-      if (_state.value.surfaceAttached) runCatching { MPVLib.detachSurface() }
+
+      // Replacing an already-attached Surface must also detach the hardware video decoder first.
+      // Otherwise MediaCodec can race the old ANativeWindow while the new Surface is attached.
+      if (_state.value.surfaceAttached) {
+        suspendVideoTrackForSurfaceLossLocked()
+        runCatching { MPVLib.detachSurface() }
+      }
+
       MPVLib.attachSurface(surface)
       width?.takeIf { it > 0 }?.let { resolvedWidth ->
         height?.takeIf { it > 0 }?.let { resolvedHeight ->
@@ -197,6 +219,7 @@ object PlaybackSession : MPVLib.EventObserver {
       MPVLib.setOptionString("force-window", "yes")
       MPVLib.setPropertyString("vo", desiredVideoOutput)
       updateState { it.copy(surfaceAttached = true) }
+      restoreSuspendedVideoTrackLocked()
       true
     }
 
@@ -211,6 +234,10 @@ object PlaybackSession : MPVLib.EventObserver {
   fun unbindSurface() {
     withCore(Unit) {
       if (!_state.value.surfaceAttached) return@withCore
+
+      // Never leave a hardware video decoder attached to a Surface that Android is destroying.
+      // Audio remains untouched, so background/audio-only playback continues normally.
+      suspendVideoTrackForSurfaceLossLocked()
       runCatching { MPVLib.setPropertyString("vo", "null") }
       runCatching { MPVLib.setOptionString("force-window", "no") }
       runCatching { MPVLib.detachSurface() }
@@ -232,8 +259,11 @@ object PlaybackSession : MPVLib.EventObserver {
   }
 
   fun markForeground() {
-    updateState { current ->
-      if (current.phase == PlaybackPhase.BACKGROUND) current.copy(phase = PlaybackPhase.READY) else current
+    withCore(Unit) {
+      updateState { current ->
+        if (current.phase == PlaybackPhase.BACKGROUND) current.copy(phase = PlaybackPhase.READY) else current
+      }
+      restoreSuspendedVideoTrackLocked()
     }
   }
 
@@ -242,6 +272,8 @@ object PlaybackSession : MPVLib.EventObserver {
     withCore(Unit) {
       val nextGeneration = _state.value.generation + 1L
       pendingGenerations.clear()
+      suspendedVideoTrack = null
+      desiredPaused = true
       runCatching { MPVLib.command("stop") }
       runCatching { MPVLib.setPropertyBoolean("pause", true) }
       if (clearQueue) _queue.value = PlaybackQueueState()
@@ -255,6 +287,7 @@ object PlaybackSession : MPVLib.EventObserver {
           error = null,
         )
       }
+      propBoolean.emit("pause", true)
     }
     releaseActiveNetworkStream()
     releaseAuxiliaryNetworkStreams()
@@ -270,6 +303,8 @@ object PlaybackSession : MPVLib.EventObserver {
 
   private fun destroyLocked() {
     updateState { it.copy(phase = PlaybackPhase.STOPPING) }
+    desiredPaused = true
+    suspendedVideoTrack = null
     runCatching { MPVLib.setPropertyBoolean("pause", true) }
     runCatching { MPVLib.setPropertyString("vo", "null") }
     runCatching { MPVLib.detachSurface() }
@@ -401,6 +436,9 @@ object PlaybackSession : MPVLib.EventObserver {
     item: PlaybackItem? = null,
   ): Long =
     withCore(default = -1L) {
+      // A saved video-track id belongs to the outgoing file only. Never carry it into a new load.
+      suspendedVideoTrack = null
+      desiredPaused = false
       val generation = _state.value.generation + 1L
       pendingGenerations.addLast(generation)
       val resolvedItem = item ?: PlaybackItem.fromUri(playableUri)
@@ -408,6 +446,7 @@ object PlaybackSession : MPVLib.EventObserver {
         it.copy(
           phase = PlaybackPhase.LOADING,
           generation = generation,
+          paused = false,
           currentItem = resolvedItem,
           error = null,
         )
@@ -419,8 +458,11 @@ object PlaybackSession : MPVLib.EventObserver {
           .joinToString(",") { (name, value) -> "$name: ${value.replace(",", "\\,")}" }
       MPVLib.setPropertyString("user-agent", userAgent.orEmpty())
       MPVLib.setPropertyString("http-header-fields", headerFields)
-      MPVLib.command("loadfile", playableUri, "replace", "-1", "pause=no")
-      updateState { it.copy(paused = false) }
+
+      // Keep the native core paused while tracks/decoder/output are being replaced. Play intent is
+      // kept in desiredPaused and applied exactly once when FILE_LOADED arrives. This prevents the
+      // audio output and UI from racing three separate pause=no writes during startup.
+      MPVLib.command("loadfile", playableUri, "replace", "-1", "pause=yes")
       propBoolean.emit("pause", false)
       generation
     }
@@ -471,7 +513,10 @@ object PlaybackSession : MPVLib.EventObserver {
   fun setPropertyInt(
     property: String,
     value: Int,
-  ) = withCore(Unit) { MPVLib.setPropertyInt(property, value) }
+  ) = withCore(Unit) {
+    MPVLib.setPropertyInt(property, value)
+    if (property == "vid" && value > 0) suspendedVideoTrack = null
+  }
 
   fun getPropertyDouble(property: String): Double? = withCore(null) { MPVLib.getPropertyDouble(property) }
 
@@ -493,18 +538,34 @@ object PlaybackSession : MPVLib.EventObserver {
     property: String,
     value: Boolean,
   ) = withCore(Unit) {
-    MPVLib.setPropertyBoolean(property, value)
     if (property == "pause") {
+      desiredPaused = value
+      // During a replacement load the native core deliberately stays paused until FILE_LOADED.
+      // Record user/service intent now, then apply it once decoder/track setup is complete.
+      if (_state.value.phase != PlaybackPhase.LOADING) {
+        MPVLib.setPropertyBoolean(property, value)
+      }
       updateState { it.copy(paused = value) }
       propBoolean.emit(property, value)
+    } else {
+      MPVLib.setPropertyBoolean(property, value)
     }
   }
 
   /** Atomically toggles pause so rapid UI/media-button taps cannot race separate reads and writes. */
   fun togglePause(): Boolean? =
     withCore(default = null) {
-      val nextPaused = !(MPVLib.getPropertyBoolean("pause") ?: _state.value.paused)
-      MPVLib.setPropertyBoolean("pause", nextPaused)
+      val currentPaused =
+        if (_state.value.phase == PlaybackPhase.LOADING) {
+          desiredPaused
+        } else {
+          MPVLib.getPropertyBoolean("pause") ?: desiredPaused
+        }
+      val nextPaused = !currentPaused
+      desiredPaused = nextPaused
+      if (_state.value.phase != PlaybackPhase.LOADING) {
+        MPVLib.setPropertyBoolean("pause", nextPaused)
+      }
       updateState { it.copy(paused = nextPaused) }
       propBoolean.emit("pause", nextPaused)
       nextPaused
@@ -517,7 +578,19 @@ object PlaybackSession : MPVLib.EventObserver {
   fun setPropertyString(
     property: String,
     value: String,
-  ) = withCore(Unit) { MPVLib.setPropertyString(property, value) }
+  ) = withCore(Unit) {
+    if (property == "vid") {
+      if (value == "no" && _state.value.phase in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) {
+        val activeVid = MPVLib.getPropertyInt("vid") ?: -1
+        if (activeVid > 0) {
+          suspendedVideoTrack = SuspendedVideoTrack(activeVid, _state.value.generation)
+        }
+      } else if (value != "no") {
+        suspendedVideoTrack = null
+      }
+    }
+    MPVLib.setPropertyString(property, value)
+  }
 
   fun grabThumbnail(dimension: Int): Bitmap? = withCore(null) { MPVLib.grabThumbnail(dimension) }
 
@@ -597,9 +670,11 @@ object PlaybackSession : MPVLib.EventObserver {
     property: String,
     value: Boolean,
   ) {
-    if (property == "pause") updateState { it.copy(paused = value) }
-    propBoolean.emit(property, value)
-    observerSnapshot().forEach { observer -> runCatching { observer.eventProperty(property, value) } }
+    val effectiveValue =
+      if (property == "pause" && _state.value.phase == PlaybackPhase.LOADING) desiredPaused else value
+    if (property == "pause") updateState { it.copy(paused = effectiveValue) }
+    propBoolean.emit(property, effectiveValue)
+    observerSnapshot().forEach { observer -> runCatching { observer.eventProperty(property, effectiveValue) } }
   }
 
   override fun eventProperty(
@@ -645,20 +720,28 @@ object PlaybackSession : MPVLib.EventObserver {
               Log.d(TAG, "Ignoring stale FILE_LOADED generation ${current.activeGeneration}; current=${current.generation}")
               false
             } else {
+              // Track/decoder replacement is now complete. Apply the latest user/service intent
+              // once instead of allowing pause writes to race the load operation.
+              MPVLib.setPropertyBoolean("pause", desiredPaused)
               updateState {
                 it.copy(
                   phase = if (it.phase == PlaybackPhase.BACKGROUND) PlaybackPhase.BACKGROUND else PlaybackPhase.READY,
+                  paused = desiredPaused,
                   error = null,
                 )
               }
+              propBoolean.emit("pause", desiredPaused)
+              restoreSuspendedVideoTrackLocked()
               true
             }
           }
           MPVLib.MpvEvent.MPV_EVENT_SHUTDOWN -> {
             releaseActiveNetworkStream()
             releaseAuxiliaryNetworkStreams()
+            suspendedVideoTrack = null
+            desiredPaused = true
             initialized = false
-            updateState { it.copy(phase = PlaybackPhase.UNINITIALIZED, surfaceAttached = false) }
+            updateState { it.copy(phase = PlaybackPhase.UNINITIALIZED, surfaceAttached = false, paused = true) }
             true
           }
           else -> true
@@ -668,6 +751,35 @@ object PlaybackSession : MPVLib.EventObserver {
     if (shouldForward) {
       observerSnapshot().forEach { observer -> runCatching { observer.event(eventId, data) } }
     }
+  }
+
+  private fun suspendVideoTrackForSurfaceLossLocked() {
+    val current = _state.value
+    if (current.phase !in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) return
+    val activeVid = MPVLib.getPropertyInt("vid") ?: -1
+    if (activeVid > 0) {
+      suspendedVideoTrack = SuspendedVideoTrack(activeVid, current.generation)
+      // Stop video decoding before the ANativeWindow disappears. Audio remains active.
+      runCatching { MPVLib.setPropertyString("vid", "no") }
+    }
+  }
+
+  private fun restoreSuspendedVideoTrackLocked() {
+    val suspended = suspendedVideoTrack ?: return
+    val current = _state.value
+    if (suspended.generation != current.generation) {
+      suspendedVideoTrack = null
+      return
+    }
+    if (!current.surfaceAttached || current.phase !in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) return
+
+    runCatching { MPVLib.setPropertyInt("vid", suspended.id) }
+      .onSuccess {
+        suspendedVideoTrack = null
+        Log.d(TAG, "Restored video track ${suspended.id} after Surface reattachment")
+      }.onFailure { error ->
+        Log.w(TAG, "Failed to restore video track ${suspended.id} after Surface reattachment", error)
+      }
   }
 
   private fun resolvePlayableUri(item: PlaybackItem): ResolvedPlayable {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -12,6 +12,8 @@ package app.gyrolet.mpvrx.ui.player
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.Surface
 import app.gyrolet.mpvrx.data.network.proxy.NetworkStreamingProxy
@@ -82,6 +84,8 @@ class PlaybackProperty<T> internal constructor(
 @Suppress("TooManyFunctions")
 object PlaybackSession : MPVLib.EventObserver {
   private const val TAG = "PlaybackSession"
+  private const val SEEK_AUDIO_RESTORE_DELAY_MS = 60L
+  private const val SEEK_AUDIO_FALLBACK_RESTORE_MS = 750L
 
   private data class NetworkStreamRegistration(
     val proxy: NetworkStreamingProxy,
@@ -109,6 +113,7 @@ object PlaybackSession : MPVLib.EventObserver {
   private val _queue = MutableStateFlow(PlaybackQueueState())
   private val streamSequence = AtomicLong()
   private val observedProperties = mutableSetOf<Pair<String, Int>>()
+  private val seekAudioGuardHandler = Handler(Looper.getMainLooper())
 
   val state: StateFlow<PlaybackSessionState> = _state.asStateFlow()
   val queue: StateFlow<PlaybackQueueState> = _queue.asStateFlow()
@@ -122,6 +127,8 @@ object PlaybackSession : MPVLib.EventObserver {
   private val auxiliaryNetworkStreams = linkedMapOf<String, NetworkStreamRegistration>()
   private var suspendedVideoTrack: SuspendedVideoTrack? = null
   private var desiredPaused = true
+  private var seekAudioGuardToken = 0L
+  private var seekAudioGuardPreviousMute: Boolean? = null
 
   val isInitialized: Boolean
     get() = initialized
@@ -158,6 +165,7 @@ object PlaybackSession : MPVLib.EventObserver {
         observedProperties.clear()
         suspendedVideoTrack = null
         desiredPaused = true
+        clearSeekAudioGuardLocked(restoreMute = false)
         updateState { it.copy(phase = PlaybackPhase.INITIALIZING, error = null) }
         try {
           MPVLib.create(context.applicationContext)
@@ -184,6 +192,7 @@ object PlaybackSession : MPVLib.EventObserver {
           activeRendererConfigurationKey = null
           suspendedVideoTrack = null
           desiredPaused = true
+          clearSeekAudioGuardLocked(restoreMute = false)
           updateState {
             it.copy(
               phase = PlaybackPhase.ERROR,
@@ -274,6 +283,7 @@ object PlaybackSession : MPVLib.EventObserver {
       pendingGenerations.clear()
       suspendedVideoTrack = null
       desiredPaused = true
+      clearSeekAudioGuardLocked(restoreMute = true)
       runCatching { MPVLib.command("stop") }
       runCatching { MPVLib.setPropertyBoolean("pause", true) }
       if (clearQueue) _queue.value = PlaybackQueueState()
@@ -305,6 +315,7 @@ object PlaybackSession : MPVLib.EventObserver {
     updateState { it.copy(phase = PlaybackPhase.STOPPING) }
     desiredPaused = true
     suspendedVideoTrack = null
+    clearSeekAudioGuardLocked(restoreMute = true)
     runCatching { MPVLib.setPropertyBoolean("pause", true) }
     runCatching { MPVLib.setPropertyString("vo", "null") }
     runCatching { MPVLib.detachSurface() }
@@ -439,6 +450,7 @@ object PlaybackSession : MPVLib.EventObserver {
       // A saved video-track id belongs to the outgoing file only. Never carry it into a new load.
       suspendedVideoTrack = null
       desiredPaused = false
+      clearSeekAudioGuardLocked(restoreMute = true)
       val generation = _state.value.generation + 1L
       pendingGenerations.addLast(generation)
       val resolvedItem = item ?: PlaybackItem.fromUri(playableUri)
@@ -478,7 +490,10 @@ object PlaybackSession : MPVLib.EventObserver {
   }
 
   fun command(vararg command: String) {
-    withCore(Unit) { MPVLib.command(*command) }
+    withCore(Unit) {
+      if (command.firstOrNull() == "seek") beginSeekAudioGuardLocked()
+      MPVLib.command(*command)
+    }
   }
 
   /** Executes a media-specific command only while its load generation is still current. */
@@ -488,6 +503,7 @@ object PlaybackSession : MPVLib.EventObserver {
   ): Boolean =
     nativeLock.withLock {
       if (!initialized || _state.value.generation != expectedGeneration) return@withLock false
+      if (command.firstOrNull() == "seek") beginSeekAudioGuardLocked()
       MPVLib.command(*command)
       true
     }
@@ -735,11 +751,16 @@ object PlaybackSession : MPVLib.EventObserver {
               true
             }
           }
+          MPVLib.MpvEvent.MPV_EVENT_PLAYBACK_RESTART -> {
+            scheduleSeekAudioGuardRestoreLocked(SEEK_AUDIO_RESTORE_DELAY_MS)
+            true
+          }
           MPVLib.MpvEvent.MPV_EVENT_SHUTDOWN -> {
             releaseActiveNetworkStream()
             releaseAuxiliaryNetworkStreams()
             suspendedVideoTrack = null
             desiredPaused = true
+            clearSeekAudioGuardLocked(restoreMute = false)
             initialized = false
             updateState { it.copy(phase = PlaybackPhase.UNINITIALIZED, surfaceAttached = false, paused = true) }
             true
@@ -750,6 +771,47 @@ object PlaybackSession : MPVLib.EventObserver {
 
     if (shouldForward) {
       observerSnapshot().forEach { observer -> runCatching { observer.event(eventId, data) } }
+    }
+  }
+
+  /**
+   * Rapid keyframe/exact seeks can expose tiny decoded audio fragments between decoder flushes,
+   * which sounds like echo/warble while scrubbing. Temporarily mute only the active seek window;
+   * the user's original mute state is restored after mpv reports playback restart.
+   */
+  private fun beginSeekAudioGuardLocked() {
+    if (_state.value.paused || _state.value.phase !in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) return
+
+    if (seekAudioGuardPreviousMute == null) {
+      val wasMuted = MPVLib.getPropertyBoolean("mute") ?: false
+      seekAudioGuardPreviousMute = wasMuted
+      if (!wasMuted) runCatching { MPVLib.setPropertyBoolean("mute", true) }
+    }
+
+    seekAudioGuardToken++
+    scheduleSeekAudioGuardRestoreLocked(SEEK_AUDIO_FALLBACK_RESTORE_MS)
+  }
+
+  private fun scheduleSeekAudioGuardRestoreLocked(delayMs: Long) {
+    if (seekAudioGuardPreviousMute == null) return
+    val token = seekAudioGuardToken
+    seekAudioGuardHandler.postDelayed(
+      {
+        nativeLock.withLock {
+          if (!initialized || token != seekAudioGuardToken) return@withLock
+          clearSeekAudioGuardLocked(restoreMute = true)
+        }
+      },
+      delayMs,
+    )
+  }
+
+  private fun clearSeekAudioGuardLocked(restoreMute: Boolean) {
+    val previousMute = seekAudioGuardPreviousMute
+    seekAudioGuardPreviousMute = null
+    seekAudioGuardToken++
+    if (restoreMute && initialized && previousMute != null) {
+      runCatching { MPVLib.setPropertyBoolean("mute", previousMute) }
     }
   }
 


### PR DESCRIPTION
## What this fixes

This PR addresses the playback failures reproduced in the attached mpvRx log without removing or disabling existing player features:

- MediaCodec / software fallback instability and frame-drop-prone decoder configuration
- distorted / eerie audio while repeatedly seeking or scrubbing
- notification re-entry where audio continues but video stays black
- audio playback state races that can require pressing Play twice

## Root causes

### Surface / notification re-entry
Background playback intentionally disables the video track with `vid=no`, but the saved video track id lived in `PlayerActivity.lastVid`. If Android recreated the Activity, that field was lost while the process-wide libmpv session remained alive with video disabled. Opening the player from the notification could therefore reconnect to working audio while leaving video disabled.

The session also detached the Android Surface while the video decoder could still be active. The supplied log later shows MediaCodec retrying after `vo=null` with no Surface/native window, which is exactly the lifecycle race this PR avoids.

### Load / Play state
A fresh load could be unpaused through several overlapping paths: `loadfile ... pause=no`, an immediate `pause=false` from the Activity, and the `FILE_LOADED` callback. That makes native/UI pause state susceptible to racing during audio startup.

### Seeking audio
The player can issue a rapid series of keyframe/exact seek commands while scrubbing. Small decoded audio fragments can escape between decoder flush/restart cycles and sound like echo/warble. A global `audio-stream-silence` workaround was explicitly avoided because mpv warns that it alters A/V-sync and underrun handling.

## Changes

### `PlaybackSession`

- make desired pause state process-wide and authoritative during replacement loads
- load media natively paused, then apply the latest desired state once on `FILE_LOADED`
- preserve toggle/play/pause intent while a file is still loading
- move suspended video-track state into the process-wide session
- disable the active video track before Surface detach and restore it only after a valid Surface is attached
- keep restoration generation-scoped so an old track id can never leak into a newly loaded file
- restore video correctly after Activity recreation / notification re-entry
- add a seek-audio guard that temporarily mutes only during an active seek window, preserves the previous mute state, and restores it after `MPV_EVENT_PLAYBACK_RESTART` (with a bounded fallback timer)

### `MPVView`

- choose the MediaCodec chain according to the active renderer backend
  - preserve direct `mediacodec` -> `mediacodec-copy` -> software fallback on `gpu + opengl + android`
  - start from `mediacodec-copy` -> software fallback on renderer paths that cannot use Android direct interop
- replace `hwdec-codecs=all` with mpv's current default hardware-decoder codec whitelist
- use `hwdec-software-fallback=3`
- change forced `vd-lavc-dr=yes` to mpv's safer `auto`
- explicitly use `vd-lavc-threads=0` for automatic software-decoder threading
- keep normal `framedrop=vo`
- enable `hr-seek-framedrop=yes` so precise HEVC/long-GOP seeks do not waste time rendering pre-target frames
- observe `hwdec-current`, frame-drop counters, `avsync`, and `estimated-vf-fps` for better decoder diagnostics

## Functionality preserved

This does not remove the Music player, thumbnails/ThumbFast, background playback, notification controls, PiP, Anime4K, HDR Toys, Vulkan/gpu-next choices, subtitles, playlists, torrents, network playback, Syncplay, or existing audio settings.

## Log evidence used

The reported HEVC Main10 file first attempts MediaCodec with a valid Android Surface but the vendor codec fails to start, then falls back to software decoding. Software decoding initializes successfully but later reports A/V desynchronization / audio underruns. During a later teardown/reconfiguration, the log shows `vo=null`, no Surface/native window, another MediaCodec failure, and HEVC reference-frame errors. The lifecycle and fallback changes here are aimed at those concrete failure modes rather than globally lowering playback quality.

## Validation

- branch is based directly on current `master`
- diff is limited to `MPVView.kt` and `PlaybackSession.kt`
- mpv option behavior was checked against the current mpv manual
- PR CI provides the repository-level Android/Kotlin validation; device validation is still needed for the original HEVC Main10 sample and notification/background lifecycle.