### PR TITLE
Fix decoder selection state handling

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -123,25 +123,6 @@ object PlaybackSession : MPVLib.EventObserver {
   val state: StateFlow<PlaybackSessionState> = _state.asStateFlow()
   val queue: StateFlow<PlaybackQueueState> = _queue.asStateFlow()
 
-  /**
-   * Tracks the decoder the user explicitly picked from the Decoders sheet.
-   *
-   * This is intentionally NOT derived from the mpv `hwdec` property: at
-   * playback start `hwdec` is set to a comma-delimited fallback list
-   * (e.g. "mediacodec,mediacodec-copy,no") rather than a single value, so
-   * reading it back would not match any Decoder enum entry. It's also not
-   * derived from `hwdec-current`, since that reflects whatever mpv actually
-   * ends up running (which can silently fall back), not what the user chose.
-   * Null means "no explicit user selection yet" (i.e. using the default
-   * fallback chain).
-   */
-  private val _userSelectedHwdec = MutableStateFlow<String?>(null)
-  val userSelectedHwdec: StateFlow<String?> = _userSelectedHwdec.asStateFlow()
-
-  fun setUserSelectedHwdec(value: String) {
-    _userSelectedHwdec.value = value
-  }
-
   @Volatile
   private var initialized = false
   private var applicationContext: Context? = null

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerEnums.kt
@@ -67,7 +67,7 @@ enum class Decoder(
   ;
 
   companion object {
-    fun getDecoderFromValue(value: String): Decoder = Decoder.entries.firstOrNull { it.value == value } ?: AutoCopy
+    fun getDecoderFromValue(value: String): Decoder = Decoder.entries.firstOrNull { it.value == value } ?: Auto
   }
 }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
@@ -252,8 +252,8 @@ fun PlayerControls(
   var resetControlsTimestamp by remember { mutableStateOf(0L) }
   val seekText = seekState.text
   val currentChapter by PlaybackSession.propInt["chapter"].collectAsState()
-  val userSelectedHwdec by PlaybackSession.userSelectedHwdec.collectAsState()
-  val decoder = remember(userSelectedHwdec) { getDecoderFromValue(userSelectedHwdec ?: "auto-copy") }
+  val mpvDecoder by PlaybackSession.propString["hwdec-current"].collectAsState()
+  val decoder = remember(mpvDecoder) { getDecoderFromValue(mpvDecoder ?: "auto") }
   val isSpeedNonOne = remember(playbackSpeed) {
     abs((playbackSpeed ?: 1f) - 1f) > 0.001f
   }
@@ -346,10 +346,7 @@ fun PlayerControls(
           viewModel.unpause()
         },
         decoder = decoder,
-        onUpdateDecoder = {
-          PlaybackSession.setPropertyString("hwdec", it.value)
-          PlaybackSession.setUserSelectedHwdec(it.value)
-        },
+        onUpdateDecoder = { PlaybackSession.setPropertyString("hwdec", it.value) },
         speed = playbackSpeed ?: playerPreferences.defaultSpeed.get(),
         onSpeedChange = { PlaybackSession.setPropertyFloat("speed", it.toFixed(2)) },
         onMakeDefaultSpeed = { playerPreferences.defaultSpeed.set(it.toFixed(2)) },
@@ -1785,10 +1782,7 @@ fun PlayerControls(
         viewModel.unpause()
       },
       decoder = decoder,
-      onUpdateDecoder = {
-        PlaybackSession.setPropertyString("hwdec", it.value)
-        PlaybackSession.setUserSelectedHwdec(it.value)
-      },
+      onUpdateDecoder = { PlaybackSession.setPropertyString("hwdec", it.value) },
       speed = playbackSpeed ?: playerPreferences.defaultSpeed.get(),
       onSpeedChange = { PlaybackSession.setPropertyFloat("speed", it.toFixed(2)) },
       onMakeDefaultSpeed = { playerPreferences.defaultSpeed.set(it.toFixed(2)) },

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/DecodersSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/DecodersSheet.kt
@@ -9,13 +9,31 @@
 
 package app.gyrolet.mpvrx.ui.player.controls.components.sheets
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.presentation.components.PlayerSheet
 import app.gyrolet.mpvrx.ui.player.Decoder
+import app.gyrolet.mpvrx.ui.player.PlaybackSession
+import app.gyrolet.mpvrx.ui.theme.spacing
 
 @Composable
 fun DecodersSheet(
@@ -23,13 +41,62 @@ fun DecodersSheet(
   onSelect: (Decoder) -> Unit,
   onDismissRequest: () -> Unit,
 ) {
+  // mediacodec is a zero-copy Android hwdec path that requires mpv's Android/OpenGL
+  // interop. It cannot interop with a Vulkan renderer. mediacodec-copy remains valid
+  // because decoded frames are copied back to system memory before GPU upload.
+  val gpuApi by PlaybackSession.propString["gpu-api"].collectAsState()
+  val isVulkanActive = gpuApi == "vulkan"
+
   PlayerSheet(onDismissRequest) {
     LazyColumn {
       items(Decoder.entries.minusElement(Decoder.Auto), key = { it.name }) { decoder ->
-        AudioTrackRow(
+        val isSupported = !(isVulkanActive && decoder == Decoder.HWPlus)
+        DecoderRow(
           title = stringResource(R.string.player_sheets_decoder_formatted, decoder.title, decoder.value),
           isSelected = selectedDecoder == decoder,
+          enabled = isSupported,
+          unsupportedReason = if (isSupported) null else "Unavailable with Vulkan",
           onClick = { onSelect(decoder) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun DecoderRow(
+  title: String,
+  isSelected: Boolean,
+  enabled: Boolean,
+  unsupportedReason: String?,
+  onClick: () -> Unit,
+) {
+  Row(
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .alpha(if (enabled) 1f else 0.45f)
+        .clickable(enabled = enabled, onClick = onClick)
+        .padding(horizontal = MaterialTheme.spacing.medium, vertical = MaterialTheme.spacing.extraSmall),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.smaller),
+  ) {
+    RadioButton(
+      selected = isSelected,
+      onClick = if (enabled) onClick else null,
+      enabled = enabled,
+    )
+    Column {
+      Text(
+        text = title,
+        fontWeight = if (isSelected) FontWeight.ExtraBold else FontWeight.Normal,
+        fontStyle = if (isSelected) FontStyle.Italic else FontStyle.Normal,
+      )
+      if (unsupportedReason != null) {
+        Text(
+          text = unsupportedReason,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
       }
     }


### PR DESCRIPTION
## Summary
- drive the decoder sheet from mpv's active `hwdec-current` value
- apply decoder changes by writing the selected value directly to `hwdec`
- use `Auto` as the safe fallback when the active decoder value is unavailable or unknown
- remove the obsolete app-side decoder mirror and its setter entirely
- disable the zero-copy `mediacodec` / HW+ option while the active renderer uses Vulkan
- keep `mediacodec-copy` / HW available with Vulkan because it copies decoded frames back through system memory

## Why
The previous implementation maintained a second decoder-selection state that could disagree with the decoder mpv actually settled on after fallback. It also allowed selecting zero-copy MediaCodec while using a Vulkan renderer even though mpv's MediaCodec interop requires the Android/OpenGL GPU path.

This keeps the UI synchronized with the active decoder and prevents an unsupported renderer/decoder combination from being selected.

## Commit history
This PR contains a single squashed commit.