### PR TITLE
fix: decoder sheet not reflecting user selection + button showing wro…

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -123,6 +123,25 @@ object PlaybackSession : MPVLib.EventObserver {
   val state: StateFlow<PlaybackSessionState> = _state.asStateFlow()
   val queue: StateFlow<PlaybackQueueState> = _queue.asStateFlow()
 
+  /**
+   * Tracks the decoder the user explicitly picked from the Decoders sheet.
+   *
+   * This is intentionally NOT derived from the mpv `hwdec` property: at
+   * playback start `hwdec` is set to a comma-delimited fallback list
+   * (e.g. "mediacodec,mediacodec-copy,no") rather than a single value, so
+   * reading it back would not match any Decoder enum entry. It's also not
+   * derived from `hwdec-current`, since that reflects whatever mpv actually
+   * ends up running (which can silently fall back), not what the user chose.
+   * Null means "no explicit user selection yet" (i.e. using the default
+   * fallback chain).
+   */
+  private val _userSelectedHwdec = MutableStateFlow<String?>(null)
+  val userSelectedHwdec: StateFlow<String?> = _userSelectedHwdec.asStateFlow()
+
+  fun setUserSelectedHwdec(value: String) {
+    _userSelectedHwdec.value = value
+  }
+
   @Volatile
   private var initialized = false
   private var applicationContext: Context? = null

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
@@ -67,7 +67,7 @@ enum class Decoder(
   ;
 
   companion object {
-    fun getDecoderFromValue(value: String): Decoder = Decoder.entries.first { it.value == value }
+    fun getDecoderFromValue(value: String): Decoder = Decoder.entries.firstOrNull { it.value == value } ?: AutoCopy
   }
 }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
@@ -252,8 +252,8 @@ fun PlayerControls(
   var resetControlsTimestamp by remember { mutableStateOf(0L) }
   val seekText = seekState.text
   val currentChapter by PlaybackSession.propInt["chapter"].collectAsState()
-  val mpvDecoder by PlaybackSession.propString["hwdec"].collectAsState()
-  val decoder = remember(mpvDecoder) { getDecoderFromValue(mpvDecoder ?: "auto-copy") }
+  val userSelectedHwdec by PlaybackSession.userSelectedHwdec.collectAsState()
+  val decoder = remember(userSelectedHwdec) { getDecoderFromValue(userSelectedHwdec ?: "auto-copy") }
   val isSpeedNonOne = remember(playbackSpeed) {
     abs((playbackSpeed ?: 1f) - 1f) > 0.001f
   }
@@ -346,7 +346,10 @@ fun PlayerControls(
           viewModel.unpause()
         },
         decoder = decoder,
-        onUpdateDecoder = { PlaybackSession.setPropertyString("hwdec", it.value) },
+        onUpdateDecoder = {
+          PlaybackSession.setPropertyString("hwdec", it.value)
+          PlaybackSession.setUserSelectedHwdec(it.value)
+        },
         speed = playbackSpeed ?: playerPreferences.defaultSpeed.get(),
         onSpeedChange = { PlaybackSession.setPropertyFloat("speed", it.toFixed(2)) },
         onMakeDefaultSpeed = { playerPreferences.defaultSpeed.set(it.toFixed(2)) },
@@ -1782,7 +1785,10 @@ fun PlayerControls(
         viewModel.unpause()
       },
       decoder = decoder,
-      onUpdateDecoder = { PlaybackSession.setPropertyString("hwdec", it.value) },
+      onUpdateDecoder = {
+        PlaybackSession.setPropertyString("hwdec", it.value)
+        PlaybackSession.setUserSelectedHwdec(it.value)
+      },
       speed = playbackSpeed ?: playerPreferences.defaultSpeed.get(),
       onSpeedChange = { PlaybackSession.setPropertyFloat("speed", it.toFixed(2)) },
       onMakeDefaultSpeed = { playerPreferences.defaultSpeed.set(it.toFixed(2)) },

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
@@ -252,8 +252,8 @@ fun PlayerControls(
   var resetControlsTimestamp by remember { mutableStateOf(0L) }
   val seekText = seekState.text
   val currentChapter by PlaybackSession.propInt["chapter"].collectAsState()
-  val mpvDecoder by PlaybackSession.propString["hwdec-current"].collectAsState()
-  val decoder = remember(mpvDecoder) { getDecoderFromValue(mpvDecoder ?: "auto") }
+  val mpvDecoder by PlaybackSession.propString["hwdec"].collectAsState()
+  val decoder = remember(mpvDecoder) { getDecoderFromValue(mpvDecoder ?: "auto-copy") }
   val isSpeedNonOne = remember(playbackSpeed) {
     abs((playbackSpeed ?: 1f) - 1f) > 0.001f
   }


### PR DESCRIPTION
fix: decoder selection UI decoupled from mpv's raw hwdec property

Problem (found via code review bot after previous fix):
- MPVView.kt sets `hwdec` at init to a fallback chain string
  ("mediacodec,mediacodec-copy,no"), not a single value.
- Reading that back in PlayerControls.kt didn't match any Decoder enum
  entry, so the UI fell back to displaying "Auto" as selected.
- Tapping that highlighted "Auto" row then overwrote `hwdec` with a single
  "auto-copy" value, silently destroying the intended HW+ -> HW -> SW
  fallback chain.

Fix:
- Added PlaybackSession.userSelectedHwdec: a dedicated StateFlow that only
  changes when the user explicitly picks a decoder from the sheet. It is
  never derived from mpv's `hwdec` or `hwdec-current` properties, so it's
  immune to mpv's internal fallback-list/runtime-choice representations.
- PlayerControls.kt now drives the top-right button label and the
  DecodersSheet selection from this flow instead.
- onUpdateDecoder now updates both: the real mpv `hwdec` property (so
  playback actually changes) and userSelectedHwdec (so the UI reflects
  it correctly).
- PlayerEnums.kt: getDecoderFromValue uses firstOrNull{} ?: AutoCopy so an
  unrecognized value can never crash.

Files changed:
- app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
- app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
- app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt