### PR TITLE
fix: make HDR mode switching deterministic

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/HdrScreenOutput.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/HdrScreenOutput.kt
@@ -176,9 +176,9 @@ private fun hdrToysSettings(profile: HdrToysProfile): List<Pair<String, String>>
 
 private fun linearHdrSettings(boostSdrToHdr: Boolean): List<Pair<String, String>> =
   commonSettings(
-    // LINEAR is mpv-native. Crucially, reset target primaries/TRC/peak back to auto so values from
-    // PQ/HLG/BT.2020 cannot leak into this mode. gpu-next will derive the target from the active
-    // swapchain/source metadata when the platform exposes it.
+    // Preserve the existing mpv-native HDR rendering policy, but reset every target value that a
+    // previous PQ/HLG/BT.2020 mode may have overridden. Without these resets Linear HDR depends on
+    // mode history and can keep rendering with stale primaries/TRC after the UI says Linear.
     targetColorspaceHint = "yes",
     targetColorspaceHintMode = "target",
     targetColorspaceHintStrict = "yes",
@@ -186,9 +186,9 @@ private fun linearHdrSettings(boostSdrToHdr: Boolean): List<Pair<String, String>
     targetTrc = "auto",
     targetPeak = "auto",
     inverseToneMapping = if (boostSdrToHdr) "yes" else "no",
-    toneMapping = "auto",
-    gamutMappingMode = "auto",
-    hdrComputePeak = "auto",
+    toneMapping = "clip",
+    gamutMappingMode = "clip",
+    hdrComputePeak = "yes",
     shaderOptions = "",
   )
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/HdrScreenOutput.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/HdrScreenOutput.kt
@@ -16,14 +16,15 @@ import app.gyrolet.mpvrx.domain.hdr.HdrToysProfile
 /**
  * Available HDR screen output modes.
  *
- * - [OFF]         — SDR output; all HDR pipeline options reset to safe defaults.
- * - [BT_2100_PQ]  — HDR10 via hdr-toys (PQ inverse-EOTF → Astra TM → Bottosson GM → bt.1886).
- * - [BT_2100_HLG] — HLG via hdr-toys (HLG inverse-EOTF → Astra TM → Bottosson GM → bt.1886).
- * - [BT_2020]     — BT.2020/BT.1886 gamut mapping only via hdr-toys Bottosson shader.
- * - [LINEAR]      — High-quality mpv-native HDR output without hdr-toys shaders.
+ * Every mode below owns the complete mpv HDR/color-output state. This is intentional: switching
+ * modes must never depend on whichever target-prim/target-trc/tone-mapping values were left behind
+ * by the previous mode.
  *
- * [OFF] is the default; the player's HDR toggle button switches between [OFF] and
- * [defaultEnabledMode].  The HDR panel only exposes [selectableModes].
+ * - [OFF]         — restore mpv's normal automatic SDR/HDR handling.
+ * - [BT_2100_PQ]  — HDR10 hdr-toys pipeline.
+ * - [BT_2100_HLG] — HLG hdr-toys pipeline.
+ * - [BT_2020]     — BT.2020 hdr-toys gamut pipeline.
+ * - [LINEAR]      — mpv-native gpu-next HDR path, without hdr-toys shaders.
  */
 enum class HdrScreenMode(
   @StringRes val titleRes: Int,
@@ -62,87 +63,136 @@ enum class HdrScreenMode(
   ;
 
   companion object {
-    /** Modes shown in the HDR panel (excludes OFF — that is handled by the toggle button). */
     val selectableModes = listOf(BT_2100_PQ, BT_2100_HLG, BT_2020, LINEAR)
 
-    /** Mode activated when the user first enables HDR from the toggle button. */
-    // The lightest hdr-toys profile; it also works on the legacy GPU renderer.
+    // The lightest hdr-toys profile; also works on the legacy GPU renderer.
     val defaultEnabledMode = BT_2020
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Internal mpv property lists
-// ─────────────────────────────────────────────────────────────────────────────
+/**
+ * All mpv options owned by the HDR mode controller.
+ *
+ * Keep this list synchronized with every mode builder below. A mode transition is deterministic
+ * only when every property that can affect output color is explicitly written by every mode.
+ */
+private val HDR_OWNED_PROPERTIES =
+  listOf(
+    "target-colorspace-hint",
+    "target-colorspace-hint-mode",
+    "target-colorspace-hint-strict",
+    "target-prim",
+    "target-trc",
+    "target-peak",
+    "inverse-tone-mapping",
+    "tone-mapping",
+    "gamut-mapping-mode",
+    "hdr-compute-peak",
+    "hdr-reference-white",
+    "tone-mapping-visualize",
+    "glsl-shader-opts",
+  )
 
-@Suppress("UNUSED_PARAMETER")
 internal fun hdrScreenOutputSettings(
   mode: HdrScreenMode,
   pipelineReady: Boolean,
   boostSdrToHdr: Boolean = false,
 ): List<Pair<String, String>> {
   val activeMode = if (pipelineReady) mode else HdrScreenMode.OFF
+  val settings =
+    when (activeMode) {
+      HdrScreenMode.OFF -> offSettings()
+      HdrScreenMode.LINEAR -> linearHdrSettings(boostSdrToHdr)
+      else -> hdrToysSettings(activeMode.hdrToysProfile ?: HdrToysProfile.BT_2100_PQ)
+    }
 
-  return when (activeMode) {
-    HdrScreenMode.OFF -> offSettings()
-    HdrScreenMode.LINEAR -> linearHdrSettings(hdrEnabled = true, boostSdrToHdr = boostSdrToHdr)
-    else -> hdrToysSettings(activeMode.hdrToysProfile ?: HdrToysProfile.BT_2100_PQ)
+  // Defensive invariant for future modes: never allow a partial color-state profile to ship.
+  check(settings.map { it.first }.toSet() == HDR_OWNED_PROPERTIES.toSet()) {
+    "Incomplete HDR output settings for $activeMode"
   }
+  return settings
 }
 
-private fun offSettings(): List<Pair<String, String>> =
+private fun commonSettings(
+  targetColorspaceHint: String,
+  targetColorspaceHintMode: String,
+  targetColorspaceHintStrict: String,
+  targetPrim: String,
+  targetTrc: String,
+  targetPeak: String,
+  inverseToneMapping: String,
+  toneMapping: String,
+  gamutMappingMode: String,
+  hdrComputePeak: String,
+  shaderOptions: String,
+): List<Pair<String, String>> =
   listOf(
-    "target-colorspace-hint" to "auto",
-    "target-colorspace-hint-mode" to "target",
-    "target-prim" to "auto",
-    "target-trc" to "auto",
-    "target-peak" to "auto",
-    "inverse-tone-mapping" to "auto",
-    "tone-mapping" to "auto",
-    "gamut-mapping-mode" to "auto",
-    "hdr-compute-peak" to "auto",
+    "target-colorspace-hint" to targetColorspaceHint,
+    "target-colorspace-hint-mode" to targetColorspaceHintMode,
+    "target-colorspace-hint-strict" to targetColorspaceHintStrict,
+    "target-prim" to targetPrim,
+    "target-trc" to targetTrc,
+    "target-peak" to targetPeak,
+    "inverse-tone-mapping" to inverseToneMapping,
+    "tone-mapping" to toneMapping,
+    "gamut-mapping-mode" to gamutMappingMode,
+    "hdr-compute-peak" to hdrComputePeak,
     "hdr-reference-white" to "203",
     "tone-mapping-visualize" to "no",
-    "glsl-shader-opts" to "",
+    "glsl-shader-opts" to shaderOptions,
+  )
+
+private fun offSettings(): List<Pair<String, String>> =
+  commonSettings(
+    targetColorspaceHint = "auto",
+    targetColorspaceHintMode = "target",
+    targetColorspaceHintStrict = "yes",
+    targetPrim = "auto",
+    targetTrc = "auto",
+    targetPeak = "auto",
+    inverseToneMapping = "auto",
+    toneMapping = "auto",
+    gamutMappingMode = "auto",
+    hdrComputePeak = "auto",
+    shaderOptions = "",
   )
 
 private fun hdrToysSettings(profile: HdrToysProfile): List<Pair<String, String>> =
-  listOf(
-    // Disable mpv's built-in colorspace management so hdr-toys shaders have full control.
-    "target-colorspace-hint" to "no",
-    "target-colorspace-hint-mode" to "target",
-    "target-prim" to profile.targetPrim,
-    "target-trc" to profile.targetTrc,
-    "target-peak" to "auto",
-    "inverse-tone-mapping" to "no",
-    "tone-mapping" to "clip", // hdr-toys handles tone-mapping in GLSL
-    "gamut-mapping-mode" to "clip", // hdr-toys handles gamut-mapping in GLSL
-    "hdr-compute-peak" to "no",
-    "hdr-reference-white" to "203",
-    "tone-mapping-visualize" to "no",
-    "glsl-shader-opts" to profile.shaderOptionsValue,
+  commonSettings(
+    // hdr-toys owns transfer/gamut/tone processing in GLSL. Do not ask gpu-next to negotiate a
+    // second HDR output transform on top of the shader pipeline.
+    targetColorspaceHint = "no",
+    targetColorspaceHintMode = "target",
+    targetColorspaceHintStrict = "yes",
+    targetPrim = profile.targetPrim,
+    targetTrc = profile.targetTrc,
+    targetPeak = "auto",
+    inverseToneMapping = "no",
+    toneMapping = "clip",
+    gamutMappingMode = "clip",
+    hdrComputePeak = "no",
+    shaderOptions = profile.shaderOptionsValue,
   )
 
-private fun linearHdrSettings(
-  hdrEnabled: Boolean,
-  boostSdrToHdr: Boolean = false,
-): List<Pair<String, String>> =
-  listOf(
-    "target-colorspace-hint" to if (hdrEnabled) "yes" else "no",
-    "tone-mapping-visualize" to "no",
-    "inverse-tone-mapping" to if (hdrEnabled && boostSdrToHdr) "yes" else "no",
-    "tone-mapping" to "clip",
-    "gamut-mapping-mode" to if (hdrEnabled) "clip" else "auto",
-    "hdr-compute-peak" to if (hdrEnabled) "yes" else "auto",
-    "hdr-reference-white" to "203",
-    "glsl-shader-opts" to "",
+private fun linearHdrSettings(boostSdrToHdr: Boolean): List<Pair<String, String>> =
+  commonSettings(
+    // LINEAR is mpv-native. Crucially, reset target primaries/TRC/peak back to auto so values from
+    // PQ/HLG/BT.2020 cannot leak into this mode. gpu-next will derive the target from the active
+    // swapchain/source metadata when the platform exposes it.
+    targetColorspaceHint = "yes",
+    targetColorspaceHintMode = "target",
+    targetColorspaceHintStrict = "yes",
+    targetPrim = "auto",
+    targetTrc = "auto",
+    targetPeak = "auto",
+    inverseToneMapping = if (boostSdrToHdr) "yes" else "no",
+    toneMapping = "auto",
+    gamutMappingMode = "auto",
+    hdrComputePeak = "auto",
+    shaderOptions = "",
   )
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Public apply helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
-/** Apply HDR settings as mpv init-time options (call before playback starts). */
+/** Apply HDR settings as mpv init-time options (before playback starts). */
 fun applyHdrScreenOutputOptions(
   mode: HdrScreenMode,
   pipelineReady: Boolean,
@@ -153,7 +203,13 @@ fun applyHdrScreenOutputOptions(
   }
 }
 
-/** Apply HDR settings as mpv runtime properties (call during active playback). */
+/**
+ * Apply HDR settings during active playback.
+ *
+ * The settings list is complete for every mode, so OFF/Linear/PQ/HLG/BT.2020 transitions are
+ * idempotent and independent of their previous state. gpu-next marks these options UPDATE_VIDEO,
+ * therefore property writes trigger the renderer to rebuild its video output state.
+ */
 fun applyHdrScreenOutputProperties(
   mode: HdrScreenMode,
   pipelineReady: Boolean,


### PR DESCRIPTION
## Summary

Fixes HDR mode transitions so OFF, BT.2100 PQ, BT.2100 HLG, BT.2020 and Linear HDR no longer inherit stale mpv color state from whichever mode was active before them.

## Root cause

The previous profiles did not write the same set of mpv color-output properties. In particular, Linear HDR did not reset `target-prim`, `target-trc`, or `target-peak`, so switching from PQ/HLG/BT.2020 into Linear could leave the old target colorspace active even though the UI reported Linear.

That made HDR behavior order-dependent: the same mode could render differently depending on the mode selected before it.

## Changes

- define one complete HDR-owned property set
- make every mode explicitly write every property in that set
- reset `target-prim`, `target-trc`, and `target-peak` when entering Linear HDR
- fully restore automatic defaults when HDR is disabled
- prevent HDR Toys state/options from leaking into Linear/OFF
- preserve the existing Linear rendering policy (`tone-mapping=clip`, `gamut-mapping-mode=clip`, peak computation enabled)
- add an invariant so a future HDR mode cannot silently introduce another partial-state transition
- use the same settings generator for init-time and runtime application

## Modes covered

- OFF -> PQ / HLG / BT.2020 / Linear
- any HDR mode -> OFF
- PQ <-> HLG <-> BT.2020
- HDR Toys modes -> Linear
- Linear -> HDR Toys modes
- repeated selection/application of the same mode
- SDR-to-HDR boost on/off while using Linear

## Android / gpu-next note

This fixes mpvRx's internal HDR processing/state transitions. Android's mpv `androidvk` context does not currently implement platform colorspace control in the same way as desktop Wayland/D3D11/winvk contexts, so this PR does not pretend to add unsupported OS-level HDR signaling. It makes the gpu-next/Vulkan pipeline deterministic and removes stale state that currently prevents Linear mode from being applied consistently.

## Validation

CI should validate Android/Kotlin compilation. Device validation should exercise every transition above on gpu-next + Vulkan and verify active mpv properties plus visual output.