### PR TITLE
fix(player): make Stretch follow source video orientation

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerObserver.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerObserver.kt
@@ -9,17 +9,62 @@
 
 package app.gyrolet.mpvrx.ui.player
 
+import android.content.pm.ActivityInfo
+import app.gyrolet.mpvrx.preferences.PlayerPreferences
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.MPVNode
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 class PlayerObserver(
   private val activity: PlayerActivity,
-) : MPVLib.EventObserver {
-  private fun shouldBypassUiThread(property: String): Boolean =
+) : MPVLib.EventObserver,
+  KoinComponent {
+  private val playerPreferences: PlayerPreferences by inject()
+
+  private fun isVideoGeometryProperty(property: String): Boolean =
     property == "video-params/aspect" ||
       property == "video-params/w" ||
-      property == "video-params/h" ||
+      property == "video-params/h"
+
+  private fun shouldBypassUiThread(property: String): Boolean =
+    isVideoGeometryProperty(property) ||
       property == "container-fps"
+
+  /**
+   * Stretch deliberately keeps a positive video-aspect-override so the picture fills the current
+   * viewport. PlayerActivity's normal "Video" orientation refresh ignores positive overrides to
+   * avoid treating custom aspect ratios as source geometry, which unintentionally also excluded
+   * Stretch. Read the source video geometry from MPVView instead and only restore auto-orientation
+   * for the built-in Stretch mode; custom aspect ratios remain untouched.
+   */
+  private fun requestStretchVideoOrientationUpdate(property: String? = null) {
+    if (property != null && !isVideoGeometryProperty(property)) return
+
+    activity.runOnUiThread {
+      if (activity.player.isExiting || activity.isFinishing || activity.isDestroyed) return@runOnUiThread
+      if (playerPreferences.orientation.get() != PlayerOrientation.Video) return@runOnUiThread
+      if (playerPreferences.lastCustomAspectRatio.get() > 0f) return@runOnUiThread
+      if (playerPreferences.lastVideoAspect.get() != VideoAspect.Stretch) return@runOnUiThread
+
+      val sourceAspect =
+        runCatching { activity.player.getVideoOutAspect() }
+          .getOrNull()
+          ?.takeIf { it > 0.0 }
+          ?: return@runOnUiThread
+
+      val targetOrientation =
+        if (sourceAspect > 1.0) {
+          ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        } else {
+          ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+        }
+
+      if (activity.requestedOrientation != targetOrientation) {
+        activity.requestedOrientation = targetOrientation
+      }
+    }
+  }
 
   override fun eventProperty(property: String) {
     if (activity.player.isExiting) return
@@ -33,6 +78,7 @@ class PlayerObserver(
     if (activity.player.isExiting) return
     if (shouldBypassUiThread(property)) {
       activity.onObserverEvent(property, value)
+      requestStretchVideoOrientationUpdate(property)
     } else {
       activity.runOnUiThread { activity.onObserverEvent(property, value) }
     }
@@ -61,6 +107,7 @@ class PlayerObserver(
     if (activity.player.isExiting) return
     if (shouldBypassUiThread(property)) {
       activity.onObserverEvent(property, value)
+      requestStretchVideoOrientationUpdate(property)
     } else {
       activity.runOnUiThread { activity.onObserverEvent(property, value) }
     }
@@ -80,6 +127,11 @@ class PlayerObserver(
     data: MPVNode,
   ) {
     if (activity.player.isExiting) return
-    activity.runOnUiThread { activity.event(eventId) }
+    activity.runOnUiThread {
+      activity.event(eventId)
+      if (eventId == MPVLib.MpvEvent.MPV_EVENT_FILE_LOADED) {
+        requestStretchVideoOrientationUpdate()
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes the remaining Stretch-mode orientation bug reported by a user: when **Player orientation = Video** and **Aspect = Stretch**, the app could stay in the current screen orientation instead of following the source video's portrait/landscape orientation.

This builds on the Stretch viewport correction introduced in `17330aed2b55d9529af31f3ec7331a61230a41da`.

## Root cause

Stretch intentionally keeps a positive `video-aspect-override` so the picture fills the current viewport. The normal video-orientation refresh in `PlayerActivity` skips orientation updates whenever that override is positive, which is correct for user-defined custom aspect ratios but accidentally excludes the built-in Stretch mode too.

## Fix

- Detect source geometry updates (`video-params/aspect`, `video-params/w`, `video-params/h`) in `PlayerObserver`.
- When orientation preference is `Video`, the built-in aspect is `Stretch`, and no custom aspect ratio is active, derive orientation from `MPVView.getVideoOutAspect()`.
- Request sensor-landscape for landscape source video and sensor-portrait for portrait source video.
- Recheck once on `MPV_EVENT_FILE_LOADED` as a safety net for files whose geometry settles around load completion.
- Leave Fit, Crop, explicit orientation modes, and user-defined custom aspect ratios unchanged.

The existing `StretchAwarePlayerLayout` continues to reapply the Stretch viewport ratio after the Activity rotates, so the two behaviors now work together: **follow the video's orientation first, then stretch to the new viewport**.

## Commit structure

One bug fix, one commit:

`23cf9a49d2a7196f554966c435ab0d0595de2ab0` — `fix(player): follow video orientation in stretch mode`