### PR TITLE
Fix secure folder related bugs

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderAccountDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderAccountDialogs.kt
@@ -12,12 +12,9 @@ package app.gyrolet.mpvrx.ui.securefolder
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -28,16 +25,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.preferences.SecureFolderPreferences
+import app.gyrolet.mpvrx.presentation.components.ExposedTextDropDownMenu
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
+import kotlinx.collections.immutable.toImmutableList
 
 /**
  * "Change PIN" and "Change Security Question" dialogs for the Secure Folder overflow menu /
@@ -107,7 +102,7 @@ fun ChangePinDialog(
             PinField(
               value = currentPin,
               onValueChange = {
-                currentPin = it.filter(Char::isDigit).take(8)
+                currentPin = it.filter(Char::isDigit).take(4)
                 errorRes = null
               },
               showPin = showPin,
@@ -119,7 +114,7 @@ fun ChangePinDialog(
             PinField(
               value = newPin,
               onValueChange = {
-                newPin = it.filter(Char::isDigit).take(8)
+                newPin = it.filter(Char::isDigit).take(4)
                 errorRes = null
               },
               showPin = showPin,
@@ -129,7 +124,7 @@ fun ChangePinDialog(
             PinField(
               value = confirmPin,
               onValueChange = {
-                confirmPin = it.filter(Char::isDigit).take(8)
+                confirmPin = it.filter(Char::isDigit).take(4)
                 errorRes = null
               },
               showPin = showPin,
@@ -180,7 +175,8 @@ fun ChangeSecurityQuestionDialog(
   var step by rememberSaveable(isOpen) { mutableStateOf(AccountDialogStep.VERIFY_CURRENT_PIN) }
   var currentPin by rememberSaveable(isOpen) { mutableStateOf("") }
   var showPin by rememberSaveable(isOpen) { mutableStateOf(false) }
-  var question by rememberSaveable(isOpen) { mutableStateOf("") }
+  val presets = SECURITY_QUESTION_PRESET_RES_IDS.map { stringResource(it) }.toImmutableList()
+  var question by rememberSaveable(isOpen, presets) { mutableStateOf(presets.first()) }
   var answer by rememberSaveable(isOpen) { mutableStateOf("") }
   var errorRes by rememberSaveable(isOpen) { mutableStateOf<Int?>(null) }
 
@@ -225,7 +221,7 @@ fun ChangeSecurityQuestionDialog(
             PinField(
               value = currentPin,
               onValueChange = {
-                currentPin = it.filter(Char::isDigit).take(8)
+                currentPin = it.filter(Char::isDigit).take(4)
                 errorRes = null
               },
               showPin = showPin,
@@ -234,12 +230,11 @@ fun ChangeSecurityQuestionDialog(
               onDone = ::submit,
             )
           AccountDialogStep.ENTER_NEW -> {
-            OutlinedTextField(
-              value = question,
-              onValueChange = { question = it },
-              label = { Text(stringResource(R.string.secure_folder_question)) },
-              singleLine = true,
-              modifier = Modifier.fillMaxWidth(),
+            ExposedTextDropDownMenu(
+              selectedValue = question,
+              options = presets,
+              label = stringResource(R.string.secure_folder_security_question),
+              onValueChangedEvent = { question = it },
             )
             OutlinedTextField(
               value = answer,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderGateScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderGateScreen.kt
@@ -9,6 +9,8 @@
 
 package app.gyrolet.mpvrx.ui.securefolder
 
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.keyframes
@@ -126,6 +128,8 @@ data object SecureFolderGateScreen : Screen {
 
     val gateStep by viewModel.gateStep.collectAsState()
     val gateError by viewModel.gateError.collectAsState()
+    val pinChangedMessage = stringResource(R.string.secure_folder_pin_changed)
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     // Biometric authentication
     val biometricManager = BiometricManager.from(context)
@@ -136,6 +140,10 @@ data object SecureFolderGateScreen : Screen {
 
     fun showBiometricPrompt() {
       val fragmentActivity = context as? FragmentActivity ?: return
+      // The PIN field's soft keyboard may still have a pending show request queued (it auto-focuses
+      // on this screen). If that request gets delivered after the biometric prompt dismisses, it
+      // flashes the numeric keyboard on whatever screen we've navigated to next. Hide it up front.
+      keyboardController?.hide()
       val executor = ContextCompat.getMainExecutor(context)
       val callback = object : BiometricPrompt.AuthenticationCallback() {
         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
@@ -161,8 +169,15 @@ data object SecureFolderGateScreen : Screen {
       biometricPrompt.authenticate(promptInfoBuilder.build())
     }
 
-    androidx.compose.runtime.LaunchedEffect(Unit) {
+    LaunchedEffect(Unit) {
       viewModel.refreshGateStep()
+    }
+
+    // Covers the system back gesture/button too, not just the topbar arrow — same keyboard-hide
+    // fix as onBackClick below, since either path can leave the IME lingering over the next screen.
+    BackHandler {
+      keyboardController?.hide()
+      backstack.popSafely()
     }
 
     Scaffold(
@@ -172,7 +187,10 @@ data object SecureFolderGateScreen : Screen {
           isInSelectionMode = false,
           selectedCount = 0,
           totalCount = 0,
-          onBackClick = { backstack.popSafely() },
+          onBackClick = {
+            keyboardController?.hide()
+            backstack.popSafely()
+          },
           onCancelSelection = {},
         )
       },
@@ -237,7 +255,11 @@ data object SecureFolderGateScreen : Screen {
                     title = stringResource(R.string.secure_folder_choose_new_pin),
                     subtitle = stringResource(R.string.secure_folder_old_pin_invalid),
                     error = gateError,
-                    onSubmit = { pin -> viewModel.finishForgotPinFlow(pin) },
+                    onSubmit = { pin ->
+                      if (viewModel.finishForgotPinFlow(pin)) {
+                        Toast.makeText(context, pinChangedMessage, Toast.LENGTH_SHORT).show()
+                      }
+                    },
                   )
               }
             }
@@ -267,7 +289,11 @@ private fun EnterPinContent(
   fun submit(): Boolean {
     if (pin.isEmpty()) return false
     val ok = onSubmit(pin)
-    if (!ok) {
+    if (ok) {
+      // Hide the keyboard right away on success — otherwise its pending close/show request can
+      // bleed into the next screen and flash there for a moment (same issue as the biometric path).
+      keyboardController?.hide()
+    } else {
       pin = ""
       scope.launch {
         shakeOffset.animateTo(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/securefolder/SecureFolderScreen.kt
@@ -76,6 +76,7 @@ import app.gyrolet.mpvrx.ui.utils.popSafely
 import app.gyrolet.mpvrx.utils.media.MediaInfoOps
 import app.gyrolet.mpvrx.utils.media.MediaUtils
 import app.gyrolet.mpvrx.utils.sort.SortUtils
+import android.widget.Toast
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
 import java.io.File
@@ -95,6 +96,9 @@ data object SecureFolderScreen : Screen {
     val backstack = LocalBackStack.current
     val viewModel: SecureFolderViewModel =
       viewModel(factory = SecureFolderViewModel.factory(context.applicationContext as android.app.Application))
+
+    val pinChangedMessage = stringResource(R.string.secure_folder_pin_changed)
+    val securityQuestionChangedMessage = stringResource(R.string.secure_folder_security_question_changed)
 
     val browserPreferences = koinInject<BrowserPreferences>()
     val appearancePreferences = koinInject<AppearancePreferences>()
@@ -597,12 +601,14 @@ data object SecureFolderScreen : Screen {
       isOpen = changePinOpen,
       preferences = viewModel.preferences,
       onDismiss = { changePinOpen = false },
+      onChanged = { Toast.makeText(context, pinChangedMessage, Toast.LENGTH_SHORT).show() },
     )
 
     ChangeSecurityQuestionDialog(
       isOpen = changeSecurityQuestionOpen,
       preferences = viewModel.preferences,
       onDismiss = { changeSecurityQuestionOpen = false },
+      onChanged = { Toast.makeText(context, securityQuestionChangedMessage, Toast.LENGTH_SHORT).show() },
     )
 
     VideoSortDialog(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1565,6 +1565,8 @@
   <string name="secure_folder_verify">التحقق</string>
   <string name="secure_folder_next">التالي</string>
   <string name="secure_folder_save">حفظ</string>
+  <string name="secure_folder_pin_changed">تم تغيير رمز PIN بنجاح</string>
+  <string name="secure_folder_security_question_changed">تم تحديث سؤال الأمان</string>
   <string name="secure_folder_use_fingerprint">استخدام بصمة الإصبع</string>
   <string name="secure_folder_enable_fingerprint">تفعيل بصمة الإصبع</string>
   <string name="secure_folder_disable_fingerprint">تعطيل بصمة الإصبع</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1565,6 +1565,8 @@ Bitte starten Sie die App neu, damit alle Änderungen wirksam werden.</string>
   <string name="secure_folder_verify">Überprüfen</string>
   <string name="secure_folder_next">Weiter</string>
   <string name="secure_folder_save">Speichern</string>
+  <string name="secure_folder_pin_changed">PIN erfolgreich geändert</string>
+  <string name="secure_folder_security_question_changed">Sicherheitsfrage aktualisiert</string>
   <string name="secure_folder_use_fingerprint">Fingerabdruck verwenden</string>
   <string name="secure_folder_enable_fingerprint">Fingerabdruck aktivieren</string>
   <string name="secure_folder_disable_fingerprint">Fingerabdruck deaktivieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1565,6 +1565,8 @@ Reinicia la aplicación para que se apliquen todos los cambios.</string>
   <string name="secure_folder_verify">Verificar</string>
   <string name="secure_folder_next">Siguiente</string>
   <string name="secure_folder_save">Guardar</string>
+  <string name="secure_folder_pin_changed">PIN cambiado correctamente</string>
+  <string name="secure_folder_security_question_changed">Pregunta de seguridad actualizada</string>
   <string name="secure_folder_use_fingerprint">Usar huella digital</string>
   <string name="secure_folder_enable_fingerprint">Activar huella digital</string>
   <string name="secure_folder_disable_fingerprint">Desactivar huella digital</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1565,6 +1565,8 @@ Veuillez redémarrer l’application pour appliquer toutes les modifications.</s
   <string name="secure_folder_verify">Vérifier</string>
   <string name="secure_folder_next">Suivant</string>
   <string name="secure_folder_save">Enregistrer</string>
+  <string name="secure_folder_pin_changed">Code PIN modifié avec succès</string>
+  <string name="secure_folder_security_question_changed">Question de sécurité mise à jour</string>
   <string name="secure_folder_use_fingerprint">Utiliser l\'empreinte digitale</string>
   <string name="secure_folder_enable_fingerprint">Activer l\'empreinte digitale</string>
   <string name="secure_folder_disable_fingerprint">Désactiver l\'empreinte digitale</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1474,6 +1474,8 @@
   <string name="secure_folder_verify">वेरिफाई करें</string>
   <string name="secure_folder_next">अगला</string>
   <string name="secure_folder_save">सेव करें</string>
+  <string name="secure_folder_pin_changed">PIN सफलतापूर्वक बदल दिया गया</string>
+  <string name="secure_folder_security_question_changed">सुरक्षा प्रश्न अपडेट हो गया</string>
   <string name="secure_folder_use_fingerprint">फिंगरप्रिंट इस्तेमाल करें</string>
   <string name="secure_folder_enable_fingerprint">फिंगरप्रिंट सक्षम करें</string>
   <string name="secure_folder_disable_fingerprint">फिंगरप्रिंट अक्षम करें</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1565,6 +1565,8 @@
   <string name="secure_folder_verify">確認</string>
   <string name="secure_folder_next">次へ</string>
   <string name="secure_folder_save">保存</string>
+  <string name="secure_folder_pin_changed">PINを変更しました</string>
+  <string name="secure_folder_security_question_changed">秘密の質問を更新しました</string>
   <string name="secure_folder_use_fingerprint">指紋を使用</string>
   <string name="secure_folder_enable_fingerprint">指紋を有効にする</string>
   <string name="secure_folder_disable_fingerprint">指紋を無効にする</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1565,6 +1565,8 @@ Reinicie o aplicativo para que todas as alterações entrem em vigor.</string>
   <string name="secure_folder_verify">Verificar</string>
   <string name="secure_folder_next">Avançar</string>
   <string name="secure_folder_save">Salvar</string>
+  <string name="secure_folder_pin_changed">PIN alterado com sucesso</string>
+  <string name="secure_folder_security_question_changed">Pergunta de segurança atualizada</string>
   <string name="secure_folder_use_fingerprint">Usar digital</string>
   <string name="secure_folder_enable_fingerprint">Ativar digital</string>
   <string name="secure_folder_disable_fingerprint">Desativar digital</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1565,6 +1565,8 @@
   <string name="secure_folder_verify">Проверить</string>
   <string name="secure_folder_next">Далее</string>
   <string name="secure_folder_save">Сохранить</string>
+  <string name="secure_folder_pin_changed">PIN-код успешно изменён</string>
+  <string name="secure_folder_security_question_changed">Контрольный вопрос обновлён</string>
   <string name="secure_folder_use_fingerprint">Использовать отпечаток пальца</string>
   <string name="secure_folder_enable_fingerprint">Включить отпечаток пальца</string>
   <string name="secure_folder_disable_fingerprint">Отключить отпечаток пальца</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1565,6 +1565,8 @@
   <string name="secure_folder_verify">验证</string>
   <string name="secure_folder_next">下一步</string>
   <string name="secure_folder_save">保存</string>
+  <string name="secure_folder_pin_changed">PIN码修改成功</string>
+  <string name="secure_folder_security_question_changed">安全问题已更新</string>
   <string name="secure_folder_use_fingerprint">使用指纹</string>
   <string name="secure_folder_enable_fingerprint">启用指纹</string>
   <string name="secure_folder_disable_fingerprint">禁用指纹</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1589,6 +1589,8 @@
   <string name="secure_folder_verify">Verify</string>
   <string name="secure_folder_next">Next</string>
   <string name="secure_folder_save">Save</string>
+  <string name="secure_folder_pin_changed">PIN changed successfully</string>
+  <string name="secure_folder_security_question_changed">Security question updated</string>
   <string name="secure_folder_use_fingerprint">Use Fingerprint</string>
   <string name="secure_folder_enable_fingerprint">Enable Fingerprint</string>
   <string name="secure_folder_disable_fingerprint">Disable Fingerprint</string>


### PR DESCRIPTION
Bug Fixes & Improvements

The following Secure Folder PIN and security settings issues have been fixed and tested:

- PIN auto-verification: Previously, the user had to manually tap the “Unlock” button after entering the 4th digit. Now, the PIN is automatically verified as soon as all 4 digits are entered.

- Incorrect PIN handling: Previously, entering an incorrect PIN did not clear/reset the field. Now, the PIN dots are automatically cleared and a shake animation is shown when an incorrect PIN is entered.

- Change PIN digit limit: Previously, the Secure Folder → Change PIN dialog allowed unlimited digits in the current, new, and confirmation PIN fields. All PIN fields now strictly accept exactly 4 digits.

- Security question preset dropdown: The Change Security Question dialog was missing the preset question dropdown and used a free-text field instead. It now uses the same preset question dropdown as the initial setup screen for a consistent experience.

- PIN change confirmation: Previously, there was no confirmation after changing the PIN, either from Secure Folder Settings or the Forgot PIN flow. Both flows now show the native Toast: “PIN changed successfully.”

- Security question change confirmation: A native Toast confirmation is now displayed after successfully changing the security question.

- PIN length validation consistency: Previously, the ViewModel checked for a minimum of 4 digits ("< 4"), while the PIN gate expected exactly 4 digits. The validation now consistently enforces exactly 4 digits ("!= 4") in both places.

- Fingerprint unlock keyboard flash: Previously, the keyboard could briefly appear on the Secure Folder screen after fingerprint authentication because a pending keyboard-show request was delivered late. The keyboard is now explicitly hidden before opening the biometric prompt.

- PIN unlock keyboard flash: The same keyboard-flash issue could occur after successful PIN verification. The keyboard is now hidden immediately after successful verification and before navigation.

- Back navigation keyboard delay: Previously, the keyboard could take 1–2 seconds to disappear when navigating back using the top-bar back arrow or system back gesture. The keyboard is now hidden immediately before navigation in both cases.

Testing

All of the above fixes have been tested successfully and are working as expected.