### PR TITLE
Fix playback markers and add verified beta build channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,90 +16,135 @@ concurrency:
 
 jobs:
   build:
+    name: Build standard APKs
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Generate short SHA
-        id: set-short-sha
-        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'gradle'
+          # BuildConfig.GIT_COUNT and preview build identities rely on the real repository history.
+          fetch-depth: 0
 
-      - name: Make gradlew executable
+      - name: Generate build metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "COMMIT_COUNT=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew assembleStandardRelease
+      - name: Build standard release APKs
+        run: ./gradlew assembleStandardRelease --stacktrace --no-daemon
 
-      - name: Sign APKs
+      - name: Sign APKs when signing secrets are available
+        shell: bash
         run: |
-          set -e
-          STANDARD_RELEASE_DIR="app/build/outputs/apk/standard/release"
-          
-          if [ -z "${{ secrets.SIGNING_KEYSTORE }}" ]; then
-            echo "SIGNING_KEYSTORE secret is not available. Skipping signing step."
+          set -euo pipefail
+          release_dir="app/build/outputs/apk/standard/release"
+          apksigner="$ANDROID_HOME/build-tools/34.0.0/apksigner"
+
+          test -d "$release_dir"
+          test -x "$apksigner"
+
+          if [[ -z "${{ secrets.SIGNING_KEYSTORE }}" ]]; then
+            echo "SIGNING_KEYSTORE is unavailable (expected for untrusted fork PRs); keeping CI APKs unsigned."
             exit 0
           fi
-          
-          echo "${{ secrets.SIGNING_KEYSTORE }}" | base64 -d > release.keystore
-          
-          find "$STANDARD_RELEASE_DIR" -name "app-standard-*-release-unsigned.apk" -type f | while read -r apk; do
-            signed_apk="${apk/-unsigned/}"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner sign \
+
+          if [[ -z "${{ secrets.SIGNING_KEY_ALIAS }}" || -z "${{ secrets.SIGNING_STORE_PASSWORD }}" || -z "${{ secrets.KEY_PASSWORD }}" ]]; then
+            echo "SIGNING_KEYSTORE exists but one or more required signing secrets are missing."
+            exit 1
+          fi
+
+          printf '%s' "${{ secrets.SIGNING_KEYSTORE }}" | base64 --decode > release.keystore
+          trap 'rm -f release.keystore' EXIT
+
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
+          for abi in "${architectures[@]}"; do
+            unsigned="$release_dir/app-standard-${abi}-release-unsigned.apk"
+            signed="$release_dir/app-standard-${abi}-release.apk"
+            if [[ ! -f "$unsigned" ]]; then
+              echo "Missing expected $abi release APK: $unsigned"
+              find "$release_dir" -maxdepth 1 -type f -name '*.apk' -print || true
+              exit 1
+            fi
+
+            "$apksigner" sign \
               --ks release.keystore \
               --ks-key-alias "${{ secrets.SIGNING_KEY_ALIAS }}" \
               --ks-pass "pass:${{ secrets.SIGNING_STORE_PASSWORD }}" \
               --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
-              --out "$signed_apk" \
-              "$apk"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner verify "$signed_apk"
-            rm "$apk"
+              --out "$signed" \
+              "$unsigned"
+            "$apksigner" verify --verbose "$signed"
+            rm -f "$unsigned"
           done
-          
-          rm release.keystore
-          echo "APKs signed and verified successfully."
 
-      - name: Upload app-arm64-v8a Artifact
-        uses: actions/upload-artifact@v4
+      - name: Verify expected architecture outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_dir="app/build/outputs/apk/standard/release"
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
+          for abi in "${architectures[@]}"; do
+            if ! compgen -G "$release_dir/app-standard-${abi}-release*.apk" >/dev/null; then
+              echo "No release APK found for $abi"
+              exit 1
+            fi
+          done
+
+      - name: Upload arm64-v8a APK
+        uses: actions/upload-artifact@v7
         with:
           name: app-standard-arm64-v8a-release-${{ env.SHORT_SHA }}
           path: app/build/outputs/apk/standard/release/app-standard-arm64-v8a-release*.apk
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
-      - name: Upload app-armeabi-v7a Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload armeabi-v7a APK
+        uses: actions/upload-artifact@v7
         with:
           name: app-standard-armeabi-v7a-release-${{ env.SHORT_SHA }}
           path: app/build/outputs/apk/standard/release/app-standard-armeabi-v7a-release*.apk
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
-      - name: Upload app-universal Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload universal APK
+        uses: actions/upload-artifact@v7
         with:
           name: app-standard-universal-release-${{ env.SHORT_SHA }}
           path: app/build/outputs/apk/standard/release/app-standard-universal-release*.apk
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
-      - name: Upload app-x86 Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload x86 APK
+        uses: actions/upload-artifact@v7
         with:
           name: app-standard-x86-release-${{ env.SHORT_SHA }}
           path: app/build/outputs/apk/standard/release/app-standard-x86-release*.apk
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
-      - name: Upload app-x86_64 Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload x86_64 APK
+        uses: actions/upload-artifact@v7
         with:
           name: app-standard-x86_64-release-${{ env.SHORT_SHA }}
           path: app/build/outputs/apk/standard/release/app-standard-x86_64-release*.apk
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,153 +1,145 @@
-name: Make Pre release
-
-permissions:
-  contents: write
+name: Make tagged pre-release
 
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-preview.[0-9]+'
 
+permissions:
+  contents: write
+
 jobs:
   release-for-github:
-    name: "Preview Release for GitHub"
+    name: Tagged preview release for GitHub
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: 17
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Resolve release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_tag="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$version_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then
+            echo "Invalid tagged preview version: $version_tag"
+            exit 1
+          fi
+          echo "VERSION_TAG=$version_tag" >> "$GITHUB_ENV"
 
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
       - name: Build preview APKs
-        run: ./gradlew assembleStandardPreview --stacktrace
+        run: ./gradlew assembleStandardPreview --stacktrace --no-daemon
 
-      - name: Get tag name
-        if: startsWith(github.ref, 'refs/tags/')
-        run: echo "VERSION_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Verify build output
+      - name: Sign and verify preview APKs
+        shell: bash
         run: |
-          PREVIEW_DIR="app/build/outputs/apk/standard/preview"
-          if [ ! -d "$PREVIEW_DIR" ]; then
-            echo "Preview directory does not exist!"
-            find app/build/outputs -name "*.apk" -type f
+          set -euo pipefail
+          preview_dir="app/build/outputs/apk/standard/preview"
+          apksigner="$ANDROID_HOME/build-tools/34.0.0/apksigner"
+
+          if [[ -z "${{ secrets.SIGNING_KEYSTORE }}" || -z "${{ secrets.SIGNING_KEY_ALIAS }}" || -z "${{ secrets.SIGNING_STORE_PASSWORD }}" || -z "${{ secrets.KEY_PASSWORD }}" ]]; then
+            echo "Tagged preview releases require all signing secrets."
             exit 1
           fi
-          ls -lah "$PREVIEW_DIR"
+          test -d "$preview_dir"
+          test -x "$apksigner"
 
-      - name: Sign APKs
-        run: |
-          set -e
-          PREVIEW_DIR="app/build/outputs/apk/standard/preview"
-          
-          echo "${{ secrets.SIGNING_KEYSTORE }}" | base64 -d > release.keystore
-          
-          APK_COUNT=$(find "$PREVIEW_DIR" -name "app-standard-*-preview-unsigned.apk" -type f | wc -l)
-          if [ "$APK_COUNT" -eq 0 ]; then
-            echo "No unsigned preview APK files found"
-            ls -lah "$PREVIEW_DIR"
-            rm release.keystore
-            exit 1
-          fi
-          
-          find "$PREVIEW_DIR" -name "app-standard-*-preview-unsigned.apk" -type f | while read -r apk; do
-            signed_apk="${apk/-unsigned/}"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner sign \
+          printf '%s' "${{ secrets.SIGNING_KEYSTORE }}" | base64 --decode > release.keystore
+          trap 'rm -f release.keystore' EXIT
+
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
+          for abi in "${architectures[@]}"; do
+            unsigned="$preview_dir/app-standard-${abi}-preview-unsigned.apk"
+            signed="$preview_dir/app-standard-${abi}-preview.apk"
+            if [[ ! -f "$unsigned" ]]; then
+              echo "Missing expected preview APK for $abi: $unsigned"
+              find "$preview_dir" -maxdepth 1 -type f -name '*.apk' -print || true
+              exit 1
+            fi
+
+            "$apksigner" sign \
               --ks release.keystore \
               --ks-key-alias "${{ secrets.SIGNING_KEY_ALIAS }}" \
               --ks-pass "pass:${{ secrets.SIGNING_STORE_PASSWORD }}" \
               --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
-              --out "$signed_apk" \
-              "$apk"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner verify "$signed_apk"
-            rm "$apk"
+              --out "$signed" \
+              "$unsigned"
+            "$apksigner" verify --verbose "$signed"
+            rm -f "$unsigned"
           done
-          
-          rm release.keystore
-          ls -lh "$PREVIEW_DIR"/app-standard-*-preview.apk
 
-      - name: Copy built artifacts
+      - name: Stage pre-release assets and checksums
+        shell: bash
         run: |
-          set -e
+          set -euo pipefail
+          preview_dir="app/build/outputs/apk/standard/preview"
           mkdir -p preview
-          declare -a apks=("universal" "arm64-v8a" "armeabi-v7a" "x86" "x86_64")
+          : > checksums.txt
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
 
-          for abi in "${apks[@]}"; do
-            src="app/build/outputs/apk/standard/preview/app-standard-${abi}-preview.apk"
-            dest="preview/mpvRx-preview-${abi}-${{ env.VERSION_TAG }}.apk"
-            if [ -f "$src" ]; then
-              cp "$src" "$dest"
-              sha=$(sha256sum "$dest" | awk '{ print $1 }')
-              echo "apk_${abi//-/_}_sha256=$sha" >> $GITHUB_ENV
-            fi
+          for abi in "${architectures[@]}"; do
+            src="$preview_dir/app-standard-${abi}-preview.apk"
+            dst="preview/mpvRx-preview-${abi}-${VERSION_TAG}.apk"
+            test -f "$src"
+            cp "$src" "$dst"
+            sha256sum "$dst" | tee -a checksums.txt
           done
 
-      - name: Prepare pre-release notes from changelog
+      - name: Prepare pre-release notes
+        shell: bash
         run: |
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
 
-          changelog = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+          changelog = Path('CHANGELOG.md').read_text(encoding='utf-8').splitlines()
           section = []
           in_latest = False
-
           for line in changelog:
-              if line.startswith("## "):
+              if line.startswith('## '):
                   if in_latest:
                       break
                   in_latest = True
               if in_latest:
                   section.append(line)
 
-          latest = "\n".join(section).strip()
+          latest = '\n'.join(section).strip()
           if not latest:
-              raise SystemExit("Could not find latest changelog section")
-
-          Path("pre-release-notes.md").write_text(latest + "\n", encoding="utf-8")
+              raise SystemExit('Could not find latest changelog section')
+          Path('pre-release-notes.md').write_text(latest + '\n\n---\n### SHA-256 checksums\n\n```text\n', encoding='utf-8')
           PY
-          cat >> pre-release-notes.md <<EOF
-
-          ---
-          ### Checksums
-
-          | Variant | SHA-256 |
-          | ------- | ------- |
-          | arm64-v8a | ${apk_arm64_v8a_sha256} |
-          | armeabi-v7a | ${apk_armeabi_v7a_sha256} |
-          | Universal | ${apk_universal_sha256} |
-          | x86 | ${apk_x86_sha256:-not built} |
-          | x86_64 | ${apk_x86_64_sha256:-not built} |
-
-          EOF
+          cat checksums.txt >> pre-release-notes.md
+          printf '%s\n' '```' >> pre-release-notes.md
 
       - name: Create GitHub pre-release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION_TAG }}
-          name: "mpvRx ${{ env.VERSION_TAG }}"
+          name: mpvRx ${{ env.VERSION_TAG }}
           body_path: pre-release-notes.md
           generate_release_notes: true
+          draft: false
+          prerelease: true
+          fail_on_unmatched_files: true
           files: |
             preview/mpvRx-preview-universal-${{ env.VERSION_TAG }}.apk
             preview/mpvRx-preview-arm64-v8a-${{ env.VERSION_TAG }}.apk
             preview/mpvRx-preview-armeabi-v7a-${{ env.VERSION_TAG }}.apk
             preview/mpvRx-preview-x86-${{ env.VERSION_TAG }}.apk
             preview/mpvRx-preview-x86_64-${{ env.VERSION_TAG }}.apk
-
-          draft: false
-          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,103 +1,219 @@
 name: Preview Build
 
+on:
+  workflow_run:
+    workflows:
+      - CI/CD Build
+    types:
+      - completed
+
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
-on:
-  workflow_dispatch:
+concurrency:
+  group: mpvrx-preview-pages
+  cancel-in-progress: true
 
 jobs:
-  build:
+  build-preview:
+    name: Build verified beta APKs
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'master' &&
+      github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
-    outputs:
-      commit_count: ${{ steps.set_commit.outputs.commit_count }}
-      build_time: ${{ steps.set_commit.outputs.build_time }}
-      universal_size: ${{ steps.set_commit.outputs.universal_size }}
-      arm64-v8a_size: ${{ steps.set_commit.outputs.arm64-v8a_size }}
-      armeabi-v7a_size: ${{ steps.set_commit.outputs.armeabi-v7a_size }}
-      x86_size: ${{ steps.set_commit.outputs.x86_size }}
-      x86_64_size: ${{ steps.set_commit.outputs.x86_64_size }}
+    timeout-minutes: 45
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - name: Checkout validated master commit
+        uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'gradle'
+      - name: Set build metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          commit_count="$(git rev-list --count HEAD)"
+          source_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short HEAD)"
+          published_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
-      - name: Make gradlew executable
+          echo "COMMIT_COUNT=$commit_count" >> "$GITHUB_ENV"
+          echo "SOURCE_SHA=$source_sha" >> "$GITHUB_ENV"
+          echo "SHORT_SHA=$short_sha" >> "$GITHUB_ENV"
+          echo "PUBLISHED_AT=$published_at" >> "$GITHUB_ENV"
+          echo "Beta source: r${commit_count} @ ${short_sha}"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew assembleStandardPreview
+      - name: Build preview APKs
+        run: ./gradlew assembleStandardPreview --stacktrace --no-daemon
 
-      - name: Sign APKs
+      - name: Sign and verify preview APKs
+        shell: bash
         run: |
-          set -e
-          PREVIEW_DIR="app/build/outputs/apk/standard/preview"
-          
-          echo "${{ secrets.SIGNING_KEYSTORE }}" | base64 -d > release.keystore
-          
-          APK_COUNT=$(find "$PREVIEW_DIR" -name "app-standard-*-preview-unsigned.apk" -type f | wc -l)
-          if [ "$APK_COUNT" -eq 0 ]; then
-            echo "No unsigned preview APK files found"
-            ls -lah "$PREVIEW_DIR"
-            rm release.keystore
+          set -euo pipefail
+          preview_dir="app/build/outputs/apk/standard/preview"
+          apksigner="$ANDROID_HOME/build-tools/34.0.0/apksigner"
+
+          if [[ -z "${{ secrets.SIGNING_KEYSTORE }}" || -z "${{ secrets.SIGNING_KEY_ALIAS }}" || -z "${{ secrets.SIGNING_STORE_PASSWORD }}" || -z "${{ secrets.KEY_PASSWORD }}" ]]; then
+            echo "Required signing secrets are missing; refusing to publish an unsigned beta build."
             exit 1
           fi
-          
-          find "$PREVIEW_DIR" -name "app-standard-*-preview-unsigned.apk" -type f | while read -r apk; do
-            signed_apk="${apk/-unsigned/}"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner sign \
+
+          test -d "$preview_dir"
+          test -x "$apksigner"
+          printf '%s' "${{ secrets.SIGNING_KEYSTORE }}" | base64 --decode > release.keystore
+          trap 'rm -f release.keystore' EXIT
+
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
+          for abi in "${architectures[@]}"; do
+            unsigned="$preview_dir/app-standard-${abi}-preview-unsigned.apk"
+            signed="$preview_dir/app-standard-${abi}-preview.apk"
+            if [[ ! -f "$unsigned" ]]; then
+              echo "Missing expected $abi preview APK: $unsigned"
+              find "$preview_dir" -maxdepth 1 -type f -name '*.apk' -print || true
+              exit 1
+            fi
+
+            "$apksigner" sign \
               --ks release.keystore \
               --ks-key-alias "${{ secrets.SIGNING_KEY_ALIAS }}" \
               --ks-pass "pass:${{ secrets.SIGNING_STORE_PASSWORD }}" \
               --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
-              --out "$signed_apk" \
-              "$apk"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner verify "$signed_apk"
-            rm "$apk"
+              --out "$signed" \
+              "$unsigned"
+            "$apksigner" verify --verbose "$signed"
+            rm -f "$unsigned"
           done
-          
-          rm release.keystore
-          ls -lh "$PREVIEW_DIR"/app-standard-*-preview.apk
 
-      - name: Copy build artifacts
-        id: set_commit
+      - name: Stage beta website and manifest
+        env:
+          SITE_BASE_URL: https://riteshp2001.github.io/mpvRx
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        shell: bash
         run: |
-          set -e
-          commit_count=$(git rev-list --count HEAD)
-          build_time=$(date -u +"%Y-%m-%d %H:%M UTC")
-          echo "commit_count=$commit_count" >> $GITHUB_OUTPUT
-          echo "build_time=$build_time" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          rm -rf site
+          mkdir -p site/downloads
+          cp preview-site/index.html site/index.html
+          touch site/.nojekyll
 
-          declare -a apks=("universal" "arm64-v8a" "armeabi-v7a" "x86" "x86_64")
-          mkdir -p output
-          
-          for arch in "${apks[@]}"; do
-            src="app/build/outputs/apk/standard/preview/app-standard-${arch}-preview.apk"
-            dest="output/mpvRx-preview-r${commit_count}-${arch}.apk"
-            if [ -f "$src" ]; then
-              cp "$src" "$dest"
-              size=$(du -h "$dest" | cut -f1)
-            else
-              size="N/A"
-            fi
-            echo "${arch}_size=$size" >> $GITHUB_OUTPUT
-          done
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import shutil
+          from pathlib import Path
 
-      - name: Upload all artifacts
-        uses: actions/upload-artifact@v4
+          source_dir = Path('app/build/outputs/apk/standard/preview')
+          site_dir = Path('site')
+          downloads_dir = site_dir / 'downloads'
+          base_url = os.environ['SITE_BASE_URL'].rstrip('/')
+          commit_count = int(os.environ['COMMIT_COUNT'])
+          source_sha = os.environ['SOURCE_SHA']
+          published_at = os.environ['PUBLISHED_AT']
+          run_id = int(os.environ['SOURCE_RUN_ID'])
+          run_number = int(os.environ['SOURCE_RUN_NUMBER'])
+          run_url = os.environ['SOURCE_RUN_URL']
+
+          architectures = ['universal', 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']
+          assets = []
+
+          for abi in architectures:
+              source = source_dir / f'app-standard-{abi}-preview.apk'
+              if not source.is_file():
+                  raise SystemExit(f'Missing signed APK for {abi}: {source}')
+
+              name = f'mpvRx-beta-r{commit_count}-{abi}.apk'
+              destination = downloads_dir / name
+              shutil.copy2(source, destination)
+
+              sha256 = hashlib.sha256(destination.read_bytes()).hexdigest()
+              size = destination.stat().st_size
+              assets.append({
+                  'abi': abi,
+                  'browser_download_url': f'{base_url}/downloads/{name}',
+                  'name': name,
+                  'size': size,
+                  'content_type': 'application/vnd.android.package-archive',
+                  'sha256': sha256,
+              })
+
+          manifest = {
+              'tag_name': f'beta-r{commit_count}',
+              'name': f'mpvRx Beta r{commit_count}',
+              'body': (
+                  f'Automated beta from successful CI/CD run #{run_number}. '
+                  f'Source commit: {source_sha[:7]}. APKs are signed and SHA-256 verified.'
+              ),
+              'published_at': published_at,
+              'assets': assets,
+              'channel': 'beta',
+              'commit_sha': source_sha,
+              'commit_count': commit_count,
+              'run_number': run_number,
+              'run_id': run_id,
+              'run_url': run_url,
+              'source_branch': 'master',
+              'source_workflow': 'CI/CD Build',
+          }
+
+          (site_dir / 'latest.json').write_text(
+              json.dumps(manifest, indent=2, sort_keys=False) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+          echo "Staged beta files:"
+          find site -maxdepth 2 -type f -printf '%p %k KB\n' | sort
+          python3 -m json.tool site/latest.json >/dev/null
+
+      - name: Upload beta APKs as Actions artifact
+        uses: actions/upload-artifact@v7
         with:
-          name: preview-apks
-          path: output/
+          name: mpvRx-beta-r${{ env.COMMIT_COUNT }}
+          path: |
+            site/downloads/*.apk
+            site/latest.json
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
-  # GitHub Pages removed — was failing consistently
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+        with:
+          enablement: true
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy-preview:
+    name: Publish beta download hub
+    needs: build-preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Make release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags:
@@ -10,162 +7,149 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: Tag to release
+        description: Tag to release (for example v2.1.0)
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   release-for-github:
-    name: "Release for GitHub"
+    name: Release for GitHub
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: 17
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
 
-      - name: Make gradlew executable
+      - name: Resolve and validate release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            version_tag="${GITHUB_REF#refs/tags/}"
+          else
+            version_tag="${{ inputs.tag_name }}"
+          fi
+
+          if [[ ! "$version_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid stable release tag: $version_tag"
+            exit 1
+          fi
+          echo "VERSION_TAG=$version_tag" >> "$GITHUB_ENV"
+
+      - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
 
-      - name: Build standard release with Gradle
-        run: ./gradlew assembleStandardRelease --stacktrace
+      - name: Build standard release APKs
+        run: ./gradlew assembleStandardRelease --stacktrace --no-daemon
 
-      - name: Get tag name
+      - name: Sign and verify release APKs
+        shell: bash
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "VERSION_TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
-          else
-            echo "VERSION_TAG=${{ inputs.tag_name }}" >> "$GITHUB_ENV"
-          fi
+          set -euo pipefail
+          release_dir="app/build/outputs/apk/standard/release"
+          apksigner="$ANDROID_HOME/build-tools/34.0.0/apksigner"
 
-      - name: Verify build output
-        run: |
-          STANDARD_RELEASE_DIR="app/build/outputs/apk/standard/release"
-          
-          if [ ! -d "$STANDARD_RELEASE_DIR" ]; then
-            echo "Standard release directory does not exist!"
-            find app/build/outputs -name "*.apk" -type f
+          if [[ -z "${{ secrets.SIGNING_KEYSTORE }}" || -z "${{ secrets.SIGNING_KEY_ALIAS }}" || -z "${{ secrets.SIGNING_STORE_PASSWORD }}" || -z "${{ secrets.KEY_PASSWORD }}" ]]; then
+            echo "Stable releases require all signing secrets."
             exit 1
           fi
-          
-          echo "Standard release APKs:"
-          ls -lah "$STANDARD_RELEASE_DIR"
+          test -d "$release_dir"
+          test -x "$apksigner"
 
-      - name: Sign APKs
-        run: |
-          set -e
-          STANDARD_RELEASE_DIR="app/build/outputs/apk/standard/release"
-          
-          echo "${{ secrets.SIGNING_KEYSTORE }}" | base64 -d > release.keystore
-          
-          APK_COUNT=$(find "$STANDARD_RELEASE_DIR" -name "app-standard-*-release-unsigned.apk" -type f | wc -l)
-          if [ "$APK_COUNT" -eq 0 ]; then
-            echo "No unsigned standard APK files found"
-            ls -lah "$STANDARD_RELEASE_DIR"
-            rm release.keystore
-            exit 1
-          fi
-          
-          find "$STANDARD_RELEASE_DIR" -name "app-standard-*-release-unsigned.apk" -type f | while read -r apk; do
-            signed_apk="${apk/-unsigned/}"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner sign \
+          printf '%s' "${{ secrets.SIGNING_KEYSTORE }}" | base64 --decode > release.keystore
+          trap 'rm -f release.keystore' EXIT
+
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
+          for abi in "${architectures[@]}"; do
+            unsigned="$release_dir/app-standard-${abi}-release-unsigned.apk"
+            signed="$release_dir/app-standard-${abi}-release.apk"
+            if [[ ! -f "$unsigned" ]]; then
+              echo "Missing expected release APK for $abi: $unsigned"
+              find "$release_dir" -maxdepth 1 -type f -name '*.apk' -print || true
+              exit 1
+            fi
+
+            "$apksigner" sign \
               --ks release.keystore \
               --ks-key-alias "${{ secrets.SIGNING_KEY_ALIAS }}" \
               --ks-pass "pass:${{ secrets.SIGNING_STORE_PASSWORD }}" \
               --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
-              --out "$signed_apk" \
-              "$apk"
-          
-            $ANDROID_HOME/build-tools/34.0.0/apksigner verify "$signed_apk"
-            rm "$apk"
+              --out "$signed" \
+              "$unsigned"
+            "$apksigner" verify --verbose "$signed"
+            rm -f "$unsigned"
           done
-          
-          rm release.keystore
-          echo "Signed standard APKs:"
-          ls -lh "$STANDARD_RELEASE_DIR"/app-standard-*-release.apk
 
-      - name: Copy build artifacts
+      - name: Stage release assets and checksums
+        shell: bash
         run: |
           set -euo pipefail
-          
-          standard_apks=("universal" "arm64-v8a" "armeabi-v7a" "x86" "x86_64")
-          for abi in "${standard_apks[@]}"; do
-            src="app/build/outputs/apk/standard/release/app-standard-${abi}-release.apk"
-            if [ ! -f "$src" ]; then
-              echo "Skipping $abi (not built)"
-              continue
-            fi
-            dst="mpvRx-${abi}-${VERSION_TAG}.apk"
-            cp "$src" "$dst"
-            checksum=$(sha256sum "$dst" | awk '{ print $1 }')
-            varname="apk_${abi//-/_}_sha256"
-            echo "$varname=$checksum" >> "$GITHUB_ENV"
-          done
-          
-          ls -lah mpvRx-*.apk
+          release_dir="app/build/outputs/apk/standard/release"
+          architectures=(universal arm64-v8a armeabi-v7a x86 x86_64)
+          : > checksums.txt
 
-      - name: Prepare release notes from changelog
+          for abi in "${architectures[@]}"; do
+            src="$release_dir/app-standard-${abi}-release.apk"
+            dst="mpvRx-${abi}-${VERSION_TAG}.apk"
+            test -f "$src"
+            cp "$src" "$dst"
+            sha256sum "$dst" | tee -a checksums.txt
+          done
+
+      - name: Prepare release notes
+        shell: bash
         run: |
           set -euo pipefail
           python3 - <<'PY'
           from pathlib import Path
 
-          changelog = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+          changelog = Path('CHANGELOG.md').read_text(encoding='utf-8').splitlines()
           section = []
           in_latest = False
-
           for line in changelog:
-              if line.startswith("## "):
+              if line.startswith('## '):
                   if in_latest:
                       break
                   in_latest = True
               if in_latest:
                   section.append(line)
 
-          latest = "\n".join(section).strip()
+          latest = '\n'.join(section).strip()
           if not latest:
-              raise SystemExit("Could not find latest changelog section")
-
-          Path("release-notes.md").write_text(latest + "\n", encoding="utf-8")
+              raise SystemExit('Could not find latest changelog section')
+          Path('release-notes.md').write_text(latest + '\n\n---\n### SHA-256 checksums\n\n```text\n', encoding='utf-8')
           PY
-          cat >> release-notes.md <<EOF
+          cat checksums.txt >> release-notes.md
+          printf '%s\n' '```' >> release-notes.md
 
-          ---
-          ### Checksums
-
-          | Variant | SHA-256 |
-          | ------- | ------- |
-          | arm64-v8a | ${apk_arm64_v8a_sha256} |
-          | armeabi-v7a | ${apk_armeabi_v7a_sha256} |
-          | Universal | ${apk_universal_sha256} |
-          | x86 | ${apk_x86_sha256:-not built} |
-          | x86_64 | ${apk_x86_64_sha256:-not built} |
-
-          EOF
-
-      - name: Create GitHub Release
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION_TAG }}
           name: mpvRx ${{ env.VERSION_TAG }}
           body_path: release-notes.md
           generate_release_notes: true
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true
           files: |
             mpvRx-universal-${{ env.VERSION_TAG }}.apk
             mpvRx-arm64-v8a-${{ env.VERSION_TAG }}.apk
             mpvRx-armeabi-v7a-${{ env.VERSION_TAG }}.apk
             mpvRx-x86-${{ env.VERSION_TAG }}.apk
             mpvRx-x86_64-${{ env.VERSION_TAG }}.apk
-
-          draft: false
-          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,10 @@ android {
       initWith(getByName("release"))
       signingConfig = null
       applicationIdSuffix = ".preview"
-      versionNameSuffix = "-${getCommitCount()}"
+      versionNameSuffix = "-beta.r${getCommitCount()}"
+      // The About screen already renders app_name and BUILD_TYPE, so preview builds get a clear
+      // Beta marker without affecting the stable package identity or stable release version.
+      resValue("string", "app_name", "mpvRx Beta")
     }
 
     named("debug") {

--- a/app/src/main/java/app/gyrolet/mpvrx/database/dao/RecentlyPlayedDao.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/database/dao/RecentlyPlayedDao.kt
@@ -27,21 +27,21 @@ interface RecentlyPlayedDao {
   @Query("SELECT * FROM RecentlyPlayedEntity WHERE filePath = :filePath LIMIT 1")
   suspend fun getByFilePath(filePath: String): RecentlyPlayedEntity?
 
-  // id is the INTEGER PRIMARY KEY and therefore already indexed by SQLite. New history entries are
-  // inserted with autoGenerate=true, so ordering by id avoids building a temporary timestamp sort
-  // for the hot recent-history queries without introducing a database migration solely for indexes.
-  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY id DESC LIMIT 1")
+  // Existing history rows keep their id when they are replayed, while timestamp is refreshed.
+  // Recency must therefore be ordered by timestamp (with id only as a deterministic tie-breaker)
+  // or the browser can keep highlighting an older row as the current/recently played video.
+  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY timestamp DESC, id DESC LIMIT 1")
   suspend fun getLastPlayed(): RecentlyPlayedEntity?
 
-  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY id DESC LIMIT 1")
+  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY timestamp DESC, id DESC LIMIT 1")
   fun observeLastPlayed(): Flow<RecentlyPlayedEntity?>
 
   @Query(
     """
-    SELECT * FROM RecentlyPlayedEntity 
+    SELECT * FROM RecentlyPlayedEntity
     WHERE (launchSource IS NULL OR launchSource = '' OR launchSource = 'normal' OR launchSource = 'playlist' OR launchSource = 'video_list')
     AND (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
-    ORDER BY id DESC 
+    ORDER BY timestamp DESC, id DESC
     LIMIT 1
   """,
   )
@@ -49,10 +49,10 @@ interface RecentlyPlayedDao {
 
   @Query(
     """
-    SELECT * FROM RecentlyPlayedEntity 
+    SELECT * FROM RecentlyPlayedEntity
     WHERE (launchSource IS NULL OR launchSource = '' OR launchSource = 'normal' OR launchSource = 'playlist' OR launchSource = 'video_list')
     AND (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
-    ORDER BY id DESC 
+    ORDER BY timestamp DESC, id DESC
     LIMIT 1
   """,
   )
@@ -60,9 +60,9 @@ interface RecentlyPlayedDao {
 
   @Query(
     """
-    SELECT * FROM RecentlyPlayedEntity 
-    WHERE (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%')) 
-    ORDER BY id DESC 
+    SELECT * FROM RecentlyPlayedEntity
+    WHERE (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
+    ORDER BY timestamp DESC, id DESC
     LIMIT :limit
   """,
   )
@@ -70,9 +70,9 @@ interface RecentlyPlayedDao {
 
   @Query(
     """
-    SELECT * FROM RecentlyPlayedEntity 
-    WHERE (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%')) 
-    ORDER BY id DESC 
+    SELECT * FROM RecentlyPlayedEntity
+    WHERE (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
+    ORDER BY timestamp DESC, id DESC
     LIMIT :limit
   """,
   )
@@ -80,10 +80,10 @@ interface RecentlyPlayedDao {
 
   @Query(
     """
-    SELECT * FROM RecentlyPlayedEntity 
+    SELECT * FROM RecentlyPlayedEntity
     WHERE launchSource = :launchSource
     AND (NOT (filePath LIKE '%.m3u%' OR filePath LIKE '%.m3u8%'))
-    ORDER BY id DESC 
+    ORDER BY timestamp DESC, id DESC
     LIMIT :limit
   """,
   )
@@ -132,7 +132,7 @@ interface RecentlyPlayedDao {
   @Query(
     """
     SELECT DISTINCT playlistId, MAX(timestamp) as timestamp
-    FROM RecentlyPlayedEntity 
+    FROM RecentlyPlayedEntity
     WHERE playlistId IS NOT NULL
     GROUP BY playlistId
     ORDER BY timestamp DESC
@@ -144,7 +144,7 @@ interface RecentlyPlayedDao {
   @Query(
     """
     SELECT DISTINCT playlistId, MAX(timestamp) as timestamp
-    FROM RecentlyPlayedEntity 
+    FROM RecentlyPlayedEntity
     WHERE playlistId IS NOT NULL
     GROUP BY playlistId
     ORDER BY timestamp DESC
@@ -158,7 +158,7 @@ interface RecentlyPlayedDao {
     val timestamp: Long,
   )
 
-  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY id DESC")
+  @Query("SELECT * FROM RecentlyPlayedEntity ORDER BY timestamp DESC, id DESC")
   suspend fun getAllRecentlyPlayed(): List<RecentlyPlayedEntity>
 
   @Query("SELECT COUNT(*) FROM RecentlyPlayedEntity")

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListViewModel.kt
@@ -20,6 +20,7 @@ import app.gyrolet.mpvrx.domain.media.model.Video
 import app.gyrolet.mpvrx.domain.playbackstate.repository.PlaybackStateRepository
 import app.gyrolet.mpvrx.repository.MediaFileRepository
 import app.gyrolet.mpvrx.ui.browser.base.BaseBrowserViewModel
+import app.gyrolet.mpvrx.ui.player.PlaybackIdentity
 import app.gyrolet.mpvrx.utils.media.MediaLibraryEvents
 import app.gyrolet.mpvrx.utils.media.MetadataRetrieval
 import app.gyrolet.mpvrx.utils.media.PlaybackStateEvents
@@ -45,8 +46,8 @@ data class VideoWithPlaybackInfo(
   val video: Video,
   val timeRemaining: Long? = null, // in seconds
   val progressPercentage: Float? = null, // 0.0 to 1.0
-  val isOldAndUnplayed: Boolean = false, // true if video is older than threshold and never played
-  val isWatched: Boolean = false, // true if video has any playback history
+  val isOldAndUnplayed: Boolean = false, // true while the NEW badge is eligible
+  val isWatched: Boolean = false, // true once the configured watched threshold is reached
 )
 
 class VideoListViewModel(
@@ -113,6 +114,8 @@ class VideoListViewModel(
       }
     }
 
+    // Playback persistence emits this event whenever a position/watched state is saved. Re-read
+    // the affected playback metadata so NEW/progress/watched UI updates without a hard refresh.
     viewModelScope.launch(Dispatchers.IO) {
       PlaybackStateEvents.changes.collectLatest {
         if (_videos.value.isNotEmpty()) {
@@ -236,11 +239,33 @@ class VideoListViewModel(
     _videosWereDeletedOrMoved.value = true
   }
 
+  /**
+   * PlayerActivity persists new playback rows with PlaybackIdentity.forUri(...). Older app
+   * versions used the display filename. Read the v2 key first and retain legacy fallbacks so
+   * existing histories continue to work without a destructive database migration.
+   */
+  private suspend fun findPlaybackState(video: Video): PlaybackStateEntity? {
+    val identifiers =
+      linkedSetOf(
+        PlaybackIdentity.forUri(video.uri.toString()),
+        PlaybackIdentity.forUri(video.path),
+        PlaybackIdentity.forUri("file://${video.path}"),
+        video.displayName,
+      )
+
+    for (identifier in identifiers) {
+      playbackStateRepository.getVideoDataByTitle(identifier)?.let { return it }
+    }
+    return null
+  }
+
+  private fun canonicalPlaybackIdentifier(video: Video): String = PlaybackIdentity.forUri(video.uri.toString())
+
   private suspend fun loadPlaybackInfo(videos: List<Video>) {
+    val watchedThreshold = browserPreferences.watchedThreshold.get()
     val videosWithInfo =
       videos.map { video ->
-        val playbackState = playbackStateRepository.getVideoDataByTitle(video.displayName)
-        val watchedThreshold = browserPreferences.watchedThreshold.get()
+        val playbackState = findPlaybackState(video)
 
         // Calculate watch progress (0.0 to 1.0)
         val progress =
@@ -296,7 +321,7 @@ class VideoListViewModel(
           item.copy(
             timeRemaining = if (watched) 0L else (video.duration / 1000L).coerceAtLeast(0L),
             progressPercentage = null,
-            isOldAndUnplayed = false,
+            isOldAndUnplayed = !watched,
             isWatched = watched,
           )
         } else {
@@ -307,16 +332,18 @@ class VideoListViewModel(
 
     viewModelScope.launch(Dispatchers.IO) {
       val durationSeconds = (video.duration / 1000L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+      val canonicalIdentifier = canonicalPlaybackIdentifier(video)
       runCatching {
-        val existing = playbackStateRepository.getVideoDataByTitle(video.displayName)
+        val existing = findPlaybackState(video)
         playbackStateRepository.upsert(
           (existing ?: emptyPlaybackState(video, durationSeconds)).copy(
+            mediaTitle = canonicalIdentifier,
             lastPosition = 0,
             timeRemaining = if (watched) 0 else durationSeconds,
             hasBeenWatched = watched,
           ),
         )
-        PlaybackStateEvents.notifyChanged(video.displayName)
+        PlaybackStateEvents.notifyChanged(canonicalIdentifier)
       }.onFailure { error ->
         Log.e(tag, "Failed to update watched state for ${video.displayName}", error)
         loadPlaybackInfo(_videos.value)
@@ -329,7 +356,7 @@ class VideoListViewModel(
     durationSeconds: Int,
   ): PlaybackStateEntity =
     PlaybackStateEntity(
-      mediaTitle = video.displayName,
+      mediaTitle = canonicalPlaybackIdentifier(video),
       lastPosition = 0,
       playbackSpeed = 1.0,
       sid = -1,
@@ -402,7 +429,7 @@ class VideoListViewModel(
     }
   }
 
-    companion object {
+  companion object {
     fun factory(
       application: Application,
       bucketId: String,

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/update/UpdateFeature.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/update/UpdateFeature.kt
@@ -60,6 +60,7 @@ import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -73,6 +74,11 @@ data class Release(
   @SerialName("body") val body: String,
   @SerialName("published_at") val publishedAt: String,
   @SerialName("assets") val assets: List<Asset>,
+  @SerialName("channel") val channel: String? = null,
+  @SerialName("commit_sha") val commitSha: String? = null,
+  @SerialName("commit_count") val commitCount: Int? = null,
+  @SerialName("run_number") val runNumber: Long? = null,
+  @SerialName("run_url") val runUrl: String? = null,
 )
 
 @Serializable
@@ -81,6 +87,7 @@ data class Asset(
   @SerialName("name") val name: String,
   @SerialName("size") val size: Long,
   @SerialName("content_type") val contentType: String,
+  @SerialName("sha256") val sha256: String? = null,
 )
 
 // --- Domain Manager ---
@@ -91,35 +98,48 @@ class UpdateManager(
   private val client = OkHttpClient()
   private val json = Json { ignoreUnknownKeys = true }
 
-  suspend fun checkForUpdate(forceShow: Boolean = false): Release? {
-    // Return null immediately if update feature is disabled (F-Droid flavor)
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return null
-    }
+  suspend fun checkForUpdate(
+    forceShow: Boolean = false,
+    includeBeta: Boolean = false,
+  ): Release? {
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return null
 
-    val release = getLatestRelease("https://api.github.com/repos/Riteshp2001/mpvRx/releases/latest")
-    val currentVersion = BuildConfig.VERSION_NAME.replace("-dev", "")
-    val remoteVersion = release.tagName.removePrefix("v")
+    val currentVersion = BuildConfig.VERSION_NAME.substringBefore('-')
     val prefs = context.getSharedPreferences("mpvrx_prefs", Context.MODE_PRIVATE)
     val ignoredVersion = prefs.getString("ignored_version", null)
 
-    // If this version was ignored, don't show it unless forced (manual check)
-    if (!forceShow && ignoredVersion == remoteVersion) {
-      return null
+    // Stable releases always have priority. Automatic checks intentionally stop here so beta
+    // builds are opt-in and never installed silently.
+    val stableResult = runCatching { getLatestRelease(STABLE_RELEASE_URL) }
+    val stableRelease = stableResult.getOrNull()
+    if (stableRelease != null) {
+      val remoteVersion = stableRelease.tagName.removePrefix("v")
+      val ignored = !forceShow && ignoredVersion == remoteVersion
+      if (!ignored && isNewerVersion(remoteVersion, currentVersion)) {
+        return stableRelease
+      }
     }
 
-    return if (isNewerVersion(remoteVersion, currentVersion)) {
-      release
-    } else {
-      null
+    if (includeBeta) {
+      val betaRelease = runCatching { getLatestRelease(BETA_RELEASE_URL) }.getOrNull()
+      if (betaRelease != null &&
+        isValidBetaManifest(betaRelease) &&
+        isBetaNewerThanCurrent(betaRelease) &&
+        (forceShow || ignoredVersion != betaRelease.tagName)
+      ) {
+        return betaRelease
+      }
     }
+
+    // Preserve the previous error behavior when GitHub itself is unavailable. A missing beta
+    // page is harmless before the first successful preview deployment and must not break stable
+    // update checks.
+    if (stableRelease == null) stableResult.getOrThrow()
+    return null
   }
 
   fun ignoreVersion(version: String) {
-    // No-op if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return
-    }
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return
 
     val prefs = context.getSharedPreferences("mpvrx_prefs", Context.MODE_PRIVATE)
     prefs
@@ -130,7 +150,12 @@ class UpdateManager(
 
   private suspend fun getLatestRelease(url: String): Release =
     withContext(Dispatchers.IO) {
-      val request = Request.Builder().url(url).build()
+      val request =
+        Request
+          .Builder()
+          .url(url)
+          .header("Cache-Control", "no-cache")
+          .build()
       client.newCall(request).execute().use { response ->
         if (!response.isSuccessful) throw IOException("Unexpected code $response")
         val responseBody = response.body.string()
@@ -154,49 +179,56 @@ class UpdateManager(
     return false
   }
 
-  fun downloadUpdate(release: Release): Flow<Float> {
-    // Return completed flow immediately if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return flowOf(100f)
+  private fun isValidBetaManifest(release: Release): Boolean {
+    if (release.channel != "beta") return false
+    if (!release.tagName.startsWith("beta-r")) return false
+    if ((release.commitCount ?: 0) <= 0) return false
+    if (release.assets.isEmpty()) return false
+
+    return release.assets.all { asset ->
+      asset.name.endsWith(".apk") &&
+        asset.downloadUrl.startsWith(BETA_DOWNLOAD_PREFIX) &&
+        asset.sha256?.matches(SHA256_REGEX) == true
     }
+  }
+
+  private fun isBetaNewerThanCurrent(release: Release): Boolean {
+    val betaCommitCount = release.commitCount ?: return false
+    return betaCommitCount > BuildConfig.GIT_COUNT
+  }
+
+  fun downloadUpdate(release: Release): Flow<Float> {
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return flowOf(100f)
 
     val asset =
       selectBestApkAsset(release.assets)
         ?: throw Exception("No compatible APK asset found")
 
     val destination = File(context.externalCacheDir, asset.name)
-    return downloadApk(asset.downloadUrl, destination)
+    return downloadApk(asset.downloadUrl, destination, asset.sha256)
   }
 
   private fun selectBestApkAsset(assets: List<Asset>): Asset? {
     val deviceArch = getDeviceArchitecture()
 
-    // First, try to find architecture-specific APK
     val archSpecificApk =
       assets.firstOrNull { asset ->
         asset.name.endsWith(".apk") && asset.name.contains(deviceArch, ignoreCase = true)
       }
 
-    if (archSpecificApk != null) {
-      return archSpecificApk
-    }
+    if (archSpecificApk != null) return archSpecificApk
 
-    // Fallback to universal APK
     val universalApk =
       assets.firstOrNull { asset ->
         asset.name.endsWith(".apk") && asset.name.contains("universal", ignoreCase = true)
       }
 
-    if (universalApk != null) {
-      return universalApk
-    }
+    if (universalApk != null) return universalApk
 
-    // Last resort: any APK
     return assets.firstOrNull { it.name.endsWith(".apk") }
   }
 
   private fun getDeviceArchitecture(): String {
-    // Get the primary ABI (Application Binary Interface)
     val primaryAbi =
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         Build.SUPPORTED_ABIS[0]
@@ -205,59 +237,90 @@ class UpdateManager(
         Build.CPU_ABI
       }
 
-    // Map Android ABI names to your APK naming convention
     return when (primaryAbi) {
       "arm64-v8a" -> "arm64-v8a"
       "armeabi-v7a" -> "armeabi-v7a"
       "x86" -> "x86"
       "x86_64" -> "x86_64"
-      else -> "universal" // Fallback for unknown architectures
+      else -> "universal"
     }
   }
 
   private fun downloadApk(
     url: String,
     destination: File,
+    expectedSha256: String?,
   ): Flow<Float> =
     flow {
-      val request = Request.Builder().url(url).build()
-      val response = client.newCall(request).execute()
-      if (!response.isSuccessful) throw IOException("Unexpected code $response")
-
-      val body = response.body
-      val contentLength = body.contentLength()
-      val inputStream = body.byteStream()
-      val outputStream = FileOutputStream(destination)
+      val partialFile = File("${destination.absolutePath}.part")
+      partialFile.delete()
 
       try {
-        val buffer = ByteArray(8 * 1024)
-        var bytesRead: Int
-        var totalBytesRead: Long = 0
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) throw IOException("Unexpected code $response")
 
-        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-          outputStream.write(buffer, 0, bytesRead)
-          totalBytesRead += bytesRead
-          val progress =
-            if (contentLength > 0) {
-              (totalBytesRead.toFloat() / contentLength.toFloat()) * 100
-            } else {
-              -1f
+          val body = response.body
+          val contentLength = body.contentLength()
+          body.byteStream().use { inputStream ->
+            FileOutputStream(partialFile).use { outputStream ->
+              val buffer = ByteArray(8 * 1024)
+              var bytesRead: Int
+              var totalBytesRead = 0L
+
+              while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                outputStream.write(buffer, 0, bytesRead)
+                totalBytesRead += bytesRead
+                val progress =
+                  if (contentLength > 0) {
+                    ((totalBytesRead.toFloat() / contentLength.toFloat()) * 99f).coerceAtMost(99f)
+                  } else {
+                    -1f
+                  }
+                emit(progress)
+              }
+              outputStream.flush()
             }
-          emit(progress)
+          }
         }
-        outputStream.flush()
+
+        if (!expectedSha256.isNullOrBlank()) {
+          val actualSha256 = calculateSha256(partialFile)
+          if (!actualSha256.equals(expectedSha256, ignoreCase = true)) {
+            throw IOException("Downloaded APK checksum does not match the published beta manifest")
+          }
+        }
+
+        if (destination.exists() && !destination.delete()) {
+          throw IOException("Could not replace cached APK")
+        }
+        if (!partialFile.renameTo(destination)) {
+          partialFile.copyTo(destination, overwrite = true)
+          partialFile.delete()
+        }
         emit(100f)
-      } finally {
-        inputStream.close()
-        outputStream.close()
+      } catch (error: Throwable) {
+        partialFile.delete()
+        destination.delete()
+        throw error
       }
     }.flowOn(Dispatchers.IO)
 
-  fun getApkFile(release: Release): File? {
-    // Return null if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return null
+  private fun calculateSha256(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().buffered().use { input ->
+      val buffer = ByteArray(16 * 1024)
+      while (true) {
+        val read = input.read(buffer)
+        if (read <= 0) break
+        digest.update(buffer, 0, read)
+      }
     }
+    return digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+  }
+
+  fun getApkFile(release: Release): File? {
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return null
 
     val asset = selectBestApkAsset(release.assets) ?: return null
     val file = File(context.externalCacheDir, asset.name)
@@ -265,14 +328,18 @@ class UpdateManager(
   }
 
   fun clearCache() {
-    // No-op if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return
-    }
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return
 
     context.externalCacheDir?.listFiles()?.forEach {
-      if (it.name.endsWith(".apk")) it.delete()
+      if (it.name.endsWith(".apk") || it.name.endsWith(".apk.part")) it.delete()
     }
+  }
+
+  private companion object {
+    const val STABLE_RELEASE_URL = "https://api.github.com/repos/Riteshp2001/mpvRx/releases/latest"
+    const val BETA_RELEASE_URL = "https://riteshp2001.github.io/mpvRx/latest.json"
+    const val BETA_DOWNLOAD_PREFIX = "https://riteshp2001.github.io/mpvRx/downloads/"
+    val SHA256_REGEX = Regex("^[a-fA-F0-9]{64}$")
   }
 }
 
@@ -300,10 +367,7 @@ class UpdateViewModel(
   val isAutoUpdateEnabled: StateFlow<Boolean> = _isAutoUpdateEnabled.asStateFlow()
 
   fun toggleAutoUpdate(enabled: Boolean) {
-    // No-op if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return
-    }
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return
 
     prefs.edit().putBoolean("auto_update", enabled).apply()
     _isAutoUpdateEnabled.value = enabled
@@ -313,14 +377,8 @@ class UpdateViewModel(
   }
 
   init {
-    // Only initialize auto-update if feature is enabled.
-    // The network check is deferred by a short delay so that it does not
-    // race with first-frame composition of the main UI. Previously the
-    // check fired synchronously inside the init block of the ViewModel,
-    // which is itself constructed during the very first Compose
-    // composition in MainActivity.Navigator() -- meaning the OkHttp
-    // client + GitHub API call competed with cold-start rendering.
-    // See issue 1.5 in the startup audit.
+    // Automatic startup checks intentionally remain stable-only. Beta is only considered after a
+    // manual check from About so users never opt into preview builds by accident.
     if (BuildConfig.ENABLE_UPDATE_FEATURE && isAutoUpdateEnabled.value) {
       viewModelScope.launch {
         kotlinx.coroutines.delay(UPDATE_CHECK_STARTUP_DELAY_MS)
@@ -330,12 +388,6 @@ class UpdateViewModel(
   }
 
   private companion object {
-    /**
-     * Delay before the auto-update network check fires after the
-     * UpdateViewModel is constructed. Long enough to let the first frame
-     * draw and the main navigation settle, short enough that the update
-     * dialog (if any) still appears within a few seconds of cold start.
-     */
     private const val UPDATE_CHECK_STARTUP_DELAY_MS = 1500L
   }
 
@@ -362,15 +414,16 @@ class UpdateViewModel(
   }
 
   fun checkForUpdate(manual: Boolean = false) {
-    // No-op if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return
-    }
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return
 
     viewModelScope.launch {
       _updateState.value = UpdateState.Loading
       try {
-        val release = updateManager.checkForUpdate(forceShow = manual)
+        val release =
+          updateManager.checkForUpdate(
+            forceShow = manual,
+            includeBeta = manual,
+          )
         if (release != null) {
           val existingFile = updateManager.getApkFile(release)
           if (existingFile != null) {
@@ -397,10 +450,7 @@ class UpdateViewModel(
   }
 
   fun downloadUpdate(release: Release) {
-    // No-op if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return
-    }
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return
 
     viewModelScope.launch {
       _isDownloading.value = true
@@ -419,10 +469,7 @@ class UpdateViewModel(
   }
 
   fun installUpdate(release: Release) {
-    // No-op if update feature is disabled
-    if (!BuildConfig.ENABLE_UPDATE_FEATURE) {
-      return
-    }
+    if (!BuildConfig.ENABLE_UPDATE_FEATURE) return
 
     val file = updateManager.getApkFile(release) ?: return
     val context = getApplication<Application>()
@@ -442,7 +489,6 @@ class UpdateViewModel(
   }
 
   fun dismiss() {
-    // Clean up downloaded APK when user dismisses the dialog
     updateManager.clearCache()
     _updateState.value = UpdateState.Idle
   }
@@ -468,15 +514,14 @@ fun UpdateDialog(
 ) {
   val downloadSize = release.assets.find { it.name.endsWith(".apk") }?.size ?: 0L
   val formattedDate = formatDate(release.publishedAt)
+  val isBeta = release.channel == "beta" || release.tagName.startsWith("beta-r")
 
   AlertDialog(
     onDismissRequest = onDismiss,
     icon = {
       Icon(
         imageVector =
-          if (actionLabel ==
-            "Install"
-          ) {
+          if (actionLabel == "Install") {
             Icons.RoundedFilled.SystemUpdate
           } else {
             Icons.RoundedFilled.CloudDownload
@@ -488,12 +533,18 @@ fun UpdateDialog(
     title = {
       Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
-          text = if (actionLabel == "Install") "Ready to Install" else "Update Available",
+          text =
+            when {
+              actionLabel == "Install" && isBeta -> "Beta Ready to Install"
+              actionLabel == "Install" -> "Ready to Install"
+              isBeta -> "Beta Build Available"
+              else -> "Update Available"
+            },
           style = MaterialTheme.typography.titleLarge,
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-          text = release.tagName.removePrefix("v"),
+          text = if (isBeta) release.name else release.tagName.removePrefix("v"),
           style = MaterialTheme.typography.titleMedium,
           color = MaterialTheme.colorScheme.primary,
         )
@@ -507,10 +558,16 @@ fun UpdateDialog(
             .verticalScroll(rememberScrollState()),
       ) {
         if (actionLabel != "Install") {
-          // Show version info for update available state
           InfoRow(label = "Current Version", value = currentVersion)
-          InfoRow(label = "Latest Version", value = release.tagName.removePrefix("v"))
-          InfoRow(label = "Release Date", value = formattedDate)
+          if (isBeta) {
+            InfoRow(label = "Channel", value = "GitHub Actions Beta")
+            release.commitCount?.let { InfoRow(label = "Build", value = "r$it") }
+            release.commitSha?.let { InfoRow(label = "Commit", value = it.take(7)) }
+            release.runNumber?.let { InfoRow(label = "Actions Run", value = "#$it") }
+          } else {
+            InfoRow(label = "Latest Version", value = release.tagName.removePrefix("v"))
+          }
+          InfoRow(label = "Build Date", value = formattedDate)
           InfoRow(label = "Size", value = formatFileSize(downloadSize))
         }
 
@@ -545,9 +602,7 @@ fun UpdateDialog(
       if (!isDownloading) {
         Button(onClick = onAction) {
           Text(
-            if (actionLabel ==
-              "Install"
-            ) {
+            if (actionLabel == "Install") {
               stringResource(R.string.ui_install)
             } else {
               stringResource(R.string.ui_download)
@@ -613,7 +668,6 @@ private fun formatFileSize(size: Long): String {
 
 private fun formatDate(dateString: String): String {
   return try {
-    // GitHub API returns ISO 8601 format: "2024-01-15T10:30:00Z"
     val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
     inputFormat.timeZone = TimeZone.getTimeZone("UTC")
     val date = inputFormat.parse(dateString) ?: return dateString

--- a/preview-site/index.html
+++ b/preview-site/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="theme-color" content="#0b0d12">
+  <meta name="description" content="Official mpvRx beta builds produced by the latest successful GitHub Actions CI run on master.">
+  <title>mpvRx Beta Builds</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #090b10;
+      --surface: #10131a;
+      --surface-2: #151923;
+      --line: rgba(255,255,255,.09);
+      --text: #f5f7fb;
+      --muted: #9aa3b2;
+      --soft: #c9d0dc;
+      --accent: #8ba9ff;
+      --accent-2: #b5c7ff;
+      --ok: #72d6a4;
+      --warn: #f3c77a;
+      --shadow: 0 24px 80px rgba(0,0,0,.32);
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 18% -10%, rgba(109,142,255,.16), transparent 34rem),
+        radial-gradient(circle at 88% 14%, rgba(106,214,164,.08), transparent 26rem),
+        var(--bg);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a { color: inherit; }
+    .shell { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
+
+    .topbar {
+      height: 76px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .brand { display: flex; align-items: center; gap: 12px; font-weight: 720; letter-spacing: -.02em; }
+    .mark {
+      width: 38px; height: 38px; border-radius: 11px;
+      display: grid; place-items: center;
+      background: linear-gradient(145deg, #eef3ff, #98b2ff);
+      color: #111522; font-weight: 900; letter-spacing: -.08em;
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,.5);
+    }
+    .brand small { display: block; color: var(--muted); font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; margin-top: 1px; }
+
+    .repo-link {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 9px 12px; border-radius: 10px; border: 1px solid var(--line);
+      text-decoration: none; color: var(--soft); background: rgba(255,255,255,.025);
+      font-size: 13px; font-weight: 650;
+    }
+    .repo-link:hover { border-color: rgba(255,255,255,.18); color: var(--text); }
+
+    .hero { padding: 84px 0 42px; display: grid; grid-template-columns: 1.2fr .8fr; gap: 56px; align-items: end; }
+    .eyebrow { display: flex; gap: 10px; align-items: center; color: var(--accent-2); font-size: 12px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
+    .status-dot { width: 8px; height: 8px; border-radius: 99px; background: var(--ok); box-shadow: 0 0 0 5px rgba(114,214,164,.09); }
+    h1 { font-size: clamp(42px, 7vw, 82px); line-height: .98; letter-spacing: -.055em; margin: 18px 0 22px; max-width: 780px; }
+    .lead { color: var(--muted); font-size: clamp(16px, 2vw, 19px); line-height: 1.65; max-width: 670px; margin: 0; }
+
+    .build-panel {
+      background: linear-gradient(180deg, rgba(255,255,255,.045), rgba(255,255,255,.018));
+      border: 1px solid var(--line); border-radius: 22px; padding: 22px; box-shadow: var(--shadow);
+    }
+    .panel-label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .11em; font-weight: 800; }
+    .build-id { font-size: 30px; font-weight: 800; letter-spacing: -.035em; margin: 8px 0 18px; }
+    .meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .meta { padding: 12px; background: rgba(0,0,0,.18); border: 1px solid rgba(255,255,255,.055); border-radius: 12px; min-width: 0; }
+    .meta span { display:block; color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; font-weight: 750; margin-bottom: 5px; }
+    .meta strong { display:block; font-size: 13px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+    .section-head { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin: 34px 0 18px; }
+    h2 { margin: 0; font-size: 25px; letter-spacing: -.03em; }
+    .section-head p { margin: 0; color: var(--muted); font-size: 13px; }
+
+    .arch-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 14px; }
+    .arch-card {
+      min-height: 224px; padding: 20px; border: 1px solid var(--line); border-radius: 18px;
+      background: linear-gradient(180deg, var(--surface-2), var(--surface));
+      display: flex; flex-direction: column; transition: transform .18s ease, border-color .18s ease, background .18s ease;
+    }
+    .arch-card:hover { transform: translateY(-2px); border-color: rgba(139,169,255,.34); background: #151a25; }
+    .arch-card.recommended { border-color: rgba(139,169,255,.33); }
+    .card-top { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+    .chip-icon { width: 42px; height: 42px; border-radius: 12px; display:grid; place-items:center; background: rgba(139,169,255,.09); color: var(--accent-2); border: 1px solid rgba(139,169,255,.14); }
+    .badge { font-size: 10px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; color: var(--accent-2); padding: 6px 8px; border-radius: 999px; background: rgba(139,169,255,.09); border: 1px solid rgba(139,169,255,.13); }
+    .arch-card h3 { font-size: 18px; margin: 15px 0 4px; letter-spacing: -.02em; }
+    .abi { color: var(--accent-2); font: 600 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .desc { color: var(--muted); font-size: 13px; line-height: 1.55; margin: 10px 0 18px; min-height: 40px; }
+    .file-meta { display:flex; justify-content:space-between; gap:10px; color: var(--muted); font-size: 11px; margin-top:auto; margin-bottom:12px; }
+    .download {
+      width:100%; display:flex; align-items:center; justify-content:center; gap:8px; padding:11px 12px;
+      border-radius:11px; background:#edf2ff; color:#121621; text-decoration:none; font-size:13px; font-weight:800;
+    }
+    .download:hover { background:#fff; }
+    .download[aria-disabled="true"] { opacity:.45; pointer-events:none; }
+
+    .trust {
+      margin: 16px 0 56px; padding: 18px 20px; border:1px solid var(--line); border-radius:16px;
+      display:flex; gap:16px; align-items:flex-start; background:rgba(255,255,255,.018);
+    }
+    .trust svg { flex:0 0 auto; color:var(--ok); margin-top:2px; }
+    .trust strong { display:block; font-size:13px; margin-bottom:4px; }
+    .trust p { margin:0; color:var(--muted); font-size:12px; line-height:1.55; }
+
+    footer { border-top:1px solid var(--line); padding:28px 0 42px; color:var(--muted); font-size:12px; }
+    .footer-row { display:flex; justify-content:space-between; gap:20px; align-items:center; }
+    .warning { color:var(--warn); }
+
+    .skeleton { animation: pulse 1.4s ease-in-out infinite; color: transparent !important; border-radius: 5px; background: rgba(255,255,255,.08); }
+    @keyframes pulse { 50% { opacity:.5; } }
+
+    @media (max-width: 900px) {
+      .hero { grid-template-columns:1fr; gap:28px; padding-top:58px; }
+      .arch-grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
+    }
+    @media (max-width: 620px) {
+      .shell { width:min(100% - 24px,1180px); }
+      .topbar { height:66px; }
+      .repo-link span { display:none; }
+      .hero { padding-top:44px; }
+      .arch-grid { grid-template-columns:1fr; }
+      .section-head, .footer-row { align-items:flex-start; flex-direction:column; }
+      .meta-grid { grid-template-columns:1fr 1fr; }
+      .arch-card { min-height:0; }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header class="topbar">
+      <div class="brand">
+        <div class="mark" aria-hidden="true">Rx</div>
+        <div>mpvRx<small>Preview Channel</small></div>
+      </div>
+      <a class="repo-link" href="https://github.com/Riteshp2001/mpvRx" target="_blank" rel="noreferrer">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .7a11.5 11.5 0 0 0-3.64 22.41c.58.1.79-.25.79-.56v-2.23c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.72 1.27 3.39.97.1-.75.4-1.27.74-1.56-2.57-.29-5.27-1.28-5.27-5.68 0-1.26.45-2.29 1.19-3.09-.12-.29-.52-1.47.11-3.05 0 0 .97-.31 3.16 1.18a10.94 10.94 0 0 1 5.75 0c2.19-1.49 3.16-1.18 3.16-1.18.63 1.58.23 2.76.11 3.05.74.8 1.19 1.83 1.19 3.09 0 4.41-2.7 5.38-5.28 5.67.42.36.79 1.06.79 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z"/></svg>
+        <span>View repository</span>
+      </a>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div>
+          <div class="eyebrow"><span class="status-dot"></span> Latest successful CI build</div>
+          <h1>Beta builds,<br>without the guesswork.</h1>
+          <p class="lead">Every APK here is produced from the latest successful <strong>master</strong> CI/CD run, signed by the project workflow, published with its architecture, and accompanied by a SHA-256 checksum.</p>
+        </div>
+
+        <aside class="build-panel" aria-label="Latest build information">
+          <div class="panel-label">Current beta</div>
+          <div id="build-id" class="build-id skeleton">r0000</div>
+          <div class="meta-grid">
+            <div class="meta"><span>Commit</span><strong id="commit" class="skeleton">0000000</strong></div>
+            <div class="meta"><span>Actions run</span><strong id="run" class="skeleton">#0000</strong></div>
+            <div class="meta"><span>Published</span><strong id="published" class="skeleton">Aug 12, 2026</strong></div>
+            <div class="meta"><span>Channel</span><strong>Beta · Master</strong></div>
+          </div>
+        </aside>
+      </section>
+
+      <section aria-labelledby="downloads-title">
+        <div class="section-head">
+          <div><h2 id="downloads-title">Choose your architecture</h2></div>
+          <p>Not sure? Use <strong>Universal</strong>. Modern phones usually use <strong>arm64-v8a</strong>.</p>
+        </div>
+        <div id="architectures" class="arch-grid" aria-live="polite"></div>
+      </section>
+
+      <div class="trust">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 3 5 6v5c0 4.55 2.94 8.66 7 10 4.06-1.34 7-5.45 7-10V6l-7-3Z" stroke="currentColor" stroke-width="1.7"/><path d="m8.7 12.1 2.1 2.1 4.6-4.7" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <div><strong>Integrity checked before install</strong><p>The published manifest includes a SHA-256 digest for every APK. mpvRx verifies that digest after download; a mismatched or incomplete beta APK is deleted instead of being offered for installation.</p></div>
+      </div>
+    </main>
+
+    <footer>
+      <div class="footer-row">
+        <span>mpvRx Preview Channel · Generated by GitHub Actions</span>
+        <span class="warning">Beta builds may be unstable. Stable releases remain the default update channel.</span>
+      </div>
+    </footer>
+  </div>
+
+  <script>
+    const catalogue = [
+      { abi: 'arm64-v8a', title: 'ARM 64-bit', badge: 'Recommended', desc: 'Best choice for most modern Android phones, tablets and TVs.' },
+      { abi: 'universal', title: 'Universal', badge: 'Safest choice', desc: 'Includes every supported native architecture. Larger download, widest compatibility.' },
+      { abi: 'armeabi-v7a', title: 'ARM 32-bit', badge: 'Legacy ARM', desc: 'For older 32-bit ARM Android devices that cannot install arm64 builds.' },
+      { abi: 'x86_64', title: 'x86 64-bit', badge: 'Emulator / x86', desc: 'For 64-bit x86 Android emulators, ChromeOS or compatible x86 devices.' },
+      { abi: 'x86', title: 'x86 32-bit', badge: 'Legacy x86', desc: 'For older 32-bit x86 Android environments and emulators.' }
+    ];
+
+    const chipIcon = (label) => `
+      <div class="chip-icon" aria-hidden="true">
+        <svg width="23" height="23" viewBox="0 0 24 24" fill="none">
+          <rect x="6" y="6" width="12" height="12" rx="2.4" stroke="currentColor" stroke-width="1.6"/>
+          <path d="M9 2.8v3.1M12 2.8v3.1M15 2.8v3.1M9 18.1v3.1M12 18.1v3.1M15 18.1v3.1M2.8 9h3.1M2.8 12h3.1M2.8 15h3.1M18.1 9h3.1M18.1 12h3.1M18.1 15h3.1" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+          <text x="12" y="14.1" text-anchor="middle" fill="currentColor" font-size="5.3" font-family="system-ui" font-weight="800">${label}</text>
+        </svg>
+      </div>`;
+
+    const formatBytes = (bytes) => {
+      if (!Number.isFinite(bytes) || bytes <= 0) return 'Unknown size';
+      const units = ['B','KB','MB','GB'];
+      const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+      return `${(bytes / Math.pow(1024, i)).toFixed(i ? 1 : 0)} ${units[i]}`;
+    };
+
+    function renderCard(info, asset) {
+      const card = document.createElement('article');
+      card.className = `arch-card${info.abi === 'arm64-v8a' ? ' recommended' : ''}`;
+      const iconLabel = info.abi === 'universal' ? 'ALL' : info.abi.includes('64') ? '64' : '32';
+      const checksum = asset?.sha256 ? asset.sha256.slice(0, 12) + '…' : 'Pending';
+      card.innerHTML = `
+        <div class="card-top">${chipIcon(iconLabel)}<span class="badge"></span></div>
+        <h3></h3><div class="abi"></div><p class="desc"></p>
+        <div class="file-meta"><span class="size"></span><span class="checksum"></span></div>
+        <a class="download" aria-disabled="true">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 20h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          Download APK
+        </a>`;
+      card.querySelector('.badge').textContent = info.badge;
+      card.querySelector('h3').textContent = info.title;
+      card.querySelector('.abi').textContent = info.abi;
+      card.querySelector('.desc').textContent = info.desc;
+      card.querySelector('.size').textContent = asset ? formatBytes(asset.size) : 'Not available';
+      card.querySelector('.checksum').textContent = `SHA ${checksum}`;
+      const link = card.querySelector('.download');
+      if (asset?.browser_download_url) {
+        link.href = asset.browser_download_url;
+        link.setAttribute('download', asset.name || '');
+        link.removeAttribute('aria-disabled');
+      }
+      return card;
+    }
+
+    async function loadBuild() {
+      const container = document.getElementById('architectures');
+      try {
+        const response = await fetch(`latest.json?t=${Date.now()}`, { cache: 'no-store' });
+        if (!response.ok) throw new Error(`Manifest request failed: ${response.status}`);
+        const release = await response.json();
+        if (release.channel !== 'beta' || !Array.isArray(release.assets)) throw new Error('Invalid beta manifest');
+
+        document.getElementById('build-id').textContent = `r${release.commit_count}`;
+        document.getElementById('commit').textContent = String(release.commit_sha || '').slice(0, 7) || 'Unknown';
+        const run = document.getElementById('run');
+        run.textContent = `#${release.run_number || '—'}`;
+        if (release.run_url) {
+          const link = document.createElement('a');
+          link.href = release.run_url;
+          link.target = '_blank';
+          link.rel = 'noreferrer';
+          link.textContent = run.textContent;
+          link.style.textDecoration = 'none';
+          run.replaceChildren(link);
+        }
+        document.getElementById('published').textContent = new Date(release.published_at).toLocaleString(undefined, { year:'numeric', month:'short', day:'numeric', hour:'2-digit', minute:'2-digit' });
+        document.querySelectorAll('.skeleton').forEach(el => el.classList.remove('skeleton'));
+
+        const byAbi = new Map(release.assets.map(asset => [asset.abi, asset]));
+        container.replaceChildren(...catalogue.map(info => renderCard(info, byAbi.get(info.abi))));
+      } catch (error) {
+        console.error(error);
+        document.getElementById('build-id').textContent = 'Unavailable';
+        document.getElementById('commit').textContent = '—';
+        document.getElementById('run').textContent = '—';
+        document.getElementById('published').textContent = 'Deployment pending';
+        document.querySelectorAll('.skeleton').forEach(el => el.classList.remove('skeleton'));
+        container.replaceChildren(...catalogue.map(info => renderCard(info, null)));
+      }
+    }
+
+    loadBuild();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix NEW/watched state refresh by resolving playback history with the same v2 media identity used by PlayerActivity, while keeping legacy filename/path fallbacks
- fix current/recently-played italic marker by ordering replayed history by timestamp rather than immutable row id
- add an opt-in beta update path to the existing updater with architecture selection and SHA-256 verification
- mark preview builds as `mpvRx Beta` and give them `-beta.r<commit-count>` build identities
- rebuild CI/release/preview workflows with deterministic full-history checkouts and current GitHub Actions majors
- publish the latest successful `master` CI build to a professional GitHub Pages beta download hub with per-architecture APKs, metadata, checksums, and Actions provenance

## Beta safety / provenance
- automatic update checks remain stable-only
- beta builds are considered only from a manual update check
- preview publishing only runs after a successful `CI/CD Build` push on `master`
- the preview workflow checks out the exact successful workflow SHA
- unsigned/missing-architecture preview builds are refused
- downloaded beta APKs are verified against the Pages manifest SHA-256 before install

## Validation
- branch is exactly one commit ahead of `master`
- expected change set: 9 files only
- CI will validate the Android build and workflow-facing source changes on this PR
