### PR TITLE
fix: keep HDR switching compatible with bundled mpv

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/HdrScreenOutput.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/HdrScreenOutput.kt
@@ -80,7 +80,6 @@ private val HDR_OWNED_PROPERTIES =
   listOf(
     "target-colorspace-hint",
     "target-colorspace-hint-mode",
-    "target-colorspace-hint-strict",
     "target-prim",
     "target-trc",
     "target-peak",
@@ -116,7 +115,6 @@ internal fun hdrScreenOutputSettings(
 private fun commonSettings(
   targetColorspaceHint: String,
   targetColorspaceHintMode: String,
-  targetColorspaceHintStrict: String,
   targetPrim: String,
   targetTrc: String,
   targetPeak: String,
@@ -129,7 +127,6 @@ private fun commonSettings(
   listOf(
     "target-colorspace-hint" to targetColorspaceHint,
     "target-colorspace-hint-mode" to targetColorspaceHintMode,
-    "target-colorspace-hint-strict" to targetColorspaceHintStrict,
     "target-prim" to targetPrim,
     "target-trc" to targetTrc,
     "target-peak" to targetPeak,
@@ -146,7 +143,6 @@ private fun offSettings(): List<Pair<String, String>> =
   commonSettings(
     targetColorspaceHint = "auto",
     targetColorspaceHintMode = "target",
-    targetColorspaceHintStrict = "yes",
     targetPrim = "auto",
     targetTrc = "auto",
     targetPeak = "auto",
@@ -163,7 +159,6 @@ private fun hdrToysSettings(profile: HdrToysProfile): List<Pair<String, String>>
     // second HDR output transform on top of the shader pipeline.
     targetColorspaceHint = "no",
     targetColorspaceHintMode = "target",
-    targetColorspaceHintStrict = "yes",
     targetPrim = profile.targetPrim,
     targetTrc = profile.targetTrc,
     targetPeak = "auto",
@@ -181,7 +176,6 @@ private fun linearHdrSettings(boostSdrToHdr: Boolean): List<Pair<String, String>
     // mode history and can keep rendering with stale primaries/TRC after the UI says Linear.
     targetColorspaceHint = "yes",
     targetColorspaceHintMode = "target",
-    targetColorspaceHintStrict = "yes",
     targetPrim = "auto",
     targetTrc = "auto",
     targetPeak = "auto",


### PR DESCRIPTION
## Follow-up to #332

#332 was merged while its final compatibility cleanup was still being prepared. This tiny follow-up contains only that cleanup.

## Changes

- remove explicit `target-colorspace-hint-strict` writes; mpvRx did not previously depend on this newer option and the bundled mpv may differ from current upstream
- keep the deterministic complete-state HDR transition fix from #332
- preserve the original Linear HDR rendering behavior (`tone-mapping=clip`, `gamut-mapping-mode=clip`, `hdr-compute-peak=yes`)
- keep the important Linear resets for `target-prim`, `target-trc`, and `target-peak`

No UI, shader, decoder, or mode-selection behavior is otherwise changed.