### PR TITLE
perf: reduce app-wide CPU, GPU, I/O and background resource use

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,10 @@
 import com.android.build.api.variant.FilterConfiguration
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val enableX86 = project.findProperty("enableX86") != "false"
+// Phone releases only need ARM by default. x86/x86_64 remain available for emulator/testing
+// builds with -PenableX86=true, avoiding two extra native stacks (mpv/libtorrent/etc.) in normal
+// release assembly and universal APKs.
+val enableX86 = project.findProperty("enableX86") == "true"
 val x86Abis = if (enableX86) listOf("x86", "x86_64") else emptyList()
 
 plugins {

--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -14,12 +14,10 @@ import android.app.Application
 import android.content.ComponentName
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.os.Environment
 import android.util.Log
 import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import android.media.MediaScannerConnection
 import app.gyrolet.mpvrx.database.repository.VideoMetadataCacheRepository
 import app.gyrolet.mpvrx.di.DatabaseModule
 import app.gyrolet.mpvrx.di.FileManagerModule
@@ -29,10 +27,9 @@ import app.gyrolet.mpvrx.presentation.crash.CrashActivity
 import app.gyrolet.mpvrx.presentation.crash.GlobalExceptionHandler
 import app.gyrolet.mpvrx.repository.NetworkRepository
 import app.gyrolet.mpvrx.ui.player.AndroidNativeCompat
-import app.gyrolet.mpvrx.utils.media.MediaLibraryEvents
 import `is`.xyz.mpv.FastThumbnails
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -53,9 +50,6 @@ class App :
 
   companion object {
     private const val TAG = "App"
-    private const val LAUNCH_SCAN_PREFS = "launch_media_scan"
-    private const val LAST_LAUNCH_SCAN_MS = "last_launch_scan_ms"
-    private const val LAUNCH_SCAN_INTERVAL_MS = 24L * 60L * 60L * 1000L
   }
 
   override fun onCreate() {
@@ -123,11 +117,10 @@ class App :
     // cold start wasted I/O + JSON parse time for a feature most users never
     // open. See issue 1.2 in the startup audit.
 
-    applicationScope.launch {
-      runCatching {
-        triggerMediaScanOnLaunch()
-      }
-    }
+    // MediaStore is Android's source of truth for the normal library. Do not trigger a recursive
+    // scan of the entire external-storage root from process startup: on large libraries that can
+    // wake storage for minutes and duplicate work the platform already performs when media changes.
+    // Explicit library refreshes and normal MediaStore notifications still invalidate app caches.
   }
 
   override fun onActivityStarted(activity: Activity) {
@@ -208,39 +201,4 @@ class App :
    * of [onCreate]).
    */
   private fun getKoin() = GlobalContext.get()
-
-  private fun triggerMediaScanOnLaunch() {
-    try {
-      if (!shouldRunLaunchMediaScan()) {
-        Log.d(TAG, "Skipped launch media scan; last scan was recent")
-        return
-      }
-
-      val externalStorage = Environment.getExternalStorageDirectory()
-
-      MediaScannerConnection.scanFile(
-        this,
-        arrayOf(externalStorage.absolutePath),
-        null,
-      ) { path, _ ->
-        Log.d(TAG, "Launch media scan completed for: $path")
-        MediaLibraryEvents.notifyChanged()
-      }
-
-      Log.d(TAG, "Triggered media scan on app launch")
-    } catch (error: Exception) {
-      Log.e(TAG, "Failed to trigger media scan on launch", error)
-    }
-  }
-
-  private fun shouldRunLaunchMediaScan(): Boolean {
-    val now = System.currentTimeMillis()
-    val prefs = getSharedPreferences(LAUNCH_SCAN_PREFS, MODE_PRIVATE)
-    val lastScan = prefs.getLong(LAST_LAUNCH_SCAN_MS, 0L)
-    if (now - lastScan < LAUNCH_SCAN_INTERVAL_MS) {
-      return false
-    }
-    prefs.edit().putLong(LAST_LAUNCH_SCAN_MS, now).apply()
-    return true
-  }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -27,12 +27,15 @@ import app.gyrolet.mpvrx.presentation.crash.CrashActivity
 import app.gyrolet.mpvrx.presentation.crash.GlobalExceptionHandler
 import app.gyrolet.mpvrx.repository.NetworkRepository
 import app.gyrolet.mpvrx.ui.player.AndroidNativeCompat
+import app.gyrolet.mpvrx.ui.player.PlaybackPhase
+import app.gyrolet.mpvrx.ui.player.PlaybackSession
 import `is`.xyz.mpv.FastThumbnails
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -54,6 +57,7 @@ class App :
     private const val TAG = "App"
     private const val POST_START_MAINTENANCE_DELAY_MS = 10_000L
     private const val THUMBNAIL_WARMUP_DELAY_MS = 1_500L
+    private const val IDLE_MPV_CORE_GRACE_MS = 3L * 60L * 1000L
   }
 
   override fun onCreate() {
@@ -77,6 +81,7 @@ class App :
     registerActivityLifecycleCallbacks(this)
 
     Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(applicationContext, CrashActivity::class.java))
+    startIdleMpvCoreReaper()
 
     applicationScope.launch {
       runCatching {
@@ -156,6 +161,38 @@ class App :
   ) = Unit
 
   override fun onActivityDestroyed(activity: Activity) = Unit
+
+  /**
+   * Keep libmpv warm for quick navigation/re-entry, but do not pin its native decoder/renderer
+   * allocation forever after playback has genuinely ended. collectLatest makes this self-cancelling:
+   * any new load, surface attachment, background session, or other state change aborts the grace
+   * timer before destruction can run.
+   */
+  private fun startIdleMpvCoreReaper() {
+    applicationScope.launch {
+      PlaybackSession.state.collectLatest { state ->
+        val isFullyIdle =
+          state.phase == PlaybackPhase.IDLE &&
+            state.currentItem == null &&
+            !state.surfaceAttached &&
+            PlaybackSession.isInitialized
+        if (!isFullyIdle) return@collectLatest
+
+        delay(IDLE_MPV_CORE_GRACE_MS)
+
+        val latest = PlaybackSession.state.value
+        val stillFullyIdle =
+          latest.phase == PlaybackPhase.IDLE &&
+            latest.currentItem == null &&
+            !latest.surfaceAttached &&
+            PlaybackSession.isInitialized
+        if (stillFullyIdle) {
+          Log.d(TAG, "Destroying libmpv after idle grace period")
+          PlaybackSession.destroy()
+        }
+      }
+    }
+  }
 
   private fun scheduleFastThumbnailWarmupOnce() {
     if (!fastThumbnailsStarted.compareAndSet(false, true)) return

--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -46,10 +46,12 @@ class App :
   Application.ActivityLifecycleCallbacks {
   private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
   private val networkAutoConnectStarted = AtomicBoolean(false)
+  private val metadataMaintenanceStarted = AtomicBoolean(false)
   private var startedActivityCount = 0
 
   companion object {
     private const val TAG = "App"
+    private const val POST_START_MAINTENANCE_DELAY_MS = 10_000L
   }
 
   override fun onCreate() {
@@ -98,24 +100,9 @@ class App :
       }
     }
 
-    // Perform cache maintenance on app startup (non-blocking).
-    // Resolve the repository lazily inside the coroutine so Room DB construction
-    // (which registers 8 migrations and opens the SQLite file) happens on the
-    // background dispatcher instead of contending with first-frame work on the
-    // main thread. See issue 1.1 in the startup audit.
-    applicationScope.launch {
-      runCatching {
-        val metadataCache: VideoMetadataCacheRepository = getKoin().get()
-        metadataCache.performMaintenance()
-      }
-    }
-
-    // Note: TextMate grammar/theme assets for the script editor are no longer
-    // pre-loaded here. They are initialized lazily on first use by
-    // ScriptEditorTextMate.ensureInitialized() in MpvScriptEditor.kt, which
-    // already has a thread-safe double-checked init. Loading them on every
-    // cold start wasted I/O + JSON parse time for a feature most users never
-    // open. See issue 1.2 in the startup audit.
+    // TextMate grammar/theme assets for the script editor are initialized lazily on first use.
+    // Metadata cache maintenance is also intentionally not started here: Room/file validation can
+    // wait until the app has reached foreground and settled after its first frames.
 
     // MediaStore is Android's source of truth for the normal library. Do not trigger a recursive
     // scan of the entire external-storage root from process startup: on large libraries that can
@@ -126,6 +113,7 @@ class App :
   override fun onActivityStarted(activity: Activity) {
     if (startedActivityCount++ == 0) {
       getKoin().get<app.gyrolet.mpvrx.domain.syncplay.SyncplayManager>().onAppForegrounded()
+      scheduleMetadataMaintenanceOnce()
     }
   }
 
@@ -168,6 +156,23 @@ class App :
   ) = Unit
 
   override fun onActivityDestroyed(activity: Activity) = Unit
+
+  private fun scheduleMetadataMaintenanceOnce() {
+    if (!metadataMaintenanceStarted.compareAndSet(false, true)) return
+    applicationScope.launch(Dispatchers.IO) {
+      try {
+        delay(POST_START_MAINTENANCE_DELAY_MS)
+        val metadataCache: VideoMetadataCacheRepository = getKoin().get()
+        metadataCache.performMaintenance()
+      } catch (cancellation: CancellationException) {
+        metadataMaintenanceStarted.set(false)
+        throw cancellation
+      } catch (error: Exception) {
+        metadataMaintenanceStarted.set(false)
+        Log.w(TAG, "Deferred metadata maintenance failed", error)
+      }
+    }
+  }
 
   /** Starts saved-share auto-connect in process scope so Activity recreation cannot cancel it. */
   internal fun autoConnectNetworksOnce() {

--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -47,11 +47,13 @@ class App :
   private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
   private val networkAutoConnectStarted = AtomicBoolean(false)
   private val metadataMaintenanceStarted = AtomicBoolean(false)
+  private val fastThumbnailsStarted = AtomicBoolean(false)
   private var startedActivityCount = 0
 
   companion object {
     private const val TAG = "App"
     private const val POST_START_MAINTENANCE_DELAY_MS = 10_000L
+    private const val THUMBNAIL_WARMUP_DELAY_MS = 1_500L
   }
 
   override fun onCreate() {
@@ -76,9 +78,6 @@ class App :
 
     Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(applicationContext, CrashActivity::class.java))
 
-    // Native libmpv thumbnail engine used by browser, folder, playlist, and network previews.
-    FastThumbnails.initialize(this)
-
     applicationScope.launch {
       runCatching {
         val preferences: PlayerPreferences = getKoin().get()
@@ -101,8 +100,8 @@ class App :
     }
 
     // TextMate grammar/theme assets for the script editor are initialized lazily on first use.
-    // Metadata cache maintenance is also intentionally not started here: Room/file validation can
-    // wait until the app has reached foreground and settled after its first frames.
+    // Metadata cache maintenance and native thumbnail startup are intentionally kept out of the
+    // Application cold-start path so they cannot compete with first composition / first frame.
 
     // MediaStore is Android's source of truth for the normal library. Do not trigger a recursive
     // scan of the entire external-storage root from process startup: on large libraries that can
@@ -113,6 +112,7 @@ class App :
   override fun onActivityStarted(activity: Activity) {
     if (startedActivityCount++ == 0) {
       getKoin().get<app.gyrolet.mpvrx.domain.syncplay.SyncplayManager>().onAppForegrounded()
+      scheduleFastThumbnailWarmupOnce()
       scheduleMetadataMaintenanceOnce()
     }
   }
@@ -156,6 +156,22 @@ class App :
   ) = Unit
 
   override fun onActivityDestroyed(activity: Activity) = Unit
+
+  private fun scheduleFastThumbnailWarmupOnce() {
+    if (!fastThumbnailsStarted.compareAndSet(false, true)) return
+    applicationScope.launch(Dispatchers.Default) {
+      try {
+        delay(THUMBNAIL_WARMUP_DELAY_MS)
+        FastThumbnails.initialize(this@App)
+      } catch (cancellation: CancellationException) {
+        fastThumbnailsStarted.set(false)
+        throw cancellation
+      } catch (error: Exception) {
+        fastThumbnailsStarted.set(false)
+        Log.w(TAG, "Deferred FastThumbnails initialization failed", error)
+      }
+    }
+  }
 
   private fun scheduleMetadataMaintenanceOnce() {
     if (!metadataMaintenanceStarted.compareAndSet(false, true)) return

--- a/app/src/main/java/app/gyrolet/mpvrx/MainActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/MainActivity.kt
@@ -468,13 +468,16 @@ class MainActivity : AppCompatActivity() {
       } else {
         null
       }
-    val updateState by (
-      updateViewModel?.updateState ?: MutableStateFlow(
-        UpdateViewModel.UpdateState.Idle,
-      )
-    ).collectAsState()
-    val isDownloading by (updateViewModel?.isDownloading ?: MutableStateFlow(false)).collectAsState()
-    val downloadProgress by (updateViewModel?.downloadProgress ?: MutableStateFlow(0f)).collectAsState()
+
+    // These flows are only fallback state for builds where the updater is compiled out. Remember
+    // them once so navigator recompositions do not allocate three new StateFlow instances and
+    // create fresh collectAsState subscriptions.
+    val fallbackUpdateState = remember { MutableStateFlow<UpdateViewModel.UpdateState>(UpdateViewModel.UpdateState.Idle) }
+    val fallbackIsDownloading = remember { MutableStateFlow(false) }
+    val fallbackDownloadProgress = remember { MutableStateFlow(0f) }
+    val updateState by (updateViewModel?.updateState ?: fallbackUpdateState).collectAsState()
+    val isDownloading by (updateViewModel?.isDownloading ?: fallbackIsDownloading).collectAsState()
+    val downloadProgress by (updateViewModel?.downloadProgress ?: fallbackDownloadProgress).collectAsState()
 
     // Provide both LocalBackStack and the LazyList/Grid states to all screens
     CompositionLocalProvider(

--- a/app/src/main/java/app/gyrolet/mpvrx/data/network/client/SmbClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/network/client/SmbClient.kt
@@ -42,7 +42,11 @@ class SmbClient(
   private val connection: NetworkConnection,
 ) : NetworkClient {
   companion object {
-    private const val SMB_BUFFER_SIZE = 1024 * 1024
+    // 1 MiB for every transport buffer plus another 1 MiB stream buffer was excessive on phones,
+    // especially when mpv opens multiple range requests while seeking. 512 KiB keeps SMBJ reads
+    // comfortably large without reserving several megabytes per active connection.
+    private const val SMB_TRANSPORT_BUFFER_SIZE = 512 * 1024
+    private const val SMB_STREAM_BUFFER_SIZE = 256 * 1024
 
     private fun newClient(): SMBClient =
       SMBClient(
@@ -51,9 +55,9 @@ class SmbClient(
           .withTransportLayerFactory(AsyncDirectTcpTransportFactory())
           .withTimeout(60000, TimeUnit.MILLISECONDS)
           .withSoTimeout(60000, TimeUnit.MILLISECONDS)
-          .withReadBufferSize(SMB_BUFFER_SIZE)
-          .withWriteBufferSize(SMB_BUFFER_SIZE)
-          .withTransactBufferSize(SMB_BUFFER_SIZE)
+          .withReadBufferSize(SMB_TRANSPORT_BUFFER_SIZE)
+          .withWriteBufferSize(SMB_TRANSPORT_BUFFER_SIZE)
+          .withTransactBufferSize(SMB_TRANSPORT_BUFFER_SIZE)
           .withDialects(
             com.hierynomus.mssmb2.SMB2Dialect.SMB_3_1_1,
             com.hierynomus.mssmb2.SMB2Dialect.SMB_3_0_2,
@@ -280,11 +284,11 @@ class SmbClient(
                   private var currentPosition = offset
                   private var closed = false
                   private var scratch = ByteArray(0)
+                  private val singleByte = ByteArray(1)
 
                   override fun read(): Int {
-                    val buffer = ByteArray(1)
-                    val read = read(buffer, 0, 1)
-                    return if (read == 1) buffer[0].toInt() and 0xFF else -1
+                    val read = read(singleByte, 0, 1)
+                    return if (read == 1) singleByte[0].toInt() and 0xFF else -1
                   }
 
                   override fun read(b: ByteArray): Int = read(b, 0, b.size)
@@ -340,7 +344,7 @@ class SmbClient(
                   }
                 }
 
-              BufferedInputStream(inputStream, SMB_BUFFER_SIZE)
+              BufferedInputStream(inputStream, SMB_STREAM_BUFFER_SIZE)
             } catch (e: Exception) {
               diskShare.close()
               throw IOException("Failed to open SMB file", e)

--- a/app/src/main/java/app/gyrolet/mpvrx/data/network/proxy/NetworkStreamingProxy.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/network/proxy/NetworkStreamingProxy.kt
@@ -23,19 +23,21 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.ByteArrayInputStream
+import java.io.IOException
 import java.io.InputStream
 import java.net.URI
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A loopback-only authenticated-capability gateway for SMB, FTP, and WebDAV media.
@@ -51,6 +53,7 @@ class NetworkStreamingProxy private constructor() :
   companion object {
     private const val TAG = "NetworkStreamingProxy"
     private const val TOKEN_BYTES = 24
+    private const val PROXY_OPERATION_TIMEOUT_SECONDS = 75L
 
     @Volatile
     private var instance: NetworkStreamingProxy? = null
@@ -80,7 +83,11 @@ class NetworkStreamingProxy private constructor() :
     fileSize: Long,
     val primaryMimeType: String,
   ) {
-    val knownPrimarySize = AtomicLong(fileSize)
+    // Cache sizes for the primary media and sibling resources (HLS segments, keys, maps, etc.).
+    // A seek can otherwise issue repeated serialized size probes before every range request.
+    val knownSizes = ConcurrentHashMap<NetworkPath, Long>().apply {
+      if (fileSize >= 0L) put(primaryPath, fileSize)
+    }
     val clientMutex = Mutex()
 
     @Volatile
@@ -245,17 +252,15 @@ class NetworkStreamingProxy private constructor() :
     streamInfo: StreamInfo,
     path: NetworkPath,
   ): Long {
-    if (path == streamInfo.primaryPath) {
-      streamInfo.knownPrimarySize.get().takeIf { it >= 0L }?.let { return it }
-    }
+    streamInfo.knownSizes[path]?.let { return it }
 
     val discovered =
-      runBlocking {
+      awaitProxyIo {
         withConnectedClient(streamInfo) { client -> client.getFileSize(path.value) }
       }.getOrNull() ?: -1L
 
-    if (path == streamInfo.primaryPath && discovered >= 0L) {
-      streamInfo.knownPrimarySize.compareAndSet(-1L, discovered)
+    if (discovered >= 0L) {
+      streamInfo.knownSizes.putIfAbsent(path, discovered)
     }
     return discovered
   }
@@ -265,9 +270,45 @@ class NetworkStreamingProxy private constructor() :
     path: NetworkPath,
     offset: Long,
   ): InputStream? =
-    runBlocking {
+    awaitProxyIo {
       withConnectedClient(streamInfo) { client -> client.getFileStream(path.value, offset) }
     }.getOrNull()
+
+  /**
+   * NanoHTTPD's serve API is synchronous, but upstream clients are suspend-based. Do not use
+   * runBlocking here: it installs a nested coroutine event loop on every range request and can
+   * amplify thread contention under rapid seeks. Dispatch the suspend work onto the proxy's bounded
+   * IO scope and wait only for the result, with a hard timeout and cancellation.
+   */
+  private fun <T> awaitProxyIo(operation: suspend () -> Result<T>): Result<T> {
+    val result = AtomicReference<Result<T>?>(null)
+    val latch = CountDownLatch(1)
+    val job =
+      proxyScope.launch {
+        try {
+          result.set(operation())
+        } catch (cancellation: CancellationException) {
+          result.set(Result.failure(cancellation))
+        } catch (error: Exception) {
+          result.set(Result.failure(error))
+        } finally {
+          latch.countDown()
+        }
+      }
+
+    return try {
+      if (!latch.await(PROXY_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        job.cancel()
+        Result.failure(IOException("Upstream proxy operation timed out"))
+      } else {
+        result.get() ?: Result.failure(IOException("Upstream proxy operation produced no result"))
+      }
+    } catch (interrupted: InterruptedException) {
+      job.cancel()
+      Thread.currentThread().interrupt()
+      Result.failure(interrupted)
+    }
+  }
 
   private suspend fun <T> withConnectedClient(
     streamInfo: StreamInfo,

--- a/app/src/main/java/app/gyrolet/mpvrx/database/dao/RecentlyPlayedDao.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/database/dao/RecentlyPlayedDao.kt
@@ -27,10 +27,13 @@ interface RecentlyPlayedDao {
   @Query("SELECT * FROM RecentlyPlayedEntity WHERE filePath = :filePath LIMIT 1")
   suspend fun getByFilePath(filePath: String): RecentlyPlayedEntity?
 
-  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY timestamp DESC LIMIT 1")
+  // id is the INTEGER PRIMARY KEY and therefore already indexed by SQLite. New history entries are
+  // inserted with autoGenerate=true, so ordering by id avoids building a temporary timestamp sort
+  // for the hot recent-history queries without introducing a database migration solely for indexes.
+  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY id DESC LIMIT 1")
   suspend fun getLastPlayed(): RecentlyPlayedEntity?
 
-  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY timestamp DESC LIMIT 1")
+  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY id DESC LIMIT 1")
   fun observeLastPlayed(): Flow<RecentlyPlayedEntity?>
 
   @Query(
@@ -38,7 +41,7 @@ interface RecentlyPlayedDao {
     SELECT * FROM RecentlyPlayedEntity 
     WHERE (launchSource IS NULL OR launchSource = '' OR launchSource = 'normal' OR launchSource = 'playlist' OR launchSource = 'video_list')
     AND (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
-    ORDER BY timestamp DESC 
+    ORDER BY id DESC 
     LIMIT 1
   """,
   )
@@ -49,7 +52,7 @@ interface RecentlyPlayedDao {
     SELECT * FROM RecentlyPlayedEntity 
     WHERE (launchSource IS NULL OR launchSource = '' OR launchSource = 'normal' OR launchSource = 'playlist' OR launchSource = 'video_list')
     AND (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
-    ORDER BY timestamp DESC 
+    ORDER BY id DESC 
     LIMIT 1
   """,
   )
@@ -59,7 +62,7 @@ interface RecentlyPlayedDao {
     """
     SELECT * FROM RecentlyPlayedEntity 
     WHERE (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%')) 
-    ORDER BY timestamp DESC 
+    ORDER BY id DESC 
     LIMIT :limit
   """,
   )
@@ -69,7 +72,7 @@ interface RecentlyPlayedDao {
     """
     SELECT * FROM RecentlyPlayedEntity 
     WHERE (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%')) 
-    ORDER BY timestamp DESC 
+    ORDER BY id DESC 
     LIMIT :limit
   """,
   )
@@ -80,7 +83,7 @@ interface RecentlyPlayedDao {
     SELECT * FROM RecentlyPlayedEntity 
     WHERE launchSource = :launchSource
     AND (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
-    ORDER BY timestamp DESC 
+    ORDER BY id DESC 
     LIMIT :limit
   """,
   )
@@ -155,7 +158,7 @@ interface RecentlyPlayedDao {
     val timestamp: Long,
   )
 
-  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY timestamp DESC")
+  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY id DESC")
   suspend fun getAllRecentlyPlayed(): List<RecentlyPlayedEntity>
 
   @Query("SELECT COUNT(*) FROM RecentlyPlayedEntity")

--- a/app/src/main/java/app/gyrolet/mpvrx/database/repository/PlaybackStateRepositoryImpl.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/database/repository/PlaybackStateRepositoryImpl.kt
@@ -12,26 +12,56 @@ package app.gyrolet.mpvrx.database.repository
 import app.gyrolet.mpvrx.database.MpvRxDatabase
 import app.gyrolet.mpvrx.database.entities.PlaybackStateEntity
 import app.gyrolet.mpvrx.domain.playbackstate.repository.PlaybackStateRepository
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PlaybackStateRepositoryImpl(
   private val database: MpvRxDatabase,
 ) : PlaybackStateRepository {
+  // Library screens can ask for the complete playback-state set several times while navigating or
+  // refreshing. Keep one process-local snapshot after the first unavoidable Room load and maintain
+  // it incrementally on writes instead of allocating/querying the full table on every request.
+  private val stateCache = ConcurrentHashMap<String, PlaybackStateEntity>()
+  private val allStatesLoaded = AtomicBoolean(false)
+  private val fullLoadMutex = Mutex()
+
   override suspend fun upsert(playbackState: PlaybackStateEntity) {
     database.videoDataDao().upsert(playbackState)
+    stateCache[playbackState.mediaTitle] = playbackState
   }
 
-  override suspend fun getVideoDataByTitle(mediaTitle: String): PlaybackStateEntity? =
-    database.videoDataDao().getVideoDataByTitle(mediaTitle)
+  override suspend fun getVideoDataByTitle(mediaTitle: String): PlaybackStateEntity? {
+    stateCache[mediaTitle]?.let { return it }
+    return database.videoDataDao().getVideoDataByTitle(mediaTitle)?.also { state ->
+      stateCache[state.mediaTitle] = state
+    }
+  }
 
-  override suspend fun getAllPlaybackStates(): List<PlaybackStateEntity> =
-    database.videoDataDao().getAllPlaybackStates()
+  override suspend fun getAllPlaybackStates(): List<PlaybackStateEntity> {
+    if (allStatesLoaded.get()) return stateCache.values.toList()
+
+    return fullLoadMutex.withLock {
+      if (!allStatesLoaded.get()) {
+        val loaded = database.videoDataDao().getAllPlaybackStates()
+        stateCache.clear()
+        loaded.forEach { state -> stateCache[state.mediaTitle] = state }
+        allStatesLoaded.set(true)
+      }
+      stateCache.values.toList()
+    }
+  }
 
   override suspend fun clearAllPlaybackStates() {
     database.videoDataDao().clearAllPlaybackStates()
+    stateCache.clear()
+    allStatesLoaded.set(true)
   }
 
   override suspend fun deleteByTitle(mediaTitle: String) {
     database.videoDataDao().deleteByTitle(mediaTitle)
+    stateCache.remove(mediaTitle)
   }
 
   override suspend fun updateMediaTitle(
@@ -39,5 +69,8 @@ class PlaybackStateRepositoryImpl(
     newTitle: String,
   ) {
     database.videoDataDao().updateMediaTitle(oldTitle, newTitle)
+    stateCache.remove(oldTitle)?.let { state ->
+      stateCache[newTitle] = state.copy(mediaTitle = newTitle)
+    }
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -11,10 +11,15 @@ package app.gyrolet.mpvrx.ui.player.controls
 
 import app.gyrolet.mpvrx.ui.player.PlaybackSession
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.util.LruCache
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.Crossfade
@@ -75,6 +80,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.ripple
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -123,6 +129,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
+import androidx.core.content.ContextCompat
 import kotlin.math.roundToInt
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.domain.thumbnail.EmbeddedArtworkResolver
@@ -140,6 +147,8 @@ import app.gyrolet.mpvrx.ui.player.RepeatMode
 import app.gyrolet.mpvrx.ui.player.Sheets
 import app.gyrolet.mpvrx.ui.player.controls.components.AbLoopIcon
 import app.gyrolet.mpvrx.ui.player.controls.components.SeekbarWithTimers
+import app.gyrolet.mpvrx.ui.player.visualizer.AudioFeatures
+import app.gyrolet.mpvrx.ui.player.visualizer.AudioSpectrumAnalyzer
 import app.gyrolet.mpvrx.ui.player.visualizer.BlobOverlay
 import app.gyrolet.mpvrx.ui.player.visualizer.CuboidOverlay
 import app.gyrolet.mpvrx.ui.player.visualizer.GalaxyOverlay
@@ -151,21 +160,59 @@ import app.gyrolet.mpvrx.utils.media.fileExtension
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
 
-@Composable
-private fun rememberAudioAlbumArt(pathOrUri: String?): Bitmap? {
-  val context = LocalContext.current
-  var bitmap by remember { mutableStateOf<Bitmap?>(null) }
-  LaunchedEffect(pathOrUri) {
-    if (pathOrUri.isNullOrBlank()) {
-      bitmap = null
-      return@LaunchedEffect
+private data class AudioPresentationMetadata(
+  val artwork: Bitmap?,
+  val artist: String?,
+)
+
+/**
+ * One bounded native-metadata pipeline for the current song, swipe previews, and queue rows.
+ *
+ * Previously each consumer created its own MediaMetadataRetriever (and the current track created a
+ * second retriever just for artist fallback), so entering Now Playing could parse the same file
+ * several times and hold several native retrievers concurrently. The cache is byte-sized by
+ * artwork memory, metadata-only/missing-art entries still consume a small fixed weight, and the
+ * mutex intentionally serializes cache misses to cap native decoder/retriever pressure.
+ */
+private object AudioPresentationMetadataCache {
+  private const val MAX_CACHE_KB = 16 * 1024
+  private const val METADATA_ONLY_WEIGHT_KB = 64
+  private val loadMutex = Mutex()
+  private val cache =
+    object : LruCache<String, AudioPresentationMetadata>(MAX_CACHE_KB) {
+      override fun sizeOf(
+        key: String,
+        value: AudioPresentationMetadata,
+      ): Int =
+        maxOf(
+          METADATA_ONLY_WEIGHT_KB,
+          (value.artwork?.byteCount ?: 0) / 1024,
+        )
     }
+
+  fun peek(pathOrUri: String?): AudioPresentationMetadata? {
+    if (pathOrUri.isNullOrBlank()) return null
+    return synchronized(cache) { cache.get(pathOrUri) }
+  }
+
+  suspend fun resolve(
+    context: android.content.Context,
+    pathOrUri: String,
+  ): AudioPresentationMetadata =
     withContext(Dispatchers.IO) {
-      runCatching {
+      synchronized(cache) { cache.get(pathOrUri) }?.let { return@withContext it }
+
+      loadMutex.withLock {
+        synchronized(cache) { cache.get(pathOrUri) }?.let { return@withLock it }
+
         val cleanPath =
           when {
             pathOrUri.startsWith("file://") -> pathOrUri.removePrefix("file://")
@@ -173,22 +220,103 @@ private fun rememberAudioAlbumArt(pathOrUri: String?): Bitmap? {
             else -> pathOrUri
           }
         val retriever = MediaMetadataRetriever()
-        if (cleanPath != null) {
-          retriever.setDataSource(cleanPath)
-        } else {
-          retriever.setDataSource(context, Uri.parse(pathOrUri))
-        }
-        val art = EmbeddedArtworkResolver.decodeEmbeddedArtwork(cleanPath, retriever)
-        retriever.release()
-        art
-      }.onSuccess { loadedBitmap ->
-        bitmap = loadedBitmap
-      }.onFailure {
-        bitmap = null
+        val loaded =
+          try {
+            if (cleanPath != null) {
+              retriever.setDataSource(cleanPath)
+            } else {
+              retriever.setDataSource(context, Uri.parse(pathOrUri))
+            }
+
+            AudioPresentationMetadata(
+              artwork = EmbeddedArtworkResolver.decodeEmbeddedArtwork(cleanPath, retriever),
+              artist =
+                retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
+                  ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
+                  ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_AUTHOR)
+                  ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COMPOSER),
+            )
+          } catch (_: Exception) {
+            AudioPresentationMetadata(artwork = null, artist = null)
+          } finally {
+            runCatching { retriever.release() }
+          }
+
+        synchronized(cache) { cache.put(pathOrUri, loaded) }
+        loaded
       }
     }
+}
+
+@Composable
+private fun rememberAudioPresentationMetadata(pathOrUri: String?): AudioPresentationMetadata? {
+  val context = LocalContext.current
+  var metadata by remember(pathOrUri) {
+    mutableStateOf(AudioPresentationMetadataCache.peek(pathOrUri))
   }
-  return bitmap
+  LaunchedEffect(pathOrUri) {
+    metadata =
+      if (pathOrUri.isNullOrBlank()) {
+        null
+      } else {
+        AudioPresentationMetadataCache.resolve(context, pathOrUri)
+      }
+  }
+  return metadata
+}
+
+@Composable
+private fun rememberAudioAlbumArt(pathOrUri: String?): Bitmap? =
+  rememberAudioPresentationMetadata(pathOrUri)?.artwork
+
+/**
+ * Cuboid is a Compose Canvas and does not pass through the GLSurfaceView VisualizerOverlay, so it
+ * needs the same scoped Android spectrum capture explicitly. The capture exists only while Cuboid
+ * is actually visible; album-art mode, lyrics and modal sheets release it immediately.
+ */
+@Composable
+private fun CuboidSpectrumCaptureEffect(
+  enabled: Boolean,
+  features: AudioFeatures,
+) {
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
+  val analyzerActive = remember(features) { AtomicBoolean(false) }
+  var hasRecordPermission by remember {
+    mutableStateOf(
+      ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+        PackageManager.PERMISSION_GRANTED,
+    )
+  }
+  val recordPermissionLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+      hasRecordPermission = granted
+    }
+
+  LaunchedEffect(enabled, hasRecordPermission) {
+    if (enabled && !hasRecordPermission) {
+      recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+    }
+  }
+
+  DisposableEffect(enabled, hasRecordPermission, features) {
+    val analyzer = if (enabled && hasRecordPermission) AudioSpectrumAnalyzer(features) else null
+    val job =
+      scope.launch(Dispatchers.Default) {
+        while (isActive && analyzer != null) {
+          val captureFresh = features.active && features.hasRecentCapture(1_500_000_000L)
+          if (!analyzerActive.get() || !captureFresh) {
+            analyzerActive.set(analyzer.start(0).isSuccess)
+          }
+          kotlinx.coroutines.delay(if (analyzerActive.get()) 1_500L else 400L)
+        }
+      }
+    onDispose {
+      job.cancel()
+      analyzerActive.set(false)
+      analyzer?.stop(resetFeatures = false)
+    }
+  }
 }
 
 @Composable
@@ -275,7 +403,8 @@ fun AudioPlayerControls(
       isLosslessCodecOrExt && (sampleRate ?: 0) >= 88200
     }
 
-  val albumArtBitmap = rememberAudioAlbumArt(mediaPath)
+  val currentAudioPresentation = rememberAudioPresentationMetadata(mediaPath)
+  val albumArtBitmap = currentAudioPresentation?.artwork
 
   fun cleanSongTitle(
     title: String,
@@ -315,29 +444,7 @@ fun AudioPlayerControls(
   val rawArtistAlt by PlaybackSession.propString["metadata/artist"].collectAsState()
   val rawAlbumArtist by PlaybackSession.propString["metadata/by-key/album_artist"].collectAsState()
   val rawPerformer by PlaybackSession.propString["metadata/by-key/PERFORMER"].collectAsState()
-
-  var retrievedArtist by remember(mediaPath) { mutableStateOf<String?>(null) }
-  LaunchedEffect(mediaPath) {
-    if (!mediaPath.isNullOrBlank()) {
-      withContext(Dispatchers.IO) {
-        runCatching {
-          val retriever = MediaMetadataRetriever()
-          if (mediaPath.startsWith("content://")) {
-            retriever.setDataSource(context, Uri.parse(mediaPath))
-          } else {
-            retriever.setDataSource(mediaPath.removePrefix("file://"))
-          }
-          val art =
-            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
-              ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
-              ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_AUTHOR)
-              ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COMPOSER)
-          retriever.release()
-          art
-        }.getOrNull()?.let { retrievedArtist = it }
-      }
-    }
-  }
+  val retrievedArtist = currentAudioPresentation?.artist
 
   val displayArtist =
     remember(rawArtist, rawArtistAlt, rawAlbumArtist, rawPerformer, retrievedArtist) {
@@ -374,6 +481,15 @@ fun AudioPlayerControls(
   val showVisualizer by viewModel.showVisualizerInAudioPlayer.collectAsState()
   val sheetShown by viewModel.sheetShown.collectAsState()
   val isSheetOpen = sheetShown != Sheets.None
+
+  CuboidSpectrumCaptureEffect(
+    enabled =
+      showVisualizer &&
+        !showInPlaceLyrics &&
+        !isSheetOpen &&
+        audioVisualizerStyle == AudioVisualizerStyle.Cuboid,
+    features = visualizerFeatures,
+  )
 
   val abLoop by viewModel.abLoopState.collectAsState()
   val abLoopA = abLoop.a
@@ -673,14 +789,16 @@ fun AudioPlayerControls(
                      modifier = Modifier.fillMaxSize(),
                    )
                  AudioVisualizerStyle.Cuboid ->
-                   CuboidOverlay(
-                     isPlaying = isPlaying,
-                     palette = palette,
-                     isSheetOpen = isSheetOpen,
-                     volumeScale = volumeScale,
-                     features = visualizerFeatures,
-                     modifier = Modifier.fillMaxSize(),
-                   )
+                   if (!isSheetOpen) {
+                     CuboidOverlay(
+                       isPlaying = isPlaying,
+                       palette = palette,
+                       isSheetOpen = false,
+                       volumeScale = volumeScale,
+                       features = visualizerFeatures,
+                       modifier = Modifier.fillMaxSize(),
+                     )
+                   }
                  AudioVisualizerStyle.Particle ->
                    ParticleOverlay(
                      palette = palette,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobComposable.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobComposable.kt
@@ -95,8 +95,47 @@ private fun <T> VisualizerOverlay(
   features: AudioFeatures,
   factory: (android.content.Context, AudioFeatures, VisualizerPalette) -> T,
 ) where T : GLSurfaceView, T : PaletteConsumer {
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
+  val realAnalyzerActive = remember(features) { AtomicBoolean(false) }
+  var hasRecordPermission by remember {
+    mutableStateOf(
+      ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+        PackageManager.PERMISSION_GRANTED,
+    )
+  }
+  val recordPermissionLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+      hasRecordPermission = granted
+    }
+
   LaunchedEffect(volumeScale) {
     features.volumeScale = volumeScale
+  }
+  LaunchedEffect(hasRecordPermission) {
+    if (!hasRecordPermission) recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+  }
+
+  // The overlay itself is only composed while a visualizer is visible. Keep Android's audio
+  // capture pipeline scoped to this lifecycle so album-art-only playback does not hold a Visualizer
+  // effect, poll capture freshness, or repeatedly retry the audio session in the background.
+  DisposableEffect(hasRecordPermission, features) {
+    val analyzer = if (hasRecordPermission) AudioSpectrumAnalyzer(features) else null
+    val job =
+      scope.launch(Dispatchers.Default) {
+        while (isActive && analyzer != null) {
+          val captureFresh = features.active && features.hasRecentCapture(1_500_000_000L)
+          if (!realAnalyzerActive.get() || !captureFresh) {
+            realAnalyzerActive.set(analyzer.start(0).isSuccess)
+          }
+          delay(if (realAnalyzerActive.get()) 1_500L else 400L)
+        }
+      }
+    onDispose {
+      job.cancel()
+      realAnalyzerActive.set(false)
+      analyzer?.stop(resetFeatures = false)
+    }
   }
 
   AndroidView(
@@ -124,58 +163,24 @@ private fun <T> VisualizerOverlay(
   )
 }
 
-/** One capture pipeline shared by every renderer and the audio-reactive seekbar. */
+/** Lightweight feature state shared by every renderer and the audio-reactive seekbar. */
 @Composable
 internal fun rememberAudioVisualizerFeatures(
   isPlaying: Boolean,
   volumeScale: Float,
 ): AudioFeatures {
-  val context = LocalContext.current
   val features = remember { AudioFeatures() }
   val scope = rememberCoroutineScope()
-  val realAnalyzerActive = remember { AtomicBoolean(false) }
-  var hasRecordPermission by remember {
-    mutableStateOf(
-      ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-        PackageManager.PERMISSION_GRANTED,
-    )
-  }
-  val recordPermissionLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-      hasRecordPermission = granted
-    }
 
   LaunchedEffect(volumeScale) {
     features.volumeScale = volumeScale.coerceIn(0f, 1f)
-  }
-  LaunchedEffect(hasRecordPermission) {
-    if (!hasRecordPermission) recordPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-  }
-
-  DisposableEffect(hasRecordPermission) {
-    val analyzer = if (hasRecordPermission) AudioSpectrumAnalyzer(features) else null
-    val job =
-      scope.launch(Dispatchers.Default) {
-        while (isActive && analyzer != null) {
-          val captureFresh = features.active && features.hasRecentCapture(1_500_000_000L)
-          if (!realAnalyzerActive.get() || !captureFresh) {
-            realAnalyzerActive.set(analyzer.start(0).isSuccess)
-          }
-          delay(if (realAnalyzerActive.get()) 1_500L else 400L)
-        }
-      }
-    onDispose {
-      job.cancel()
-      realAnalyzerActive.set(false)
-      analyzer?.stop(resetFeatures = false)
-    }
   }
 
   DisposableEffect(isPlaying) {
     val job =
       scope.launch(Dispatchers.Default) {
         while (isActive) {
-          val realCapture = realAnalyzerActive.get() && features.hasRecentCapture(1_500_000_000L)
+          val realCapture = features.active && features.hasRecentCapture(1_500_000_000L)
           if (!realCapture && isPlaying) {
             val time = System.nanoTime() / 1_000_000_000f
             features.energy = 0.025f + sin(time * 0.72f) * 0.006f

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobComposable.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/BlobComposable.kt
@@ -119,8 +119,10 @@ private fun <T> VisualizerOverlay(
   // The overlay itself is only composed while a visualizer is visible. Keep Android's audio
   // capture pipeline scoped to this lifecycle so album-art-only playback does not hold a Visualizer
   // effect, poll capture freshness, or repeatedly retry the audio session in the background.
-  DisposableEffect(hasRecordPermission, features) {
-    val analyzer = if (hasRecordPermission) AudioSpectrumAnalyzer(features) else null
+  // A modal sheet covers the renderer, so suspend capture there too and let the UI consume zero
+  // analyzer work until the visualizer is visible again.
+  DisposableEffect(hasRecordPermission, features, isSheetOpen) {
+    val analyzer = if (hasRecordPermission && !isSheetOpen) AudioSpectrumAnalyzer(features) else null
     val job =
       scope.launch(Dispatchers.Default) {
         while (isActive && analyzer != null) {
@@ -150,12 +152,16 @@ private fun <T> VisualizerOverlay(
     },
     modifier = modifier,
     update = { view ->
-      view.renderMode = GLSurfaceView.RENDERMODE_CONTINUOUSLY
       view.updatePalette(palette)
       if (isSheetOpen) {
+        // A sheet fully covers the expensive GLSurfaceView. Keep the last frame but stop the
+        // continuous render loop (particle/galaxy renderers otherwise burn GPU underneath it).
+        view.renderMode = GLSurfaceView.RENDERMODE_WHEN_DIRTY
+        view.requestRender()
         view.setZOrderOnTop(false)
         view.setZOrderMediaOverlay(true)
       } else {
+        view.renderMode = GLSurfaceView.RENDERMODE_CONTINUOUSLY
         view.setZOrderMediaOverlay(false)
         view.setZOrderOnTop(true)
       }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/ParticleFeedbackRenderer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/visualizer/ParticleFeedbackRenderer.kt
@@ -33,8 +33,13 @@ internal class ParticleFeedbackRenderer(
   @Volatile private var reducedMotionEnabled = reducedMotion
 
   private object Cfg {
-    const val SIM_SIZE = 512
+    // 384² still provides ~147k particles, but removes ~44% of the simulation/point work compared
+    // with 512². Trails carry most of the perceived density, so the visual difference is tiny on a
+    // phone while GPU bandwidth and the dummy vertex allocation fall substantially.
+    const val SIM_SIZE = 384
     const val NUM_PARTICLES = SIM_SIZE * SIM_SIZE
+    const val TRAIL_SCALE = 0.65f
+    const val MIPMAP_INTERVAL_FRAMES = 2L
     const val DECAY = 0.880f
     const val DIFFUSE = 0.004f
     const val BRIGHT = 0.008f
@@ -81,6 +86,8 @@ internal class ParticleFeedbackRenderer(
 
   private var viewportWidth = 1
   private var viewportHeight = 1
+  private var trailWidth = 1
+  private var trailHeight = 1
 
   // Uniform locations
   private var uSimState = -1
@@ -194,6 +201,8 @@ internal class ParticleFeedbackRenderer(
   override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int) {
     viewportWidth = max(2, width)
     viewportHeight = max(2, height)
+    trailWidth = max(2, (viewportWidth * Cfg.TRAIL_SCALE).toInt())
+    trailHeight = max(2, (viewportHeight * Cfg.TRAIL_SCALE).toInt())
     allocTrailBuffers()
   }
 
@@ -235,12 +244,12 @@ internal class ParticleFeedbackRenderer(
     /* 2. Decay + Diffuse Previous Trail */
     val nextTrail = 1 - trailSrc
     GLES30.glBindFramebuffer(GLES30.GL_FRAMEBUFFER, trailFbo[nextTrail])
-    GLES30.glViewport(0, 0, viewportWidth, viewportHeight)
+    GLES30.glViewport(0, 0, trailWidth, trailHeight)
     GLES30.glUseProgram(pDecay)
     GLES30.glActiveTexture(GLES30.GL_TEXTURE0)
     GLES30.glBindTexture(GLES30.GL_TEXTURE_2D, trailTex[trailSrc])
     GLES30.glUniform1i(uDecayTrail, 0)
-    GLES30.glUniform2f(uDecayTexel, 1f / viewportWidth, 1f / viewportHeight)
+    GLES30.glUniform2f(uDecayTexel, 1f / trailWidth, 1f / trailHeight)
     GLES30.glUniform1f(uDecayFactor, Cfg.DECAY)
     GLES30.glUniform1f(uDecayDiff, Cfg.DIFFUSE)
     GLES30.glDrawArrays(GLES30.GL_TRIANGLES, 0, 3)
@@ -254,7 +263,7 @@ internal class ParticleFeedbackRenderer(
     GLES30.glUniform1i(uPtsState, 0)
     GLES30.glUniform1i(uPtsSimSize, Cfg.SIM_SIZE)
     GLES30.glUniform1f(uPtsAspect, aspect)
-    GLES30.glUniform1f(uPtsViewportHeight, viewportHeight.toFloat())
+    GLES30.glUniform1f(uPtsViewportHeight, trailHeight.toFloat())
     GLES30.glUniform1f(uPtsHue, hueCurrent)
     GLES30.glUniform1f(uPtsEnergy, energySmoothed)
     GLES30.glUniform1f(uPtsBeat, beatSmoothed)
@@ -268,11 +277,13 @@ internal class ParticleFeedbackRenderer(
     GLES30.glDisable(GLES30.GL_BLEND)
     trailSrc = nextTrail
 
-    /* 4. Generate Mipmaps for Bloom */
+    /* 4. Generate bloom mip levels every other frame. The base trail is still updated every frame. */
     GLES30.glBindFramebuffer(GLES30.GL_FRAMEBUFFER, 0)
     GLES30.glActiveTexture(GLES30.GL_TEXTURE0)
     GLES30.glBindTexture(GLES30.GL_TEXTURE_2D, trailTex[trailSrc])
-    GLES30.glGenerateMipmap(GLES30.GL_TEXTURE_2D)
+    if (frameCounter % Cfg.MIPMAP_INTERVAL_FRAMES == 0L) {
+      GLES30.glGenerateMipmap(GLES30.GL_TEXTURE_2D)
+    }
 
     /* 5. Composite Pass to Screen with Dynamic Colors & Theme Adaptation */
     val primaryRgb = requestedPalette.primaryRgb()
@@ -385,7 +396,8 @@ internal class ParticleFeedbackRenderer(
 
     GLES30.glBindVertexArray(dummyVao)
     GLES30.glBindBuffer(GLES30.GL_ARRAY_BUFFER, dummyVbo)
-    val dummyData = FloatArray(Cfg.NUM_PARTICLES * 4)
+    // Attribute 0 consumes one float per point. The previous 4-float allocation was never read.
+    val dummyData = FloatArray(Cfg.NUM_PARTICLES)
     GLES30.glBufferData(GLES30.GL_ARRAY_BUFFER, dummyData.size * Float.SIZE_BYTES, GlUtils.floatBuffer(dummyData), GLES30.GL_STATIC_DRAW)
     GLES30.glEnableVertexAttribArray(0)
     GLES30.glVertexAttribPointer(0, 1, GLES30.GL_FLOAT, false, 0, 0)
@@ -419,10 +431,12 @@ internal class ParticleFeedbackRenderer(
     }
     GLES30.glGenTextures(2, trailTex, 0)
     GLES30.glGenFramebuffers(2, trailFbo, 0)
-    val levels = max(1, log2(max(viewportWidth, viewportHeight).toDouble()).toInt() + 1)
+    // Bloom/feedback is intentionally rendered below display resolution and upscaled in the final
+    // composite. At 0.65x this cuts trail FBO pixels by ~58% while the soft feedback hides scaling.
+    val levels = max(1, log2(max(trailWidth, trailHeight).toDouble()).toInt() + 1)
     for (i in 0 until 2) {
       GLES30.glBindTexture(GLES30.GL_TEXTURE_2D, trailTex[i])
-      GLES30.glTexStorage2D(GLES30.GL_TEXTURE_2D, levels, GLES30.GL_RGBA16F, viewportWidth, viewportHeight)
+      GLES30.glTexStorage2D(GLES30.GL_TEXTURE_2D, levels, GLES30.GL_RGBA16F, trailWidth, trailHeight)
       GLES30.glTexParameteri(GLES30.GL_TEXTURE_2D, GLES30.GL_TEXTURE_MIN_FILTER, GLES30.GL_LINEAR_MIPMAP_LINEAR)
       GLES30.glTexParameteri(GLES30.GL_TEXTURE_2D, GLES30.GL_TEXTURE_MAG_FILTER, GLES30.GL_LINEAR)
       GLES30.glTexParameteri(GLES30.GL_TEXTURE_2D, GLES30.GL_TEXTURE_WRAP_S, GLES30.GL_CLAMP_TO_EDGE)

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaInfoOps.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaInfoOps.kt
@@ -12,11 +12,34 @@ package app.gyrolet.mpvrx.utils.media
 import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.util.LruCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.mediaarea.mediainfo.lib.MediaInfo
+import java.io.File
 
 object MediaInfoOps {
+  // Basic metadata is requested from several entry points (filesystem browser, playlists, recents,
+  // thumbnail fallback and the persistent Room metadata repository). Keep the expensive native
+  // MediaInfo extraction behind one process-wide bounded cache so those paths do not repeatedly
+  // parse the same container during a session. The persistent repository can still provide the
+  // cross-process cache; this layer catches direct callers that previously bypassed it.
+  private const val BASIC_METADATA_CACHE_ENTRIES = 512
+  private val basicMetadataCache = LruCache<String, VideoMetadata>(BASIC_METADATA_CACHE_ENTRIES)
+
+  private fun basicMetadataCacheKey(
+    uri: Uri,
+    fileName: String,
+  ): String {
+    if (uri.scheme.equals("file", ignoreCase = true)) {
+      val file = uri.path?.let(::File)
+      if (file != null) {
+        return "${file.absolutePath}|${file.length()}|${file.lastModified()}"
+      }
+    }
+    return "${uri}|$fileName"
+  }
+
   /**
    * Extract detailed media information from a video file
    */
@@ -315,99 +338,119 @@ object MediaInfoOps {
     fileName: String,
   ): Result<VideoMetadata> =
     withContext(Dispatchers.IO) {
-      runCatching {
-        val contentResolver = context.contentResolver
-        val pfd =
-          contentResolver.openFileDescriptor(uri, "r")
-            ?: return@runCatching VideoMetadata(0L, 0L, 0, 0, 0f, false)
+      val cacheKey = basicMetadataCacheKey(uri, fileName)
+      synchronized(basicMetadataCache) {
+        basicMetadataCache.get(cacheKey)
+      }?.let { cached -> return@withContext Result.success(cached) }
 
-        val fd = pfd.detachFd()
-        val mi = MediaInfo()
+      val result =
+        runCatching {
+          val contentResolver = context.contentResolver
+          val pfd =
+            contentResolver.openFileDescriptor(uri, "r")
+              ?: return@runCatching VideoMetadata(0L, 0L, 0, 0, 0f, false)
 
-        try {
-          mi.Open(fd, fileName)
+          val fd = pfd.detachFd()
+          val mi = MediaInfo()
 
-          // Extract file size in bytes
-          val fileSizeStr = mi.getInfo(MediaInfo.Stream.General, 0, "FileSize")
-          val fileSize = fileSizeStr.toLongOrNull() ?: 0L
+          try {
+            mi.Open(fd, fileName)
 
-          // Extract duration in milliseconds - handle both integer and decimal formats
-          val durationStr = mi.getInfo(MediaInfo.Stream.General, 0, "Duration")
-          val duration = durationStr.toDoubleOrNull()?.toLong() ?: 0L
+            // Extract file size in bytes
+            val fileSizeStr = mi.getInfo(MediaInfo.Stream.General, 0, "FileSize")
+            val fileSize = fileSizeStr.toLongOrNull() ?: 0L
 
-          // Extract video resolution (width and height)
-          val widthStr = mi.getInfo(MediaInfo.Stream.Video, 0, "Width")
-          val width = widthStr.toIntOrNull() ?: 0
+            // Extract duration in milliseconds - handle both integer and decimal formats
+            val durationStr = mi.getInfo(MediaInfo.Stream.General, 0, "Duration")
+            val duration = durationStr.toDoubleOrNull()?.toLong() ?: 0L
 
-          val heightStr = mi.getInfo(MediaInfo.Stream.Video, 0, "Height")
-          val height = heightStr.toIntOrNull() ?: 0
+            // Extract video resolution (width and height)
+            val widthStr = mi.getInfo(MediaInfo.Stream.Video, 0, "Width")
+            val width = widthStr.toIntOrNull() ?: 0
 
-          // Extract framerate (fps)
-          val fpsStr = mi.getInfo(MediaInfo.Stream.Video, 0, "FrameRate")
-          val fps = fpsStr.toFloatOrNull() ?: 0f
+            val heightStr = mi.getInfo(MediaInfo.Stream.Video, 0, "Height")
+            val height = heightStr.toIntOrNull() ?: 0
 
-          val textCount = mi.Count_Get(MediaInfo.Stream.Text)
-          val hasEmbeddedSubtitles = textCount > 0
+            // Extract framerate (fps)
+            val fpsStr = mi.getInfo(MediaInfo.Stream.Video, 0, "FrameRate")
+            val fps = fpsStr.toFloatOrNull() ?: 0f
 
-          val subtitleCodec =
-            if (hasEmbeddedSubtitles) {
-              val codecs = mutableSetOf<String>()
-              for (i in 0 until textCount) {
-                val codecId = mi.getInfo(MediaInfo.Stream.Text, i, "CodecID")
+            val textCount = mi.Count_Get(MediaInfo.Stream.Text)
+            val hasEmbeddedSubtitles = textCount > 0
 
-                val normalizedCodec =
-                  when {
-                    codecId.contains("PGS", ignoreCase = true) -> "PGS"
-                    codecId.contains("ASS", ignoreCase = true) -> "ASS"
-                    codecId.contains("SSA", ignoreCase = true) -> "SSA"
-                    codecId.contains("SRT", ignoreCase = true) -> "SRT"
-                    codecId.contains("SUBRIP", ignoreCase = true) -> "SRT"
-                    codecId.contains("VOBSUB", ignoreCase = true) -> "DVD"
-                    codecId.contains("WEBVTT", ignoreCase = true) -> "VTT"
-                    codecId.contains("UTF8", ignoreCase = true) -> "SRT"
-                    codecId.contains("HDMV", ignoreCase = true) -> "PGS"
-                    codecId.contains("DVB", ignoreCase = true) -> "DVB"
-                    codecId.contains("MOV_TEXT", ignoreCase = true) -> "TX3G"
-                    codecId.isNotEmpty() -> {
-                      codecId.substringAfterLast("/").substringAfterLast("_").uppercase()
+            val subtitleCodec =
+              if (hasEmbeddedSubtitles) {
+                val codecs = mutableSetOf<String>()
+                for (i in 0 until textCount) {
+                  val codecId = mi.getInfo(MediaInfo.Stream.Text, i, "CodecID")
+
+                  val normalizedCodec =
+                    when {
+                      codecId.contains("PGS", ignoreCase = true) -> "PGS"
+                      codecId.contains("ASS", ignoreCase = true) -> "ASS"
+                      codecId.contains("SSA", ignoreCase = true) -> "SSA"
+                      codecId.contains("SRT", ignoreCase = true) -> "SRT"
+                      codecId.contains("SUBRIP", ignoreCase = true) -> "SRT"
+                      codecId.contains("VOBSUB", ignoreCase = true) -> "DVD"
+                      codecId.contains("WEBVTT", ignoreCase = true) -> "VTT"
+                      codecId.contains("UTF8", ignoreCase = true) -> "SRT"
+                      codecId.contains("HDMV", ignoreCase = true) -> "PGS"
+                      codecId.contains("DVB", ignoreCase = true) -> "DVB"
+                      codecId.contains("MOV_TEXT", ignoreCase = true) -> "TX3G"
+                      codecId.isNotEmpty() -> {
+                        codecId.substringAfterLast("/").substringAfterLast("_").uppercase()
+                      }
+                      else -> ""
                     }
-                    else -> ""
+
+                  if (normalizedCodec.isNotEmpty()) {
+                    codecs.add(normalizedCodec)
                   }
-
-                if (normalizedCodec.isNotEmpty()) {
-                  codecs.add(normalizedCodec)
                 }
+                codecs.joinToString(" ")
+              } else {
+                ""
               }
-              codecs.joinToString(" ")
-            } else {
-              ""
-            }
 
-          val retrieverFallback =
-            if (duration <= 0L || width <= 0 || height <= 0 || fps <= 0f) {
-              extractRetrieverMetadata(context, uri)
-            } else {
-              null
-            }
+            val retrieverFallback =
+              if (duration <= 0L || width <= 0 || height <= 0 || fps <= 0f) {
+                extractRetrieverMetadata(context, uri)
+              } else {
+                null
+              }
 
-          VideoMetadata(
-            sizeBytes =
-              fileSize.takeIf { it > 0L }
-                ?: retrieverFallback?.sizeBytes
-                ?: pfd.statSize.takeIf { it > 0L }
-                ?: 0L,
-            durationMs = duration.takeIf { it > 0L } ?: retrieverFallback?.durationMs ?: 0L,
-            width = width.takeIf { it > 0 } ?: retrieverFallback?.width ?: 0,
-            height = height.takeIf { it > 0 } ?: retrieverFallback?.height ?: 0,
-            fps = fps.takeIf { it > 0f } ?: retrieverFallback?.fps ?: 0f,
-            hasEmbeddedSubtitles = hasEmbeddedSubtitles,
-            subtitleCodec = subtitleCodec,
-          )
-        } finally {
-          mi.Close()
-          pfd.close()
+            VideoMetadata(
+              sizeBytes =
+                fileSize.takeIf { it > 0L }
+                  ?: retrieverFallback?.sizeBytes
+                  ?: pfd.statSize.takeIf { it > 0L }
+                  ?: 0L,
+              durationMs = duration.takeIf { it > 0L } ?: retrieverFallback?.durationMs ?: 0L,
+              width = width.takeIf { it > 0 } ?: retrieverFallback?.width ?: 0,
+              height = height.takeIf { it > 0 } ?: retrieverFallback?.height ?: 0,
+              fps = fps.takeIf { it > 0f } ?: retrieverFallback?.fps ?: 0f,
+              hasEmbeddedSubtitles = hasEmbeddedSubtitles,
+              subtitleCodec = subtitleCodec,
+            )
+          } finally {
+            mi.Close()
+            pfd.close()
+          }
+        }
+
+      result.getOrNull()?.let { metadata ->
+        // Do not make a transient open/parse failure sticky. Successful metadata with at least one
+        // useful field is safe to reuse for the remainder of this process.
+        if (
+          metadata.sizeBytes > 0L || metadata.durationMs > 0L || metadata.width > 0 ||
+          metadata.height > 0 || metadata.fps > 0f || metadata.hasEmbeddedSubtitles
+        ) {
+          synchronized(basicMetadataCache) {
+            basicMetadataCache.put(cacheKey, metadata)
+          }
         }
       }
+      result
     }
 
   private fun extractRetrieverMetadata(

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/storage/FolderViewScanner.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/storage/FolderViewScanner.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.ArrayDeque
 import java.util.Locale
 
 /**
@@ -73,6 +74,25 @@ object FolderViewScanner {
     var path: String,
     val videos: MutableList<VideoInfo> = mutableListOf(),
   )
+
+  private class NoMediaScanBudget(
+    private var remaining: Int,
+  ) {
+    private val visited = HashSet<String>()
+    var exhausted: Boolean = false
+      private set
+
+    fun tryEnter(path: String): Boolean {
+      val key = storagePathKey(path) ?: path.lowercase(Locale.ROOT)
+      if (!visited.add(key)) return false
+      if (remaining <= 0) {
+        exhausted = true
+        return false
+      }
+      remaining--
+      return true
+    }
+  }
 
   /**
    * Get all video folders for folder list view
@@ -172,6 +192,7 @@ object FolderViewScanner {
         val rootPath = normalizeStoragePath(root.absolutePath) ?: continue
         val entries = mutableListOf<DirectoryScanEntity>()
         val pending = mutableListOf<VideoFolder>()
+        val scanBudget = NoMediaScanBudget(MAX_INDEXED_DIRECTORIES_PER_ROOT)
         scanIndexedDirectory(
           directory = root,
           rootPath = rootPath,
@@ -180,6 +201,7 @@ object FolderViewScanner {
           cached = cached,
           isNoMediaRoot = true,
           entries = entries,
+          budget = scanBudget,
         ) { folder ->
           pending += folder
           if (pending.size >= EMIT_BATCH_SIZE) {
@@ -188,8 +210,15 @@ object FolderViewScanner {
           }
         }
         if (pending.isNotEmpty()) emit(pending.toList())
-        val changedEntries = entries.filter { entry -> cached[storagePathKey(entry.path)] != entry }
-        dao.reconcileRoot(scanKey, rootPath, entries.map { it.path }, changedEntries)
+
+        if (!scanBudget.exhausted) {
+          val changedEntries = entries.filter { entry -> cached[storagePathKey(entry.path)] != entry }
+          dao.reconcileRoot(scanKey, rootPath, entries.map { it.path }, changedEntries)
+        } else {
+          // Never reconcile a partial traversal: doing so would interpret folders beyond the budget
+          // as deleted and throw away otherwise valid cached entries.
+          Log.w(TAG, "Paused .nomedia indexing after $MAX_INDEXED_DIRECTORIES_PER_ROOT directories: $rootPath")
+        }
       }
     }
 
@@ -201,10 +230,12 @@ object FolderViewScanner {
     cached: Map<String?, DirectoryScanEntity>,
     isNoMediaRoot: Boolean,
     entries: MutableList<DirectoryScanEntity>,
+    budget: NoMediaScanBudget,
     onFolder: suspend (VideoFolder) -> Unit,
   ) {
-    val files = runCatching { directory.listFiles()?.toList().orEmpty() }.getOrElse { return }
     val path = normalizeStoragePath(directory.absolutePath) ?: return
+    if (!budget.tryEnter(path)) return
+    val files = runCatching { directory.listFiles()?.toList().orEmpty() }.getOrElse { return }
     val fingerprint = directoryFingerprint(directory, files)
     val previous = cached[storagePathKey(path)]
     val subdirectories = files.filter { it.isDirectory && shouldVisitDuringNoMediaScan(it) }
@@ -257,8 +288,10 @@ object FolderViewScanner {
         cached,
         isNoMediaRoot = false,
         entries = entries,
+        budget = budget,
         onFolder = onFolder,
       )
+      if (budget.exhausted) break
     }
   }
 
@@ -269,26 +302,37 @@ object FolderViewScanner {
     StorageVolumeUtils.getExternalStorageVolumes(context).mapNotNullTo(searchRoots) { volume ->
       StorageVolumeUtils.getVolumePath(volume)?.let(::File)
     }
-    val found = mutableListOf<File>()
-    searchRoots.forEach { discoverNoMediaRoots(it, found, 0) }
-    return found.distinctBy { storagePathKey(it.absolutePath) }
-  }
 
-  private fun discoverNoMediaRoots(
-    directory: File,
-    found: MutableList<File>,
-    depth: Int,
-  ) {
-    if (depth >= MAX_DISCOVERY_DEPTH || !directory.isDirectory || !directory.canRead()) return
-    if (File(directory, ".nomedia").isFile) {
-      found += directory
-      return
+    val found = mutableListOf<File>()
+    val pending = ArrayDeque<Pair<File, Int>>()
+    val visited = HashSet<String>()
+    searchRoots.forEach { root -> pending.addLast(root to 0) }
+    var remaining = MAX_DISCOVERY_DIRECTORIES
+
+    while (pending.isNotEmpty() && remaining > 0) {
+      val (directory, depth) = pending.removeFirst()
+      if (depth >= MAX_DISCOVERY_DEPTH || !directory.isDirectory || !directory.canRead()) continue
+      val pathKey = storagePathKey(directory.absolutePath) ?: directory.absolutePath.lowercase(Locale.ROOT)
+      if (!visited.add(pathKey)) continue
+      remaining--
+
+      if (File(directory, ".nomedia").isFile) {
+        found += directory
+        continue
+      }
+
+      runCatching { directory.listFiles() }
+        .getOrNull()
+        .orEmpty()
+        .asSequence()
+        .filter { it.isDirectory && shouldVisitDuringNoMediaScan(it) }
+        .forEach { child -> pending.addLast(child to (depth + 1)) }
     }
-    runCatching { directory.listFiles() }
-      .getOrNull()
-      .orEmpty()
-      .filter { it.isDirectory && shouldVisitDuringNoMediaScan(it) }
-      .forEach { discoverNoMediaRoots(it, found, depth + 1) }
+
+    if (pending.isNotEmpty()) {
+      Log.w(TAG, "Stopped .nomedia discovery after $MAX_DISCOVERY_DIRECTORIES directories")
+    }
+    return found.distinctBy { storagePathKey(it.absolutePath) }
   }
 
   private fun shouldVisitDuringNoMediaScan(directory: File): Boolean {
@@ -325,7 +369,9 @@ object FolderViewScanner {
   }
 
   private const val EMIT_BATCH_SIZE = 8
-  private const val MAX_DISCOVERY_DEPTH = 20
+  private const val MAX_DISCOVERY_DEPTH = 16
+  private const val MAX_DISCOVERY_DIRECTORIES = 6_000
+  private const val MAX_INDEXED_DIRECTORIES_PER_ROOT = 8_000
   private val NO_MEDIA_SCAN_SKIP_FOLDERS =
     setOf(
       ".thumbnails",


### PR DESCRIPTION
## Summary

Implements the resource/performance audit as 16 isolated fixes, with one commit per fix. The thumbnail RAM/disk cache sizing item was intentionally excluded as requested.

## Changes

1. Reduce particle visualizer simulation size, trail render resolution, mipmap frequency, and dummy VBO allocation.
2. Scope Android audio-spectrum capture to the visible visualizer lifecycle.
3. Stop continuous GLSurfaceView rendering and analyzer work while modal sheets cover the visualizer.
4. Remove automatic full external-storage MediaScanner scans from process startup.
5. Centralize audio artwork + fallback artist extraction behind one bounded, serialized metadata cache.
6. Route repeated basic media metadata extraction through one bounded process cache.
7. Bound and deduplicate `.nomedia` discovery/index traversal and avoid reconciling partial scans.
8. Remove `runBlocking` bridges from the network proxy, dispatch upstream work to its IO scope, add timeouts, and cache sibling resource sizes.
9. Reduce SMB transport/stream buffers and remove per-byte `ByteArray(1)` allocation.
10. Use the existing INTEGER PRIMARY KEY ordering for hot Recently Played queries to avoid repeated timestamp sorts without adding a Room migration.
11. Cache playback-state table snapshots in the repository and maintain them incrementally on writes.
12. Defer metadata maintenance until after foreground startup settles.
13. Defer FastThumbnails native initialization until after first foreground rather than Application cold start.
14. Release an idle libmpv core after a 3-minute grace period, automatically cancelling the timer on any playback/surface state change.
15. Make x86/x86_64 native artifacts opt-in (`-PenableX86=true`) while keeping ARM as the production default.
16. Remember updater fallback StateFlows so Navigator recompositions do not allocate/resubscribe to fresh flows.

## Commit structure

This branch is exactly 16 commits ahead of its original base (`90ae06e`), matching one commit per implemented audit item. No thumbnail RAM/disk cache-limit changes are included.

## Notes / validation

- Existing playback/background behavior is preserved by only reaping libmpv when the session is fully IDLE, has no current item, and has no attached surface.
- `.nomedia` scans never reconcile the database after a budget-limited partial traversal.
- Network proxy serving remains synchronous at the NanoHTTPD boundary, but nested `runBlocking` coroutine event loops were removed and upstream suspend work is bounded on the proxy IO scope.
- The branch was created before the latest notification-handoff change on `master`; that newer master change touches a separate playback-service path. GitHub should merge the histories normally if no conflict is reported.

CI should validate Android/Kotlin compilation and packaging for the final head.