### PR TITLE
fix(player): restore HEVC software playback stability

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVView.kt
@@ -210,10 +210,11 @@ class MPVView(
     )
     PlaybackSession.setOptionString("hwdec-codecs", "all")
 
-    // Enable direct rendering for hardware decoding (reduces memory copies)
-    PlaybackSession.setOptionString("vd-lavc-dr", "yes")
-    // Queue extra frames to absorb decode jitter on 4K content
-    PlaybackSession.setOptionString("vd-lavc-queue", "yes")
+    // These were forced on between the last known-good build (e3b1de8) and the first build
+    // reproducing the HEVC/Main10 frame-drop regression (84f21fc). Keep mpv's normal direct-
+    // rendering heuristic and disable the extra decoder-frame queue, matching mpv's defaults.
+    PlaybackSession.setOptionString("vd-lavc-dr", "auto")
+    PlaybackSession.setOptionString("vd-lavc-queue", "no")
 
     if (decoderPreferences.useYUV420P.get()) {
       PlaybackSession.setOptionString("vf", "format=yuv420p")


### PR DESCRIPTION
## Summary

Restore the decoder defaults that were present in the last known-good build for HEVC / HEVC Main10 software playback, without reverting newer player lifecycle, HDR, notification, renderer, or UI work.

Refs #107

## Regression boundary

The regression can be narrowed to two consecutive known states supplied from GitHub Actions:

- Last known-good build: https://github.com/Riteshp2001/mpvRx/actions/runs/30712701179 — `e3b1de8`
- First known-bad build: https://github.com/Riteshp2001/mpvRx/actions/runs/30716931726 — `84f21fc`

There are 12 commits between those builds. In the player initialization path, the bad build newly forces:

- `vd-lavc-dr=yes`
- `vd-lavc-queue=yes`

The good build did not override either setting.

This lines up with #107: devices that cannot hardware-decode HEVC fall back to software decoding, where mpvRx shows severe output drops / A-V sync degradation while the same files play correctly in mpvKt.

## Fix

- restore `vd-lavc-dr=auto`, matching mpv's normal direct-rendering heuristic
- disable the extra decoder frame queue with `vd-lavc-queue=no`, matching mpv's default
- keep the existing MediaCodec -> MediaCodec-copy -> software fallback chain unchanged
- keep current `PlaybackSession`, lifecycle/surface handling, HDR modes, gpu/gpu-next selection, subtitles, Anime4K, background playback, notification behavior, and all newer features unchanged

## Why this is safer

mpv documents direct rendering as `auto` by default. Its decoder queue is off by default; the manual notes that the separate decoder queue is largely unnecessary because libavcodec is already threaded, increases memory use, can make seeking slower, and should not be used with hardware decoding.

Forcing both globally changed the decode pipeline for every video and is especially harmful on low/mid-range devices that fall back to CPU decoding for HEVC/Main10.

## Scope

One file only: `MPVView.kt`.

No codec whitelist changes, no renderer removal, no quality downgrade, no feature removal, and no unrelated cleanup.

## Validation

- source diff is limited to restoring the two decoder defaults
- branch is based on current `master`
- GitHub Actions will validate the Android build
- device validation should include the original #107 HEVC/Main10 software-decoding sample and both local/network playback
