### PR TITLE
Fix torrent series picker and video mini player dependency

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerPreferences.kt
@@ -9,6 +9,7 @@
 
 package app.gyrolet.mpvrx.preferences
 
+import app.gyrolet.mpvrx.preferences.preference.DependentBooleanPreference
 import app.gyrolet.mpvrx.preferences.preference.PreferenceStore
 import app.gyrolet.mpvrx.preferences.preference.getEnum
 import app.gyrolet.mpvrx.ui.player.AmbientVisualMode
@@ -120,7 +121,9 @@ class PlayerPreferences(
   val autoplayNextVideo = preferenceStore.getBoolean("autoplay_next_video", true)
 
   val autoPiPOnNavigation = preferenceStore.getBoolean("auto_pip_on_navigation", false)
-  val enableVideoMiniPlayer = preferenceStore.getBoolean("enable_video_mini_player", false)
+  private val videoBackgroundPlayback = preferenceStore.getBoolean("automatic_background_playback", false)
+  private val storedEnableVideoMiniPlayer = preferenceStore.getBoolean("enable_video_mini_player", false)
+  val enableVideoMiniPlayer = DependentBooleanPreference(storedEnableVideoMiniPlayer, videoBackgroundPlayback)
 
   val keepScreenOnWhenPaused = preferenceStore.getBoolean("keep_screen_on_when_paused", false)
   val autoplayAfterScreenUnlock = preferenceStore.getBoolean("autoplay_after_screen_unlock", false)

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/preference/DependentBooleanPreference.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/preference/DependentBooleanPreference.kt
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.gyrolet.mpvrx.preferences.preference
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Boolean preference that can only be enabled while [required] is enabled.
+ *
+ * If an older app version left the stored value enabled while the dependency is disabled, the
+ * stale value is cleared as soon as it is observed. This keeps every consumer on the same rule
+ * instead of relying on individual screens or activities to remember the dependency.
+ */
+class DependentBooleanPreference(
+  private val delegate: Preference<Boolean>,
+  private val required: Preference<Boolean>,
+) : Preference<Boolean> {
+  override fun key(): String = delegate.key()
+
+  override fun get(): Boolean {
+    val allowed = required.get()
+    val enabled = delegate.get()
+    if (enabled && !allowed) delegate.set(false)
+    return enabled && allowed
+  }
+
+  override fun set(value: Boolean) {
+    delegate.set(value && required.get())
+  }
+
+  override fun isSet(): Boolean = delegate.isSet()
+
+  override fun delete() = delegate.delete()
+
+  override fun defaultValue(): Boolean = delegate.defaultValue() && required.defaultValue()
+
+  override fun changes(): Flow<Boolean> =
+    combine(delegate.changes(), required.changes()) { enabled, allowed -> enabled to allowed }
+      .onEach { (enabled, allowed) ->
+        if (enabled && !allowed) delegate.set(false)
+      }.map { (enabled, allowed) -> enabled && allowed }
+      .distinctUntilChanged()
+
+  override fun stateIn(scope: CoroutineScope): StateFlow<Boolean> =
+    changes().stateIn(
+      scope = scope,
+      started = SharingStarted.Eagerly,
+      initialValue = get(),
+    )
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -9,6 +9,8 @@
 
 package app.gyrolet.mpvrx.ui.browser.networkstreaming
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -32,15 +33,18 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,9 +53,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.activity.compose.BackHandler
-import androidx.compose.material3.SearchBar
-import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
@@ -68,19 +69,27 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.database.entities.NetworkStreamEntryEntity
+import app.gyrolet.mpvrx.database.repository.NetworkStreamEntryRepository
 import app.gyrolet.mpvrx.domain.network.NetworkConnection
+import app.gyrolet.mpvrx.domain.torrent.TorrentStreamingEngine
 import app.gyrolet.mpvrx.domain.torrent.formatTorrentBytes
+import app.gyrolet.mpvrx.domain.torrent.isTorrentSource
 import app.gyrolet.mpvrx.domain.torrent.normalizeTorrentSource
 import app.gyrolet.mpvrx.presentation.Screen
+import app.gyrolet.mpvrx.repository.wyzie.WyzieSearchRepository
 import app.gyrolet.mpvrx.ui.browser.cards.NetworkConnectionCard
 import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.browser.dialogs.AddConnectionSheet
 import app.gyrolet.mpvrx.ui.browser.dialogs.EditConnectionSheet
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.torrent.TorrentSelectionInput
+import app.gyrolet.mpvrx.ui.torrent.TorrentSelectionScreen
+import app.gyrolet.mpvrx.ui.torrent.TorrentSelectionViewModel
 import app.gyrolet.mpvrx.ui.utils.LocalBackStack
 import app.gyrolet.mpvrx.utils.media.MediaUtils
 import kotlinx.serialization.Serializable
+import org.koin.compose.koinInject
 
 @Serializable
 object NetworkStreamingScreen : Screen {
@@ -91,13 +100,42 @@ object NetworkStreamingScreen : Screen {
     val context = LocalContext.current
     val viewModel: NetworkStreamingViewModel =
       viewModel(factory = NetworkStreamingViewModel.factory(context.applicationContext as android.app.Application))
+    val torrentStreamingEngine = koinInject<TorrentStreamingEngine>()
+    val streamEntryRepository = koinInject<NetworkStreamEntryRepository>()
+    val wyzieSearchRepository = koinInject<WyzieSearchRepository>()
+    val torrentPickerViewModel: TorrentSelectionViewModel =
+      viewModel(
+        key = "network_torrent_picker",
+        factory =
+          TorrentSelectionViewModel.factory(
+            torrentStreamingEngine = torrentStreamingEngine,
+            streamEntryRepository = streamEntryRepository,
+            wyzieSearchRepository = wyzieSearchRepository,
+          ),
+      )
+    val torrentPickerState by torrentPickerViewModel.uiState.collectAsState()
     val connections by viewModel.connections.collectAsState()
     val connectionStatuses by viewModel.connectionStatuses.collectAsState()
     val recentLinks by viewModel.recentLinks.collectAsState()
     val torrentGroups by viewModel.torrentGroups.collectAsState()
     var showAddSheet by remember { mutableStateOf(false) }
     var editingConnection by remember { mutableStateOf<NetworkConnection?>(null) }
+    var showTorrentPicker by rememberSaveable { mutableStateOf(false) }
     val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
+
+    LaunchedEffect(torrentPickerViewModel) {
+      torrentPickerViewModel.launches.collect { request ->
+        showTorrentPicker = false
+        MediaUtils.playFile(
+          source = request.source,
+          context = context,
+          launchSource = "network_torrent",
+          title = request.file.name,
+          torrentFileIndex = request.file.index,
+          torrentPreparationId = request.preparationId,
+        )
+      }
+    }
 
     val listState = rememberLazyListState()
     val isFabVisible = remember { mutableStateOf(true) }
@@ -158,7 +196,7 @@ object NetworkStreamingScreen : Screen {
         }
       }
 
-    androidx.activity.compose.BackHandler(enabled = isSearching) {
+    BackHandler(enabled = isSearching) {
       isSearching = false
       searchQuery = ""
     }
@@ -216,7 +254,7 @@ object NetworkStreamingScreen : Screen {
             isInSelectionMode = false,
             selectedCount = 0,
             totalCount = connections.size + recentLinks.size + torrentGroups.size,
-            onBackClick = null, // No back button for network screen (root tab)
+            onBackClick = null,
             onCancelSelection = { },
             onSortClick = null,
             onSearchClick = { isSearching = true },
@@ -266,13 +304,17 @@ object NetworkStreamingScreen : Screen {
             bottom = navigationBarHeight,
           ),
       ) {
-        // Section 1: Stream Link
         item {
           StreamLinkSection(
             onPlayLink = { url ->
-              val playableSource = normalizeTorrentSource(url) ?: url
-              viewModel.recordSubmittedLink(playableSource)
-              MediaUtils.playFile(playableSource, context, "network_stream")
+              val playableSource = normalizeTorrentSource(url) ?: url.trim()
+              if (isTorrentSource(playableSource)) {
+                showTorrentPicker = true
+                torrentPickerViewModel.open(TorrentSelectionInput(source = playableSource))
+              } else {
+                viewModel.recordSubmittedLink(playableSource)
+                MediaUtils.playFile(playableSource, context, "network_stream")
+              }
             },
           )
         }
@@ -298,7 +340,6 @@ object NetworkStreamingScreen : Screen {
           }
         }
 
-        // Syncplay
         item {
           Spacer(modifier = Modifier.height(24.dp))
           var showSyncplaySheet by remember { mutableStateOf(false) }
@@ -325,7 +366,6 @@ object NetworkStreamingScreen : Screen {
           }
         }
 
-        // Section 2: Local Network header
         item {
           Spacer(modifier = Modifier.height(24.dp))
           Text(
@@ -339,7 +379,6 @@ object NetworkStreamingScreen : Screen {
           )
         }
 
-        // Show empty state or connection list
         if (connections.isEmpty()) {
           item {
             Card(
@@ -460,7 +499,6 @@ object NetworkStreamingScreen : Screen {
           }
         }
 
-        // Keep the torrent catalog at the bottom of the Network tab.
         if (filteredTorrentGroups.isNotEmpty()) {
           item {
             StreamEntrySectionHeader(stringResource(R.string.ui_torrent_files))
@@ -486,7 +524,6 @@ object NetworkStreamingScreen : Screen {
         }
       }
 
-      // Add Connection Sheet
       AddConnectionSheet(
         isOpen = showAddSheet,
         onDismiss = { showAddSheet = false },
@@ -496,7 +533,6 @@ object NetworkStreamingScreen : Screen {
         },
       )
 
-      // Edit Connection Sheet
       editingConnection?.let { connection ->
         EditConnectionSheet(
           connection = connection,
@@ -506,6 +542,18 @@ object NetworkStreamingScreen : Screen {
             viewModel.updateConnection(updatedConnection, clearPassword)
             editingConnection = null
           },
+        )
+      }
+
+      if (showTorrentPicker) {
+        TorrentSelectionScreen(
+          state = torrentPickerState,
+          onBack = {
+            showTorrentPicker = false
+            torrentPickerViewModel.cancel()
+          },
+          onRetry = torrentPickerViewModel::retry,
+          onSelect = torrentPickerViewModel::select,
         )
       }
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerLifecyclePolicy.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerLifecyclePolicy.kt
@@ -29,13 +29,9 @@ internal object PlayerLifecyclePolicy {
   ): Boolean = backgroundPlaybackEnabled && mediaReady
 
   fun shouldKeepBackgroundPlaybackAliveOnDestroy(
-    @Suppress("UNUSED_PARAMETER") backgroundPlaybackEnabled: Boolean,
+    backgroundPlaybackEnabled: Boolean,
     backgroundPlaybackSessionActive: Boolean,
-  ): Boolean =
-    // The detached service is also the owner of an in-app Mini Player session. Once that handoff
-    // is active, destroying PlayerActivity must not tear down the shared mpv core just because the
-    // separate background-playback preference is disabled.
-    backgroundPlaybackSessionActive
+  ): Boolean = backgroundPlaybackEnabled && backgroundPlaybackSessionActive
 
   fun shouldTreatStopAsPipDismissal(
     wasInPictureInPictureMode: Boolean,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/PlayerPreferencesScreen.kt
@@ -87,6 +87,7 @@ object PlayerPreferencesScreen : Screen {
       ) { _ -> }
     var showTemplateDialog by remember { mutableStateOf(false) }
     var templateDraft by remember { mutableStateOf("") }
+    var showVideoMiniPlayerDependencyDialog by remember { mutableStateOf(false) }
     Scaffold(
       topBar = {
         TopAppBar(
@@ -158,6 +159,10 @@ object PlayerPreferencesScreen : Screen {
                 value = videoBackgroundPlayback,
                 onValueChange = { enabled ->
                   audioPreferences.backgroundPlayback.set(enabled)
+                  if (!enabled) {
+                    preferences.enableVideoMiniPlayer.set(false)
+                    showVideoMiniPlayerDependencyDialog = false
+                  }
                   if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                     ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
                     PackageManager.PERMISSION_GRANTED
@@ -265,7 +270,16 @@ object PlayerPreferencesScreen : Screen {
               val enableVideoMiniPlayer by preferences.enableVideoMiniPlayer.collectAsState()
               SwitchPreference(
                 value = enableVideoMiniPlayer,
-                onValueChange = preferences.enableVideoMiniPlayer::set,
+                onValueChange = { enabled ->
+                  when {
+                    !enabled -> preferences.enableVideoMiniPlayer.set(false)
+                    videoBackgroundPlayback -> preferences.enableVideoMiniPlayer.set(true)
+                    else -> {
+                      preferences.enableVideoMiniPlayer.set(false)
+                      showVideoMiniPlayerDependencyDialog = true
+                    }
+                  }
+                },
                 title = { Text(stringResource(R.string.pref_enable_video_mini_player_title)) },
                 summary = {
                   Text(
@@ -951,6 +965,40 @@ object PlayerPreferencesScreen : Screen {
           }
         }
       }
+    }
+    if (showVideoMiniPlayerDependencyDialog) {
+      AlertDialog(
+        onDismissRequest = { showVideoMiniPlayerDependencyDialog = false },
+        title = { Text(stringResource(R.string.pref_video_mini_player_dependency_title)) },
+        text = { Text(stringResource(R.string.pref_video_mini_player_dependency_message)) },
+        confirmButton = {
+          TextButton(
+            onClick = {
+              audioPreferences.backgroundPlayback.set(true)
+              preferences.enableVideoMiniPlayer.set(true)
+              showVideoMiniPlayerDependencyDialog = false
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+              ) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+              }
+            },
+          ) {
+            Text(stringResource(R.string.pref_video_mini_player_dependency_confirm))
+          }
+        },
+        dismissButton = {
+          TextButton(
+            onClick = {
+              preferences.enableVideoMiniPlayer.set(false)
+              showVideoMiniPlayerDependencyDialog = false
+            },
+          ) {
+            Text(stringResource(R.string.generic_cancel))
+          }
+        },
+      )
     }
     if (showTemplateDialog) {
       AlertDialog(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/torrent/TorrentSelectionViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/torrent/TorrentSelectionViewModel.kt
@@ -79,6 +79,11 @@ class TorrentSelectionViewModel(
 
   fun initialize(value: TorrentSelectionInput) {
     if (input != null) return
+    open(value)
+  }
+
+  /** Opens a new torrent in the same picker host, replacing any previous picker session. */
+  fun open(value: TorrentSelectionInput) {
     input = value
     load(value)
   }

--- a/app/src/main/res/values/strings_mini_player.xml
+++ b/app/src/main/res/values/strings_mini_player.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="pref_video_mini_player_dependency_title">Enable video background playback?</string>
+  <string name="pref_video_mini_player_dependency_message">Video Mini Player needs Video Player Background Playback to keep the video playing after you leave the full player.</string>
+  <string name="pref_video_mini_player_dependency_confirm">Enable and continue</string>
+</resources>


### PR DESCRIPTION
## Summary
- keep Network torrent selection inside the Network screen as an inline episode/file picker
- resolve a multi-file torrent once, list every playable episode/file, and launch the selected item directly
- persist the full torrent catalog so Network shows one collapsible series/torrent group with all saved episodes underneath
- make Video Mini Player depend on Video Background Playback
- prompt to enable Video Background Playback when Mini Player is turned on without it; cancelling keeps Mini Player disabled
- disabling Video Background Playback disables the Mini Player preference as well
- enforce the dependency at the preference/runtime level and during background-session teardown

## Commit history
This PR contains one squashed commit.