### PR TITLE
fix(player): keep playback notification owner persistent

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MediaPlaybackService.kt
@@ -104,7 +104,16 @@ class MediaPlaybackService :
     @Volatile
     private var activeInstance: MediaPlaybackService? = null
 
-    fun isRunning(): Boolean = isServiceRunning
+    /**
+     * True only while playback is detached from the foreground Activity.
+     *
+     * PlayerActivity historically used this query in onStart() as a signal to destroy the
+     * playback service. Keeping the physical service alive while the Activity owns the surface
+     * avoids tearing down and recreating the MediaSession/foreground notification on every
+     * notification tap. This mirrors the single long-lived notification-owner model used by
+     * MediaSessionService-style players.
+     */
+    fun isRunning(): Boolean = isServiceRunning && !activityForeground
 
     fun isForegroundActive(): Boolean = activeInstance?.foregroundReady == true
 
@@ -113,16 +122,21 @@ class MediaPlaybackService :
      * (e.g. the full player is visible and playing, including audio-only media that has no
      * attached video surface). The service must not steal audio focus from it.
      *
-     * Clearing this flag is also the boundary between a completed foreground handoff and a new
-     * detached playback cycle. A service instance can survive briefly because of Binder timing;
-     * never let a stale handoff marker poison the next notification/background start.
+     * Entering the foreground is an ownership handoff, not a service teardown: the service keeps
+     * the MediaSession/notification alive but releases audio focus to PlayerActivity. Leaving the
+     * foreground clears the handoff marker so detached playback can take ownership again.
      */
     @Volatile
     var activityForeground = false
       set(value) {
         field = value
-        if (!value) {
-          activeInstance?.handingBackToActivity = false
+        activeInstance?.let { service ->
+          if (value) {
+            service.handingBackToActivity = true
+            service.abandonAudioOwnership()
+          } else {
+            service.handingBackToActivity = false
+          }
         }
       }
 


### PR DESCRIPTION
## Problem

The playback notification still disappears after notification re-entry/background cycles. The previous fix hardened audio-focus handoff, but `PlayerActivity.onStart()` still tears down `MediaPlaybackService` whenever the Activity returns to the foreground. That means every notification tap can destroy the foreground-service notification and force a later recreate.

## Reference architecture

I compared this lifecycle with ArchiveTune's current playback architecture and Android's MediaSessionService guidance. The robust pattern is one long-lived playback service/media session owning the system media notification for the active playback session; opening/closing the player UI is an ownership/surface handoff, not notification-service destruction/recreation.

This PR adapts that ownership principle to mpvRx's existing native mpv `PlaybackSession` without importing Media3/ExoPlayer or copying ArchiveTune source.

## Fix

- Keep the physical `MediaPlaybackService` alive while `PlayerActivity` is foreground.
- Treat `MediaPlaybackService.isRunning()` as detached/background ownership so the existing `PlayerActivity.onStart()` teardown branch no longer destroys the persistent notification owner.
- When `PlayerActivity` becomes foreground, immediately mark the service → Activity handoff and release service-owned audio focus without changing mpv pause state.
- Clear the handoff marker when the Activity backgrounds again.
- Preserve all existing explicit teardown paths: disabling background playback, notification Stop, playback shutdown, notification style None, etc.

## Scope

One commit, one file: `MediaPlaybackService.kt`.

## Regression verification

1. Enable background playback and start a video.
2. Background the app: playback notification remains visible and playback continues.
3. Tap the notification: player opens and playback does not pause; notification owner is not destroyed.
4. Background again: the same service/session continues owning the notification, with no recreate race.
5. Repeat notification → player → background at least 5–10 times.
6. Verify notification Play/Pause/Next/Previous/Stop still work.
7. Disable background playback: service/notification must stop normally.
8. Repeat with audio-only playback.

This specifically removes the service destroy/recreate lifecycle that caused the notification to vanish on later cycles.