### PR TITLE
fix(ui): stack mini player actions and support unlimited NEW labels

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/MainActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/MainActivity.kt
@@ -531,8 +531,8 @@ class MainActivity : AppCompatActivity() {
                   .windowInsetsPadding(WindowInsets.navigationBars)
                   .padding(bottom = 12.dp, start = 12.dp, end = 12.dp)
 
-              // Portrait phones: full width with a small side margin, sitting above
-              // the pill nav bar (or at the very bottom when there is no nav bar).
+              // Portrait phones: full width with a small side margin. During selection,
+              // lift the mini player above the edit actions instead of covering them.
               isPortrait && !isTablet ->
                 Modifier
                   .align(Alignment.BottomCenter)
@@ -541,7 +541,17 @@ class MainActivity : AppCompatActivity() {
                   .padding(
                     start = 12.dp,
                     end = 12.dp,
-                    bottom = if (NavigationBarState.isNavBarVisible) 88.dp else 12.dp,
+                    bottom =
+                      (if (NavigationBarState.isNavBarVisible) {
+                        NavigationBarState.navigationBarClearance
+                      } else {
+                        12.dp
+                      }) +
+                        (if (NavigationBarState.isInSelectionMode) {
+                          NavigationBarState.selectionBarClearance
+                        } else {
+                          0.dp
+                        }),
                   )
 
               // Landscape/tablet single-pane: sit on the right side of the nav bar,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/NavigationBarState.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/NavigationBarState.kt
@@ -25,9 +25,20 @@ object NavigationBarState {
 
   var isDualPaneFolderSelected: Boolean by mutableStateOf(false)
 
+  private var miniPlayerVisibleState: Boolean by mutableStateOf(false)
+
   // Mini player coordination state (published by MiniPlayer/MainScreen so the
   // browser layout can adapt when the mini player is on screen).
-  var isMiniPlayerVisible: Boolean by mutableStateOf(false)
+  var isMiniPlayerVisible: Boolean
+    get() = miniPlayerVisibleState
+    set(value) {
+      miniPlayerVisibleState = value
+      // While selecting with active playback, keep the navigation layer available
+      // so the three bottom layers can be stacked instead of covering one another.
+      if (isInSelectionMode) {
+        shouldHideNavigationBar = !value
+      }
+    }
 
   // True while the floating pill nav bar is actually on screen (MainScreen on top
   // and not hidden). Lets the mini player drop to the very bottom when there is no
@@ -37,6 +48,11 @@ object NavigationBarState {
   var navbarLeftOffset: Dp by mutableStateOf(0.dp)
 
   var navbarWidth: Dp by mutableStateOf(320.dp)
+
+  // Shared portrait clearances for the floating browser layers. These match the
+  // existing pill/mini-player geometry and keep selection actions between them.
+  val navigationBarClearance: Dp = 88.dp
+  val selectionBarClearance: Dp = 100.dp
 
   // Vertical space the mini player needs to clear from the bottom of the screen in
   // screens that sit below it without a nav bar (FABs/list content).
@@ -61,7 +77,10 @@ object NavigationBarState {
   ) {
     isInSelectionMode = inSelectionMode
     onlyVideosSelected = onlyVideos
-    shouldHideNavigationBar = inSelectionMode
+    // Preserve the old hide-on-selection behavior when there is no mini player.
+    // With active playback, keep navigation visible and stack the selection bar and
+    // mini player above it instead of letting either overlay cover the actions.
+    shouldHideNavigationBar = inSelectionMode && !isMiniPlayerVisible
   }
 
   fun updatePermissionState(denied: Boolean) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
@@ -131,14 +131,6 @@ fun VideoCard(
   val showUnplayedOldVideoLabel = resolvedUiConfig.showUnplayedOldVideoLabel
   val unplayedOldVideoDays = resolvedUiConfig.unplayedOldVideoDays
   val showDurationField = resolvedUiConfig.showDurationField
-  val isWithinNewLabelAgeWindow =
-    if (unplayedOldVideoDays == 0) {
-      true
-    } else {
-      val videoAge = System.currentTimeMillis() - (video.dateModified * 1000)
-      val thresholdMillis = unplayedOldVideoDays * 24L * 60L * 60L * 1000L
-      videoAge <= thresholdMillis
-    }
   val displayName =
     if (resolvedUiConfig.showExtensionField) {
       video.displayName
@@ -303,25 +295,33 @@ fun VideoCard(
               )
             }
 
-            // 0 days means unlimited; otherwise enforce the configured age window.
-            if (showUnplayedOldVideoLabel && isOldAndUnplayed && isWithinNewLabelAgeWindow) {
-              Box(
-                modifier =
-                  Modifier
-                    .align(Alignment.TopStart)
-                    .padding(6.dp)
-                    .clip(AppShapeScale.extraSmall)
-                    .background(Color(0xFFD32F2F)) // Warning red color
-                    .padding(horizontal = 8.dp, vertical = 3.dp),
-              ) {
-                Text(
-                  text = stringResource(R.string.video_label_new),
-                  style =
-                    MaterialTheme.typography.labelSmall.copy(
-                      fontWeight = FontWeight.Bold,
-                    ),
-                  color = Color.White,
-                )
+            // Show "NEW" label for recently added unplayed videos if enabled (top-left corner)
+            // Like MX Player: show NEW for videos added within threshold days that haven't been played
+            if (showUnplayedOldVideoLabel && isOldAndUnplayed) {
+              // Check if video is recently modified (within threshold days)
+              val currentTime = System.currentTimeMillis()
+              val videoAge = currentTime - (video.dateModified * 1000) // dateModified is in seconds
+              val thresholdMillis = unplayedOldVideoDays * 24L * 60L * 60L * 1000L
+
+              if (unplayedOldVideoDays == 0 || videoAge <= thresholdMillis) {
+                Box(
+                  modifier =
+                    Modifier
+                      .align(Alignment.TopStart)
+                      .padding(6.dp)
+                      .clip(AppShapeScale.extraSmall)
+                      .background(Color(0xFFD32F2F)) // Warning red color
+                      .padding(horizontal = 8.dp, vertical = 3.dp),
+                ) {
+                  Text(
+                    text = stringResource(R.string.video_label_new),
+                    style =
+                      MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                      ),
+                    color = Color.White,
+                  )
+                }
               }
             }
 
@@ -592,25 +592,33 @@ fun VideoCard(
               )
             }
 
-            // 0 days means unlimited; otherwise enforce the configured age window.
-            if (showUnplayedOldVideoLabel && isOldAndUnplayed && isWithinNewLabelAgeWindow) {
-              Box(
-                modifier =
-                  Modifier
-                    .align(Alignment.TopStart)
-                    .padding(6.dp)
-                    .clip(AppShapeScale.extraSmall)
-                    .background(Color(0xFFD32F2F)) // Warning red color
-                    .padding(horizontal = 8.dp, vertical = 3.dp),
-              ) {
-                Text(
-                  text = stringResource(R.string.video_label_new),
-                  style =
-                    MaterialTheme.typography.labelSmall.copy(
-                      fontWeight = FontWeight.Bold,
-                    ),
-                  color = Color.White,
-                )
+            // Show "NEW" label for recently added unplayed videos if enabled (top-left corner)
+            // Like MX Player: show NEW for videos added within threshold days that haven't been played
+            if (showUnplayedOldVideoLabel && isOldAndUnplayed) {
+              // Check if video is recently modified (within threshold days)
+              val currentTime = System.currentTimeMillis()
+              val videoAge = currentTime - (video.dateModified * 1000) // dateModified is in seconds
+              val thresholdMillis = unplayedOldVideoDays * 24L * 60L * 60L * 1000L
+
+              if (unplayedOldVideoDays == 0 || videoAge <= thresholdMillis) {
+                Box(
+                  modifier =
+                    Modifier
+                      .align(Alignment.TopStart)
+                      .padding(6.dp)
+                      .clip(AppShapeScale.extraSmall)
+                      .background(Color(0xFFD32F2F)) // Warning red color
+                      .padding(horizontal = 8.dp, vertical = 3.dp),
+                ) {
+                  Text(
+                    text = stringResource(R.string.video_label_new),
+                    style =
+                      MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                      ),
+                    color = Color.White,
+                  )
+                }
               }
             }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
@@ -131,6 +131,14 @@ fun VideoCard(
   val showUnplayedOldVideoLabel = resolvedUiConfig.showUnplayedOldVideoLabel
   val unplayedOldVideoDays = resolvedUiConfig.unplayedOldVideoDays
   val showDurationField = resolvedUiConfig.showDurationField
+  val isWithinNewLabelAgeWindow =
+    if (unplayedOldVideoDays == 0) {
+      true
+    } else {
+      val videoAge = System.currentTimeMillis() - (video.dateModified * 1000)
+      val thresholdMillis = unplayedOldVideoDays * 24L * 60L * 60L * 1000L
+      videoAge <= thresholdMillis
+    }
   val displayName =
     if (resolvedUiConfig.showExtensionField) {
       video.displayName
@@ -295,33 +303,25 @@ fun VideoCard(
               )
             }
 
-            // Show "NEW" label for recently added unplayed videos if enabled (top-left corner)
-            // Like MX Player: show NEW for videos added within threshold days that haven't been played
-            if (showUnplayedOldVideoLabel && isOldAndUnplayed) {
-              // Check if video is recently modified (within threshold days)
-              val currentTime = System.currentTimeMillis()
-              val videoAge = currentTime - (video.dateModified * 1000) // dateModified is in seconds
-              val thresholdMillis = unplayedOldVideoDays * 24 * 60 * 60 * 1000L
-
-              if (videoAge <= thresholdMillis) {
-                Box(
-                  modifier =
-                    Modifier
-                      .align(Alignment.TopStart)
-                      .padding(6.dp)
-                      .clip(AppShapeScale.extraSmall)
-                      .background(Color(0xFFD32F2F)) // Warning red color
-                      .padding(horizontal = 8.dp, vertical = 3.dp),
-                ) {
-                  Text(
-                    text = stringResource(R.string.video_label_new),
-                    style =
-                      MaterialTheme.typography.labelSmall.copy(
-                        fontWeight = FontWeight.Bold,
-                      ),
-                    color = Color.White,
-                  )
-                }
+            // 0 days means unlimited; otherwise enforce the configured age window.
+            if (showUnplayedOldVideoLabel && isOldAndUnplayed && isWithinNewLabelAgeWindow) {
+              Box(
+                modifier =
+                  Modifier
+                    .align(Alignment.TopStart)
+                    .padding(6.dp)
+                    .clip(AppShapeScale.extraSmall)
+                    .background(Color(0xFFD32F2F)) // Warning red color
+                    .padding(horizontal = 8.dp, vertical = 3.dp),
+              ) {
+                Text(
+                  text = stringResource(R.string.video_label_new),
+                  style =
+                    MaterialTheme.typography.labelSmall.copy(
+                      fontWeight = FontWeight.Bold,
+                    ),
+                  color = Color.White,
+                )
               }
             }
 
@@ -592,33 +592,25 @@ fun VideoCard(
               )
             }
 
-            // Show "NEW" label for recently added unplayed videos if enabled (top-left corner)
-            // Like MX Player: show NEW for videos added within threshold days that haven't been played
-            if (showUnplayedOldVideoLabel && isOldAndUnplayed) {
-              // Check if video is recently modified (within threshold days)
-              val currentTime = System.currentTimeMillis()
-              val videoAge = currentTime - (video.dateModified * 1000) // dateModified is in seconds
-              val thresholdMillis = unplayedOldVideoDays * 24 * 60 * 60 * 1000L
-
-              if (videoAge <= thresholdMillis) {
-                Box(
-                  modifier =
-                    Modifier
-                      .align(Alignment.TopStart)
-                      .padding(6.dp)
-                      .clip(AppShapeScale.extraSmall)
-                      .background(Color(0xFFD32F2F)) // Warning red color
-                      .padding(horizontal = 8.dp, vertical = 3.dp),
-                ) {
-                  Text(
-                    text = stringResource(R.string.video_label_new),
-                    style =
-                      MaterialTheme.typography.labelSmall.copy(
-                        fontWeight = FontWeight.Bold,
-                      ),
-                    color = Color.White,
-                  )
-                }
+            // 0 days means unlimited; otherwise enforce the configured age window.
+            if (showUnplayedOldVideoLabel && isOldAndUnplayed && isWithinNewLabelAgeWindow) {
+              Box(
+                modifier =
+                  Modifier
+                    .align(Alignment.TopStart)
+                    .padding(6.dp)
+                    .clip(AppShapeScale.extraSmall)
+                    .background(Color(0xFFD32F2F)) // Warning red color
+                    .padding(horizontal = 8.dp, vertical = 3.dp),
+              ) {
+                Text(
+                  text = stringResource(R.string.video_label_new),
+                  style =
+                    MaterialTheme.typography.labelSmall.copy(
+                      fontWeight = FontWeight.Bold,
+                    ),
+                  color = Color.White,
+                )
               }
             }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/FloatingBottomBar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/FloatingBottomBar.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.ui.browser.NavigationBarState
 import app.gyrolet.mpvrx.ui.icons.AppIcon
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
@@ -96,9 +97,16 @@ fun BrowserBottomBar(
   val effectiveShowDelete = if (isSelectionMode) showDelete else lastShowDelete
   val effectiveShowAddToPlaylist = if (isSelectionMode) showAddToPlaylist else lastShowAddToPlaylist
 
+  val stackedModifier =
+    if (NavigationBarState.isNavBarVisible) {
+      modifier.padding(bottom = NavigationBarState.navigationBarClearance)
+    } else {
+      modifier
+    }
+
   AnimatedVisibility(
     visible = isSelectionMode,
-    modifier = modifier,
+    modifier = stackedModifier,
     enter =
       androidx.compose.animation.slideInVertically(
         animationSpec =
@@ -166,9 +174,9 @@ fun BrowserBottomBar(
           isTablet -> {
             val options =
               listOf(
-                BarLayoutParams(64.dp, 32.dp, 24.dp, 20.dp, 8.dp, 32.dp, 16.dp), // Large
-                BarLayoutParams(56.dp, 28.dp, 16.dp, 16.dp, 6.dp, 24.dp, 12.dp), // Medium
-                BarLayoutParams(48.dp, 24.dp, 12.dp, 12.dp, 6.dp, 16.dp, 10.dp), // Small
+                BarLayoutParams(64.dp, 32.dp, 24.dp, 20.dp, 8.dp, 32.dp, 16.dp),
+                BarLayoutParams(56.dp, 28.dp, 16.dp, 16.dp, 6.dp, 24.dp, 12.dp),
+                BarLayoutParams(48.dp, 24.dp, 12.dp, 12.dp, 6.dp, 16.dp, 10.dp),
               )
             options.firstOrNull { opt ->
               val totalWidth =
@@ -180,10 +188,10 @@ fun BrowserBottomBar(
           isLandscape -> {
             val options =
               listOf(
-                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 4.dp, 16.dp, 6.dp), // Large (Compact vertical)
-                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 4.dp, 12.dp, 6.dp), // Medium (Compact vertical)
-                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 2.dp, 8.dp, 4.dp), // Small (Compact vertical)
-                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 2.dp, 6.dp, 4.dp), // Tiny (Compact vertical)
+                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 4.dp, 16.dp, 6.dp),
+                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 4.dp, 12.dp, 6.dp),
+                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 2.dp, 8.dp, 4.dp),
+                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 2.dp, 6.dp, 4.dp),
               )
             options.firstOrNull { opt ->
               val totalWidth =
@@ -195,10 +203,10 @@ fun BrowserBottomBar(
           else -> {
             val options =
               listOf(
-                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 8.dp, 16.dp, 12.dp), // Large
-                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 6.dp, 12.dp, 10.dp), // Medium
-                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 4.dp, 8.dp, 8.dp), // Small
-                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 4.dp, 6.dp, 6.dp), // Tiny
+                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 8.dp, 16.dp, 12.dp),
+                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 6.dp, 12.dp, 10.dp),
+                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 4.dp, 8.dp, 8.dp),
+                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 4.dp, 6.dp, 6.dp),
               )
             options.firstOrNull { opt ->
               val totalWidth =
@@ -232,46 +240,11 @@ fun BrowserBottomBar(
           horizontalArrangement = Arrangement.spacedBy(layoutParams.spacing),
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          BrowserBottomBarButton(
-            effectiveShowCopy,
-            onCopyClick,
-            Icons.RoundedFilled.ContentCopy,
-            "Copy",
-            layoutParams.buttonSize,
-            layoutParams.iconSize,
-          )
-          BrowserBottomBarButton(
-            effectiveShowMove,
-            onMoveClick,
-            Icons.RoundedFilled.DriveFileMove,
-            "Move",
-            layoutParams.buttonSize,
-            layoutParams.iconSize,
-          )
-          BrowserBottomBarButton(
-            effectiveShowDownscale,
-            onDownscaleClick,
-            Icons.RoundedFilled.FitScreen,
-            "Compressor",
-            layoutParams.buttonSize,
-            layoutParams.iconSize,
-          )
-          BrowserBottomBarButton(
-            effectiveShowRename,
-            onRenameClick,
-            Icons.RoundedFilled.DriveFileRenameOutline,
-            "Rename",
-            layoutParams.buttonSize,
-            layoutParams.iconSize,
-          )
-          BrowserBottomBarButton(
-            effectiveShowAddToPlaylist,
-            onAddToPlaylistClick,
-            Icons.RoundedFilled.PlaylistAdd,
-            "Add to Playlist",
-            layoutParams.buttonSize,
-            layoutParams.iconSize,
-          )
+          BrowserBottomBarButton(effectiveShowCopy, onCopyClick, Icons.RoundedFilled.ContentCopy, "Copy", layoutParams.buttonSize, layoutParams.iconSize)
+          BrowserBottomBarButton(effectiveShowMove, onMoveClick, Icons.RoundedFilled.DriveFileMove, "Move", layoutParams.buttonSize, layoutParams.iconSize)
+          BrowserBottomBarButton(effectiveShowDownscale, onDownscaleClick, Icons.RoundedFilled.FitScreen, "Compressor", layoutParams.buttonSize, layoutParams.iconSize)
+          BrowserBottomBarButton(effectiveShowRename, onRenameClick, Icons.RoundedFilled.DriveFileRenameOutline, "Rename", layoutParams.buttonSize, layoutParams.iconSize)
+          BrowserBottomBarButton(effectiveShowAddToPlaylist, onAddToPlaylistClick, Icons.RoundedFilled.PlaylistAdd, "Add to Playlist", layoutParams.buttonSize, layoutParams.iconSize)
           BrowserBottomBarButton(
             effectiveShowDelete,
             onDeleteClick,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/FloatingBottomBar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/FloatingBottomBar.kt
@@ -174,9 +174,9 @@ fun BrowserBottomBar(
           isTablet -> {
             val options =
               listOf(
-                BarLayoutParams(64.dp, 32.dp, 24.dp, 20.dp, 8.dp, 32.dp, 16.dp),
-                BarLayoutParams(56.dp, 28.dp, 16.dp, 16.dp, 6.dp, 24.dp, 12.dp),
-                BarLayoutParams(48.dp, 24.dp, 12.dp, 12.dp, 6.dp, 16.dp, 10.dp),
+                BarLayoutParams(64.dp, 32.dp, 24.dp, 20.dp, 8.dp, 32.dp, 16.dp), // Large
+                BarLayoutParams(56.dp, 28.dp, 16.dp, 16.dp, 6.dp, 24.dp, 12.dp), // Medium
+                BarLayoutParams(48.dp, 24.dp, 12.dp, 12.dp, 6.dp, 16.dp, 10.dp), // Small
               )
             options.firstOrNull { opt ->
               val totalWidth =
@@ -188,10 +188,10 @@ fun BrowserBottomBar(
           isLandscape -> {
             val options =
               listOf(
-                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 4.dp, 16.dp, 6.dp),
-                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 4.dp, 12.dp, 6.dp),
-                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 2.dp, 8.dp, 4.dp),
-                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 2.dp, 6.dp, 4.dp),
+                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 4.dp, 16.dp, 6.dp), // Large (Compact vertical)
+                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 4.dp, 12.dp, 6.dp), // Medium (Compact vertical)
+                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 2.dp, 8.dp, 4.dp), // Small (Compact vertical)
+                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 2.dp, 6.dp, 4.dp), // Tiny (Compact vertical)
               )
             options.firstOrNull { opt ->
               val totalWidth =
@@ -203,10 +203,10 @@ fun BrowserBottomBar(
           else -> {
             val options =
               listOf(
-                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 8.dp, 16.dp, 12.dp),
-                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 6.dp, 12.dp, 10.dp),
-                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 4.dp, 8.dp, 8.dp),
-                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 4.dp, 6.dp, 6.dp),
+                BarLayoutParams(56.dp, 28.dp, 12.dp, 10.dp, 8.dp, 16.dp, 12.dp), // Large
+                BarLayoutParams(48.dp, 24.dp, 10.dp, 8.dp, 6.dp, 12.dp, 10.dp), // Medium
+                BarLayoutParams(42.dp, 22.dp, 8.dp, 6.dp, 4.dp, 8.dp, 8.dp), // Small
+                BarLayoutParams(36.dp, 18.dp, 6.dp, 4.dp, 4.dp, 6.dp, 6.dp), // Tiny
               )
             options.firstOrNull { opt ->
               val totalWidth =
@@ -240,11 +240,46 @@ fun BrowserBottomBar(
           horizontalArrangement = Arrangement.spacedBy(layoutParams.spacing),
           verticalAlignment = Alignment.CenterVertically,
         ) {
-          BrowserBottomBarButton(effectiveShowCopy, onCopyClick, Icons.RoundedFilled.ContentCopy, "Copy", layoutParams.buttonSize, layoutParams.iconSize)
-          BrowserBottomBarButton(effectiveShowMove, onMoveClick, Icons.RoundedFilled.DriveFileMove, "Move", layoutParams.buttonSize, layoutParams.iconSize)
-          BrowserBottomBarButton(effectiveShowDownscale, onDownscaleClick, Icons.RoundedFilled.FitScreen, "Compressor", layoutParams.buttonSize, layoutParams.iconSize)
-          BrowserBottomBarButton(effectiveShowRename, onRenameClick, Icons.RoundedFilled.DriveFileRenameOutline, "Rename", layoutParams.buttonSize, layoutParams.iconSize)
-          BrowserBottomBarButton(effectiveShowAddToPlaylist, onAddToPlaylistClick, Icons.RoundedFilled.PlaylistAdd, "Add to Playlist", layoutParams.buttonSize, layoutParams.iconSize)
+          BrowserBottomBarButton(
+            effectiveShowCopy,
+            onCopyClick,
+            Icons.RoundedFilled.ContentCopy,
+            "Copy",
+            layoutParams.buttonSize,
+            layoutParams.iconSize,
+          )
+          BrowserBottomBarButton(
+            effectiveShowMove,
+            onMoveClick,
+            Icons.RoundedFilled.DriveFileMove,
+            "Move",
+            layoutParams.buttonSize,
+            layoutParams.iconSize,
+          )
+          BrowserBottomBarButton(
+            effectiveShowDownscale,
+            onDownscaleClick,
+            Icons.RoundedFilled.FitScreen,
+            "Compressor",
+            layoutParams.buttonSize,
+            layoutParams.iconSize,
+          )
+          BrowserBottomBarButton(
+            effectiveShowRename,
+            onRenameClick,
+            Icons.RoundedFilled.DriveFileRenameOutline,
+            "Rename",
+            layoutParams.buttonSize,
+            layoutParams.iconSize,
+          )
+          BrowserBottomBarButton(
+            effectiveShowAddToPlaylist,
+            onAddToPlaylistClick,
+            Icons.RoundedFilled.PlaylistAdd,
+            "Add to Playlist",
+            layoutParams.buttonSize,
+            layoutParams.iconSize,
+          )
           BrowserBottomBarButton(
             effectiveShowDelete,
             onDeleteClick,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/MiniPlayer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/MiniPlayer.kt
@@ -117,14 +117,13 @@ fun MiniPlayer(modifier: Modifier = Modifier) {
 
   val currentItem = sessionState.currentItem
   val isMediaActive = isServiceRunning && currentItem != null &&
-    !NavigationBarState.isInSelectionMode &&
     !isSettingsScreen &&
     sessionState.phase != PlaybackPhase.IDLE &&
     sessionState.phase != PlaybackPhase.UNINITIALIZED &&
     sessionState.phase != PlaybackPhase.ERROR
 
-  // Expose visibility so MainScreen can slide the nav bar aside in
-  // landscape/tablet and raise it above the full-width bar in portrait.
+  // Keep the mini player alive while browser selection mode is active. Its outer
+  // placement is lifted above the selection actions instead of hiding/overlapping.
   SideEffect {
     NavigationBarState.isMiniPlayerVisible = isMediaActive
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryViewModel.kt
@@ -91,7 +91,7 @@ class MediaLibraryViewModel(
     val playbackStates = playbackStateRepository.getAllPlaybackStates()
     val currentTime = System.currentTimeMillis()
     val thresholdDays = appearancePreferences.unplayedOldVideoDays.get()
-    val thresholdMillis = thresholdDays * 24 * 60 * 60 * 1000L
+    val thresholdMillis = thresholdDays * 24L * 60L * 60L * 1000L
     val watchedThreshold = browserPreferences.watchedThreshold.get()
     val playbackByTitle = playbackStates.associateBy { it.mediaTitle }
 
@@ -123,9 +123,10 @@ class MediaLibraryViewModel(
             false
           }
 
-        // "NEW" badge shows while the video is recent AND not yet watched. Removed once
-        // watched to the configured threshold percentage (0 = infinite, never removed).
-        val isOldAndUnplayed = !isWatched && videoAge <= thresholdMillis
+        // 0 days means no age expiry. Otherwise NEW is bounded by the configured
+        // age window and is removed sooner if the watched threshold is reached.
+        val isWithinNewLabelAgeWindow = thresholdDays == 0 || videoAge <= thresholdMillis
+        val isOldAndUnplayed = !isWatched && isWithinNewLabelAgeWindow
 
         VideoWithPlaybackInfo(
           video = video,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
@@ -394,14 +394,19 @@ object AppearancePreferencesScreen : Screen {
                     text = stringResource(id = R.string.pref_appearance_unplayed_old_video_days_title),
                   )
                 },
-                valueRange = 1f..30f,
+                valueRange = 0f..30f,
+                valueSteps = 29,
                 summary = {
                   Text(
                     text =
-                      stringResource(
-                        id = R.string.pref_appearance_unplayed_old_video_days_summary,
-                        unplayedOldVideoDays,
-                      ),
+                      if (unplayedOldVideoDays == 0) {
+                        "Unlimited — NEW stays until the watched threshold is reached"
+                      } else {
+                        stringResource(
+                          id = R.string.pref_appearance_unplayed_old_video_days_summary,
+                          unplayedOldVideoDays,
+                        )
+                      },
                     color = MaterialTheme.colorScheme.outline,
                   )
                 },
@@ -815,7 +820,6 @@ object AppearancePreferencesScreen : Screen {
                   )
                 },
               )
-
             }
           }
 


### PR DESCRIPTION
## Summary

Fix two browser UI/state issues without changing playback, decoder, renderer, shader, or network behavior.

### Mini player + selection actions
- keep the active mini player visible while selecting songs/items
- keep the bottom navigation visible when selection mode starts during active mini-player playback
- stack portrait layers instead of overlapping them: bottom navigation -> selection/edit actions -> mini player
- preserve the previous hide-navigation behavior for selection when there is no active mini player

### NEW video threshold
- allow `Days threshold for new video label` to reach `0`
- show `Unlimited` semantics at `0`
- `0` disables age expiry, so NEW remains until the configured watched threshold is reached
- non-zero values (for example 7 or 29 days) keep the existing age limit and remove NEW earlier if the watched threshold is reached
- apply the same rule in Media Library plus grid/list VideoCard paths

## Scope

Only browser/UI state and NEW-label calculations are changed. This PR does not touch playback decoding, networking, ambient shaders, HDR, PiP playback behavior, or media scanning.

This branch contains connector-side preparation commits and is intended to be **squash merged** so `master` receives one commit.