### PR TITLE
feat: replace YouTube ambient with Flow-style color picking

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/AmbientShaderBuilder.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/AmbientShaderBuilder.kt
@@ -39,7 +39,9 @@ enum class AmbientVisualMode(
 ) {
   GLOW("Glow"),
   FRAME_EXTEND("Frame Extend"),
-  YOUTUBE("YouTube"),
+  // Keep the enum key for compatibility with existing saved preferences. The old YouTube-style
+  // average-color implementation has been replaced by the Flow-style palette scorer below.
+  YOUTUBE("Flow"),
 }
 
 sealed interface AmbientShaderSpec {
@@ -276,12 +278,14 @@ object AmbientShaderBuilder {
       buildSpiralTapTable("FRAME_GLOW_TAPS", glowSamples) { _, indexNorm -> indexNorm }
     }
 
-  private val youtubeTapTable: String by lazy {
+  private val flowTapTable: String by lazy {
+    // Twelve low-discrepancy samples are enough to estimate both palette population and scene
+    // coverage without adding Android PixelCopy/Palette readbacks to the playback hot path.
     val taps =
-      (1..8).joinToString(",\n") { i ->
+      (1..12).joinToString(",\n") { i ->
         "    vec2(${glslFloat(halton(i, 2))}, ${glslFloat(halton(i, 3))})"
       }
-    "const vec2 YOUTUBE_TAPS[8] = vec2[8](\n$taps\n);"
+    "const vec2 FLOW_TAPS[12] = vec2[12](\n$taps\n);"
   }
 
   fun build(spec: AmbientShaderSpec): String =
@@ -291,89 +295,146 @@ object AmbientShaderBuilder {
       is AmbientYouTubeShaderSpec -> buildYouTube(spec)
     }
 
+  /**
+   * GPU-native adaptation of Flow's palette-selection idea.
+   *
+   * The old YouTube mode averaged the frame, which naturally collapses mixed or dark scenes toward
+   * grey/brown. Instead, we score sampled colour candidates by saturation, preferred mid-luminance
+   * and approximate population, then use the best repeated vibrant colour. This deliberately stays
+   * inside mpv's OUTPUT shader so Ambient Mode does not introduce Surface readbacks or media-thread
+   * contention during playback.
+   */
   private fun buildYouTube(spec: AmbientYouTubeShaderSpec): String =
     """
 //!HOOK OUTPUT
 //!BIND HOOKED
-//!DESC YouTube-Style Ambient Mode
+//!DESC Flow Palette Ambient Mode
 
-#define SCALE_X       ${spec.context.scaleX}
-#define SCALE_Y       ${spec.context.scaleY}
-// IS_LINEAR_HDR=1 → Vulkan gpu-next linear swapchain (target-colorspace-hint=yes).
-// HOOKED_tex values are raw linear-light where 1.0 = 203 nits.  We must work in
-// perceptual space (sqrt ≈ γ0.5) for colour averaging so bright highlights do not
-// overwhelm dark colours, then convert back to linear and scale to ~0.08 linear
-// (≈16 nits) for a visible but non-blinding ambient glow.
-#define IS_LINEAR_HDR ${if (spec.context.isLinearHdr) 1 else 0}
+#define SCALE_X          ${spec.context.scaleX}
+#define SCALE_Y          ${spec.context.scaleY}
+#define OPACITY          ${spec.shared.opacity}
+#define VIGNETTE_STR     ${spec.shared.vignetteStrength}
+#define IS_LINEAR_HDR    ${if (spec.context.isLinearHdr) 1 else 0}
+#define FLOW_SAMPLES     12
+#define PREFERRED_LUMA   0.56
+#define MIN_FLOW_LUMA    0.20
+#define MAX_FLOW_LUMA    0.86
 
 #if IS_LINEAR_HDR
 vec3 to_perceptual(vec3 c) { return sqrt(max(c, vec3(0.0))); }
 vec3 to_linear(vec3 c)     { return c * c; }
 #endif
 
-// 8 Halton(2,3) positions precomputed in Kotlin — better spatial coverage than
-// 20 pseudo-random scatter points, 60% fewer texture fetches per ambient pixel.
-${youtubeTapTable}
+${flowTapTable}
 
-// Colour math is mediump (fp16) — cheaper on mobile, no perceptual quality loss.
-// UV coordinate variables below are explicitly highp (fp32): on 1080p+ screens
-// mediump step size (~0.001) is coarser than a pixel (~0.0004), causing the
-// video_uv remapping to jump in 2-3 pixel blocks and damage fine video lines.
 precision mediump float;
+
+float flow_luma(vec3 rgb) {
+    return dot(rgb, vec3(0.2126, 0.7152, 0.0722));
+}
+
+float flow_saturation(vec3 rgb) {
+    float mx = max(max(rgb.r, rgb.g), rgb.b);
+    float mn = min(min(rgb.r, rgb.g), rgb.b);
+    return mx <= 1e-5 ? 0.0 : (mx - mn) / mx;
+}
+
+float flow_population(vec3 candidate, vec3 palette[FLOW_SAMPLES]) {
+    float population = 0.0;
+    for (int j = 0; j < FLOW_SAMPLES; j++) {
+        // Soft population estimate: nearby sampled colours vote for the candidate. Squaring the
+        // similarity suppresses unrelated colours while keeping gradients/fades in one cluster.
+        float similarity = 1.0 - clamp(length(candidate - palette[j]) / 0.48, 0.0, 1.0);
+        population += similarity * similarity;
+    }
+    return population / float(FLOW_SAMPLES);
+}
+
+vec3 select_flow_color(vec3 palette[FLOW_SAMPLES], vec3 scene_avg) {
+    vec3 preferred = scene_avg;
+    vec3 fallback = scene_avg;
+    float preferred_score = -1.0;
+    float fallback_score = -1.0;
+
+    for (int i = 0; i < FLOW_SAMPLES; i++) {
+        vec3 candidate = palette[i];
+        float lum = flow_luma(candidate);
+        float saturation = flow_saturation(candidate);
+        float luma_fit = 1.0 - clamp(abs(lum - PREFERRED_LUMA) / PREFERRED_LUMA, 0.0, 1.0);
+        float population = flow_population(candidate, palette);
+
+        // Same selection priorities as Flow: saturated colours first, favour useful mid-luminance,
+        // then reward colours that represent a meaningful portion of the sampled frame.
+        float score = (saturation * 1.5 + luma_fit) * (0.30 + population * 1.70);
+
+        if (score > fallback_score) {
+            fallback_score = score;
+            fallback = candidate;
+        }
+        if (lum >= MIN_FLOW_LUMA && lum <= MAX_FLOW_LUMA && score > preferred_score) {
+            preferred_score = score;
+            preferred = candidate;
+        }
+    }
+
+    vec3 picked = preferred_score >= 0.0 ? preferred : fallback;
+    // A small scene-average contribution damps one-sample outliers/cuts without washing the picked
+    // colour back into the dull average that the old implementation used.
+    return mix(picked, scene_avg, 0.12);
+}
 
 vec4 hook() {
     highp vec2 uv = HOOKED_pos;
     highp vec2 video_uv = (uv - 0.5) * vec2(SCALE_X, SCALE_Y) + 0.5;
 
-    // Return video pixel if inside video bounds
     if (video_uv.x >= 0.0 && video_uv.x <= 1.0 &&
         video_uv.y >= 0.0 && video_uv.y <= 1.0) {
         return HOOKED_tex(video_uv);
     }
 
-    // Sample 8 well-distributed positions across the entire video frame.
-    // In Linear HDR mode: convert to perceptual space before averaging so that
-    // bright linear highlights do not dominate dark colours in the blend.
-    vec3 avg_color = vec3(0.0);
-    for (int i = 0; i < 8; i++) {
+    vec3 palette[FLOW_SAMPLES];
+    vec3 scene_avg = vec3(0.0);
+    for (int i = 0; i < FLOW_SAMPLES; i++) {
 #if IS_LINEAR_HDR
-        avg_color += to_perceptual(HOOKED_tex(YOUTUBE_TAPS[i]).rgb);
+        vec3 sampled = to_perceptual(HOOKED_tex(FLOW_TAPS[i]).rgb);
 #else
-        avg_color += HOOKED_tex(YOUTUBE_TAPS[i]).rgb;
+        vec3 sampled = HOOKED_tex(FLOW_TAPS[i]).rgb;
 #endif
+        palette[i] = sampled;
+        scene_avg += sampled;
     }
-    avg_color /= 8.0;
+    scene_avg /= float(FLOW_SAMPLES);
 
-    // Boost saturation slightly for more vibrant glow
-    float luma = dot(avg_color, vec3(0.2126, 0.7152, 0.0722));
-    avg_color = mix(vec3(luma), avg_color, 1.3); // 30% saturation boost
+    vec3 ambient_color = select_flow_color(palette, scene_avg);
+
+    // Preserve the selected hue while giving the glow a modest extra colourfulness. The palette
+    // scorer already avoids dull swatches, so this is intentionally gentler than brute-force boost.
+    float lum = flow_luma(ambient_color);
+    ambient_color = clamp(mix(vec3(lum), ambient_color, 1.16), 0.0, 1.0);
 
 #if IS_LINEAR_HDR
-    // Reference white in gpu-next linear light = 1.0 = 203 nits.
-    // 0.08 was too conservative (~2-5 nits after edge_fade): invisible on OLED.
-    // 0.40 targets ~70-85 nits at the video edge for a mid-bright scene:
-    //   avg perceptual ~0.65 → to_linear = 0.42 → 0.42 * 0.40 * 203 ≈ 34 nits base,
-    //   before edge falloff.  Adjust down if content is too bright on your display.
-    avg_color = to_linear(avg_color) * 0.40;
+    // The palette calculations above happen in perceptual space. Return to linear light for the
+    // gpu-next HDR pipeline and keep roughly the same ambient luminance budget as the existing mode.
+    ambient_color = to_linear(ambient_color) * 0.40;
 #else
-    // SDR / hdr-toys mode: values are already gamma-encoded, scale normally.
-    avg_color *= 0.30;
+    ambient_color *= 0.34;
 #endif
 
-    // Smooth fade based on distance from video edge
     highp vec2 edge_uv = clamp(video_uv, 0.0, 1.0);
     float dist = length(video_uv - edge_uv);
-    float fade = exp(-dist * 2.5);
-    avg_color *= fade;
+    float fade = exp(-dist * 2.35);
+    ambient_color *= fade;
 
-    // Debanding via Interleaved Gradient Noise (Jimenez 2014).
-    // Replaces the previous sin-based hash() — uses only fract + dot,
-    // eliminating the last GPU sin() call from this shader.
+    float vig_r = length(uv - 0.5) * 2.0;
+    ambient_color *= mix(1.0, smoothstep(1.3, 0.1, vig_r), VIGNETTE_STR);
+    ambient_color *= OPACITY;
+
+    // Cheap deterministic dither prevents visible banding in large flat glow areas.
     highp vec2 screen_pos = floor(uv * HOOKED_size);
     float ign = fract(dot(screen_pos, vec2(0.75487766, 0.56984029)));
-    avg_color = clamp(avg_color + (ign - 0.5) * 0.004, 0.0, 1.0);
+    ambient_color = clamp(ambient_color + (ign - 0.5) * 0.004, 0.0, 1.0);
 
-    return vec4(avg_color, 1.0);
+    return vec4(ambient_color, 1.0);
 }
     """.trimIndent()
 


### PR DESCRIPTION
## Summary

Replaces the existing YouTube ambient color picker with a Flow-inspired vibrant palette scorer, as requested in #328.

Closes #328

## What changed

- keeps the existing `AmbientVisualMode.YOUTUBE` enum key so current saved preferences continue to load normally
- changes the user-facing mode label from `YouTube` to `Flow`
- replaces whole-frame averaging with distributed palette sampling
- scores candidate colors using saturation, preferred mid-luminance, and approximate color population
- falls back safely for very dark/bright scenes
- lightly blends the chosen swatch with the scene average to avoid unstable one-sample picks
- preserves Linear HDR perceptual/linear conversion handling
- applies existing ambient opacity and vignette settings to this mode
- keeps the implementation entirely in the mpv GPU OUTPUT shader; no PixelCopy/Palette loop or additional media decoder/readback work is introduced

## Why GPU-native

Flow's Android implementation performs frame capture and Palette processing. mpvRx already has a GPU ambient pipeline and has previously seen playback/resource contention from concurrent media work, so this implements the same color-selection priorities inside the shader rather than adding repeated Surface readbacks during playback.

## Compatibility

No preference migration is required. Existing users with `YOUTUBE` saved will automatically receive the new Flow implementation.

## Validation

CI will validate Kotlin/Android compilation. Device testing should cover dark scenes, mixed-color anime/live action, SDR, HDR Toys, Linear HDR, portrait/landscape, and lower-end GPUs.