### PR TITLE
feat(preferences): add unified audio and video folder blacklisting

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/FoldersPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/FoldersPreferences.kt
@@ -11,6 +11,12 @@ package app.gyrolet.mpvrx.preferences
 
 import app.gyrolet.mpvrx.preferences.preference.PreferenceStore
 
+enum class BlacklistScope {
+  BOTH,
+  VIDEO_ONLY,
+  AUDIO_ONLY
+}
+
 /**
  * Preferences for folder management
  */
@@ -20,11 +26,53 @@ class FoldersPreferences(
   // Root folder from which all app storage paths are derived
   val baseStorageFolder = preferenceStore.getString("base_storage_folder", "")
 
-  // Set of folder paths that should be hidden from the folder list
+  // Set of folder paths that should be hidden from the video folder list
   val blacklistedFolders = preferenceStore.getStringSet("blacklisted_folders", emptySet())
+  // Set of folder paths that should be hidden from the audio/music library
+  val blacklistedAudioFolders = preferenceStore.getStringSet("blacklisted_audio_folders", emptySet())
   val pinnedFolders = preferenceStore.getStringSet("pinned_folders", emptySet())
   val includeNoMediaFolders = preferenceStore.getBoolean("include_nomedia_folders", false)
 
   // Dedicated folder where downloaded movies are stored
   val movieFolder = preferenceStore.getString("movie_folder", "")
+
+  fun addBlacklistedFolders(paths: Set<String>, scope: BlacklistScope) {
+    val currentVideo = blacklistedFolders.get().toMutableSet()
+    val currentAudio = blacklistedAudioFolders.get().toMutableSet()
+    when (scope) {
+      BlacklistScope.BOTH -> {
+        currentVideo.addAll(paths)
+        currentAudio.addAll(paths)
+      }
+      BlacklistScope.VIDEO_ONLY -> {
+        currentVideo.addAll(paths)
+        currentAudio.removeAll(paths)
+      }
+      BlacklistScope.AUDIO_ONLY -> {
+        currentAudio.addAll(paths)
+        currentVideo.removeAll(paths)
+      }
+    }
+    blacklistedFolders.set(currentVideo)
+    blacklistedAudioFolders.set(currentAudio)
+  }
+
+  fun removeBlacklistedFolder(path: String) {
+    val currentVideo = blacklistedFolders.get().toMutableSet().apply { remove(path) }
+    val currentAudio = blacklistedAudioFolders.get().toMutableSet().apply { remove(path) }
+    blacklistedFolders.set(currentVideo)
+    blacklistedAudioFolders.set(currentAudio)
+  }
+
+  fun removeBlacklistedFolders(paths: Set<String>) {
+    val currentVideo = blacklistedFolders.get().toMutableSet().apply { removeAll(paths) }
+    val currentAudio = blacklistedAudioFolders.get().toMutableSet().apply { removeAll(paths) }
+    blacklistedFolders.set(currentVideo)
+    blacklistedAudioFolders.set(currentAudio)
+  }
+
+  fun clearAllBlacklistedFolders() {
+    blacklistedFolders.set(emptySet())
+    blacklistedAudioFolders.set(emptySet())
+  }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
@@ -660,11 +660,9 @@ object FolderListScreen : Screen {
               onBlacklistClick = {
                 coroutineScope.launch {
                   val selectedFolders = selectionManager.getSelectedItems()
-                  val blacklistedFolders = foldersPreferences.blacklistedFolders.get().toMutableSet()
-                  selectedFolders.forEach { folder ->
-                    blacklistedFolders.add(folder.path)
-                  }
-                  foldersPreferences.blacklistedFolders.set(blacklistedFolders)
+                  val paths = selectedFolders.map { it.path }.toSet()
+                  val scope = if (audioOnly) app.gyrolet.mpvrx.preferences.BlacklistScope.AUDIO_ONLY else app.gyrolet.mpvrx.preferences.BlacklistScope.VIDEO_ONLY
+                  foldersPreferences.addBlacklistedFolders(paths, scope)
                   selectionManager.clear()
                   viewModel.refresh()
                   android.widget.Toast

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListViewModel.kt
@@ -124,10 +124,21 @@ class FolderListViewModel(
       }
     }
 
-    // Filter folders based on blacklist
+    // Filter folders based on blacklist (video vs audio scope)
+    val blacklistFlow = if (audioOnly) {
+      foldersPreferences.blacklistedAudioFolders.changes()
+    } else {
+      foldersPreferences.blacklistedFolders.changes()
+    }
+
     viewModelScope.launch {
-      combine(_allVideoFolders, foldersPreferences.blacklistedFolders.changes()) { folders, blacklist ->
-        folders.filter { folder -> folder.path !in blacklist }
+      combine(_allVideoFolders, blacklistFlow) { folders, blacklist ->
+        folders.filter { folder ->
+          blacklist.none { blacklisted ->
+            folder.path.equals(blacklisted, ignoreCase = true) ||
+              folder.path.startsWith(if (blacklisted.endsWith("/")) blacklisted else "$blacklisted/", ignoreCase = true)
+          }
+        }
       }.collectLatest { filteredFolders ->
         // Check if folders became empty after having folders
         if (previousFolderCount > 0 && filteredFolders.isEmpty()) {
@@ -370,7 +381,6 @@ class FolderListViewModel(
                 minimumAudioDurationSeconds = browserPreferences.minimumAudioDurationSeconds.get(),
               )
             _allVideoFolders.value = folders
-            _videoFolders.value = folders
             _isLoading.value = false
             _hasCompletedInitialLoad.value = true
           } catch (e: Exception) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryContent.kt
@@ -187,6 +187,7 @@ fun MusicLibraryContent(
   val isPlaybackActive by musicViewModel.isPlaybackActive.collectAsState()
 
   val browserPreferences = koinInject<BrowserPreferences>()
+  val foldersPreferences = koinInject<app.gyrolet.mpvrx.preferences.FoldersPreferences>()
   val coverArtSizeDp by browserPreferences.musicCoverArtSize.collectAsState()
 
   val isRefreshing = remember { mutableStateOf(false) }
@@ -418,7 +419,19 @@ fun MusicLibraryContent(
                 }
               },
               onPinClick = null,
-              onBlacklistClick = null,
+              onBlacklistClick = {
+                val selectedItems = activeSelectionManager.getSelectedItems()
+                val selectedPaths = selectedItems.mapNotNull { item ->
+                  when (item) {
+                    is MusicSong -> java.io.File(item.path).parent
+                    else -> null
+                  }
+                }.toSet()
+                if (selectedPaths.isNotEmpty()) {
+                  foldersPreferences.addBlacklistedFolders(selectedPaths, app.gyrolet.mpvrx.preferences.BlacklistScope.AUDIO_ONLY)
+                  activeSelectionManager.clear()
+                }
+              },
               onRenameClick = null,
               isSingleSelection = activeSelectionManager.isSingleSelection,
               onInfoClick = null,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
@@ -32,6 +32,7 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
   private val playlistRepository: PlaylistRepository by inject()
   private val browserPreferences: app.gyrolet.mpvrx.preferences.BrowserPreferences by inject()
   private val audioPreferences: app.gyrolet.mpvrx.preferences.AudioPreferences by inject()
+  private val foldersPreferences: app.gyrolet.mpvrx.preferences.FoldersPreferences by inject()
 
   val visibleTabs: StateFlow<List<MusicTab>> = combine(
     audioPreferences.musicTabOrder.changes(),
@@ -95,10 +96,14 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
 
   init {
     viewModelScope.launch {
-      browserPreferences.minimumAudioDurationSeconds
-        .changes()
+      combine(
+        browserPreferences.minimumAudioDurationSeconds.changes(),
+        foldersPreferences.blacklistedAudioFolders.changes()
+      ) { minimumSeconds, blacklist ->
+        Pair(minimumSeconds, blacklist)
+      }
         .distinctUntilChanged()
-        .collect { minimumSeconds -> applyDurationFilter(minimumSeconds) }
+        .collect { (minimumSeconds, blacklist) -> applyFilters(minimumSeconds, blacklist) }
     }
   }
 
@@ -164,7 +169,10 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
     _isLoading.value = true
     try {
       _allSongs.value = MusicLibraryScanner.scanSongs(context)
-      applyDurationFilter(browserPreferences.minimumAudioDurationSeconds.get())
+      applyFilters(
+        browserPreferences.minimumAudioDurationSeconds.get(),
+        foldersPreferences.blacklistedAudioFolders.get()
+      )
     } catch (e: Exception) {
       e.printStackTrace()
     } finally {
@@ -175,15 +183,18 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
   /**
    * Minimum duration is a lower bound only. There is intentionally no upper bound: if the user
    * selects 30 seconds, every 30s, 3min, 30min, or multi-hour audio file remains in the library.
+   * Also filters out songs whose path starts with any blacklisted audio folder path.
    */
-  private fun applyDurationFilter(minimumSeconds: Int) {
+  private fun applyFilters(minimumSeconds: Int, blacklist: Set<String>) {
     val minimumMs = minimumSeconds.coerceAtLeast(0).toLong() * 1000L
-    val visibleSongs =
-      if (minimumMs == 0L) {
-        _allSongs.value
-      } else {
-        _allSongs.value.filter { song -> song.durationMs >= minimumMs }
+    val visibleSongs = _allSongs.value.filter { song ->
+      val meetsDuration = (minimumMs == 0L || song.durationMs >= minimumMs)
+      val isNotBlacklisted = blacklist.none { folderPath ->
+        song.path.equals(folderPath, ignoreCase = true) ||
+          song.path.startsWith(if (folderPath.endsWith("/")) folderPath else "$folderPath/", ignoreCase = true)
       }
+      meetsDuration && isNotBlacklisted
+    }
 
     _songs.value = visibleSongs
     _albums.value = buildAlbums(visibleSongs)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/FoldersPreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/FoldersPreferencesScreen.kt
@@ -56,6 +56,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.domain.media.model.VideoFolder
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.RadioButton
+import app.gyrolet.mpvrx.preferences.BlacklistScope
 import app.gyrolet.mpvrx.preferences.FoldersPreferences
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.presentation.Screen
@@ -83,7 +87,8 @@ object FoldersPreferencesScreen : Screen {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
-    val blacklistedFolders by preferences.blacklistedFolders.collectAsState()
+    val blacklistedVideoFolders by preferences.blacklistedFolders.collectAsState()
+    val blacklistedAudioFolders by preferences.blacklistedAudioFolders.collectAsState()
     val includeNoMediaFolders by preferences.includeNoMediaFolders.collectAsState()
     var availableFolders by remember { mutableStateOf<List<VideoFolder>>(emptyList()) }
     var showAddDialog by remember { mutableStateOf(false) }
@@ -91,7 +96,9 @@ object FoldersPreferencesScreen : Screen {
     var selectionState by remember { mutableStateOf(SelectionState<String>()) }
     var showClearAllDialog by remember { mutableStateOf(false) }
 
-    val blacklistedFoldersList = remember(blacklistedFolders) { blacklistedFolders.toList() }
+    val allBlacklistedFolders = remember(blacklistedVideoFolders, blacklistedAudioFolders) {
+      (blacklistedVideoFolders + blacklistedAudioFolders).toList().sorted()
+    }
 
     Scaffold(
       topBar = {
@@ -101,7 +108,7 @@ object FoldersPreferencesScreen : Screen {
           forceHeadlineSmall = true,
           isInSelectionMode = selectionState.isInSelectionMode,
           selectedCount = selectionState.selectedCount,
-          totalCount = blacklistedFoldersList.size,
+          totalCount = allBlacklistedFolders.size,
           onCancelSelection = { selectionState = selectionState.clear() },
           onBackClick =
             if (LocalShowSettingsBackArrow.current) {
@@ -110,18 +117,14 @@ object FoldersPreferencesScreen : Screen {
               null
             },
           onDeleteClick = {
-            val updated =
-              blacklistedFolders.toMutableSet().apply {
-                removeAll(selectionState.selectedIds)
-              }
-            preferences.blacklistedFolders.set(updated)
+            preferences.removeBlacklistedFolders(selectionState.selectedIds)
             selectionState = selectionState.clear()
           },
-          onSelectAll = { selectionState = selectionState.selectAll(blacklistedFoldersList) },
-          onInvertSelection = { selectionState = selectionState.invertSelection(blacklistedFoldersList) },
+          onSelectAll = { selectionState = selectionState.selectAll(allBlacklistedFolders) },
+          onInvertSelection = { selectionState = selectionState.invertSelection(allBlacklistedFolders) },
           onDeselectAll = { selectionState = selectionState.clear() },
           additionalActions = {
-            if (!selectionState.isInSelectionMode && blacklistedFolders.isNotEmpty()) {
+            if (!selectionState.isInSelectionMode && allBlacklistedFolders.isNotEmpty()) {
               IconButton(
                 onClick = { showClearAllDialog = true },
                 modifier = Modifier.padding(horizontal = 2.dp),
@@ -174,7 +177,7 @@ object FoldersPreferencesScreen : Screen {
           Spacer(modifier = Modifier.height(8.dp))
         }
 
-        if (blacklistedFolders.isEmpty()) {
+        if (allBlacklistedFolders.isEmpty()) {
           Box(
             modifier =
               Modifier
@@ -192,14 +195,25 @@ object FoldersPreferencesScreen : Screen {
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(8.dp),
           ) {
-            items(blacklistedFoldersList, key = { it }) { folderPath ->
+            items(allBlacklistedFolders, key = { it }) { folderPath ->
+              val isVideo = folderPath in blacklistedVideoFolders
+              val isAudio = folderPath in blacklistedAudioFolders
+              val scope = when {
+                isVideo && isAudio -> BlacklistScope.BOTH
+                isVideo -> BlacklistScope.VIDEO_ONLY
+                else -> BlacklistScope.AUDIO_ONLY
+              }
+
               BlacklistedFolderItem(
                 folderPath = folderPath,
+                scope = scope,
                 isSelected = selectionState.isSelected(folderPath),
                 isInSelectionMode = selectionState.isInSelectionMode,
                 onRemove = {
-                  val updated = blacklistedFolders.toMutableSet().apply { remove(folderPath) }
-                  preferences.blacklistedFolders.set(updated)
+                  preferences.removeBlacklistedFolder(folderPath)
+                },
+                onScopeChange = { newScope ->
+                  preferences.addBlacklistedFolders(setOf(folderPath), newScope)
                 },
                 onLongClick = { selectionState = selectionState.toggle(folderPath) },
                 onClick = {
@@ -222,7 +236,7 @@ object FoldersPreferencesScreen : Screen {
                   isLoading = true
                   coroutineScope.launch(Dispatchers.IO) {
                     try {
-                      availableFolders = scanAllVideoFolders(context.applicationContext as Application)
+                      availableFolders = scanAllMediaFolders(context.applicationContext as Application)
                     } finally {
                       isLoading = false
                     }
@@ -261,12 +275,11 @@ object FoldersPreferencesScreen : Screen {
     if (showAddDialog) {
       AddFolderDialog(
         folders = availableFolders,
-        blacklistedFolders = blacklistedFolders,
+        blacklistedFolders = allBlacklistedFolders.toSet(),
         isLoading = isLoading,
         onDismiss = { showAddDialog = false },
-        onAddFolders = { folderPaths ->
-          val updated = blacklistedFolders.toMutableSet().apply { addAll(folderPaths) }
-          preferences.blacklistedFolders.set(updated)
+        onAddFolders = { folderPaths, scope ->
+          preferences.addBlacklistedFolders(folderPaths, scope)
         },
       )
     }
@@ -278,7 +291,7 @@ object FoldersPreferencesScreen : Screen {
         text = { Text(stringResource(R.string.pref_folders_clear_all_confirm_message)) },
         confirmButton = {
           TextButton(onClick = {
-            preferences.blacklistedFolders.set(emptySet())
+            preferences.clearAllBlacklistedFolders()
             showClearAllDialog = false
           }) {
             Text(stringResource(R.string.generic_confirm))
@@ -340,9 +353,11 @@ private fun NoMediaPreferenceCard(
 @Composable
 private fun BlacklistedFolderItem(
   folderPath: String,
+  scope: BlacklistScope,
   isSelected: Boolean,
   isInSelectionMode: Boolean,
   onRemove: () -> Unit,
+  onScopeChange: (BlacklistScope) -> Unit,
   onLongClick: () -> Unit,
   onClick: () -> Unit,
 ) {
@@ -382,6 +397,29 @@ private fun BlacklistedFolderItem(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
           )
+          if (!isInSelectionMode) {
+            Spacer(modifier = Modifier.height(4.dp))
+            AssistChip(
+              onClick = {
+                val nextScope = when (scope) {
+                  BlacklistScope.BOTH -> BlacklistScope.VIDEO_ONLY
+                  BlacklistScope.VIDEO_ONLY -> BlacklistScope.AUDIO_ONLY
+                  BlacklistScope.AUDIO_ONLY -> BlacklistScope.BOTH
+                }
+                onScopeChange(nextScope)
+              },
+              label = {
+                Text(
+                  text = when (scope) {
+                    BlacklistScope.BOTH -> "Both (Video & Audio)"
+                    BlacklistScope.VIDEO_ONLY -> "Videos Only"
+                    BlacklistScope.AUDIO_ONLY -> "Audio Only"
+                  },
+                  style = MaterialTheme.typography.labelSmall
+                )
+              }
+            )
+          }
         }
       }
       if (!isInSelectionMode) {
@@ -403,10 +441,11 @@ private fun AddFolderDialog(
   blacklistedFolders: Set<String>,
   isLoading: Boolean,
   onDismiss: () -> Unit,
-  onAddFolders: (Set<String>) -> Unit,
+  onAddFolders: (Set<String>, BlacklistScope) -> Unit,
 ) {
   var selectionState by remember { mutableStateOf(SelectionState<String>()) }
   var showDropdown by remember { mutableStateOf(false) }
+  var selectedScope by remember { mutableStateOf(BlacklistScope.BOTH) }
 
   val availableFolders =
     remember(folders, blacklistedFolders) {
@@ -462,28 +501,75 @@ private fun AddFolderDialog(
       } else if (availableFolders.isEmpty()) {
         Text(stringResource(R.string.pref_folders_no_folders))
       } else {
-        LazyColumn(modifier = Modifier.fillMaxWidth().height(400.dp)) {
-          items(availableFolders, key = { it.path }) { folder ->
-            Row(
-              modifier =
-                Modifier
-                  .fillMaxWidth()
-                  .clickable { selectionState = selectionState.toggle(folder.path) }
-                  .padding(vertical = 8.dp),
-              verticalAlignment = Alignment.CenterVertically,
-            ) {
-              Checkbox(
-                checked = selectionState.isSelected(folder.path),
-                onCheckedChange = { selectionState = selectionState.toggle(folder.path) },
-              )
-              Column(modifier = Modifier.padding(start = 8.dp)) {
-                Text(text = folder.name, style = MaterialTheme.typography.bodyLarge)
-                Text(
-                  text = folder.path,
-                  style = MaterialTheme.typography.bodySmall,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+        Column {
+          LazyColumn(modifier = Modifier.fillMaxWidth().height(280.dp)) {
+            items(availableFolders, key = { it.path }) { folder ->
+              Row(
+                modifier =
+                  Modifier
+                    .fillMaxWidth()
+                    .clickable { selectionState = selectionState.toggle(folder.path) }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+              ) {
+                Checkbox(
+                  checked = selectionState.isSelected(folder.path),
+                  onCheckedChange = { selectionState = selectionState.toggle(folder.path) },
                 )
+                Column(modifier = Modifier.padding(start = 8.dp)) {
+                  Text(text = folder.name, style = MaterialTheme.typography.bodyLarge)
+                  Text(
+                    text = folder.path,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                  )
+                }
               }
+            }
+          }
+
+          HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+          Text(
+            text = "Blacklist for",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+          )
+
+          Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.clickable { selectedScope = BlacklistScope.BOTH },
+            ) {
+              RadioButton(
+                selected = selectedScope == BlacklistScope.BOTH,
+                onClick = { selectedScope = BlacklistScope.BOTH },
+              )
+              Text("Both", style = MaterialTheme.typography.bodyMedium)
+            }
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.clickable { selectedScope = BlacklistScope.VIDEO_ONLY },
+            ) {
+              RadioButton(
+                selected = selectedScope == BlacklistScope.VIDEO_ONLY,
+                onClick = { selectedScope = BlacklistScope.VIDEO_ONLY },
+              )
+              Text("Video", style = MaterialTheme.typography.bodyMedium)
+            }
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.clickable { selectedScope = BlacklistScope.AUDIO_ONLY },
+            ) {
+              RadioButton(
+                selected = selectedScope == BlacklistScope.AUDIO_ONLY,
+                onClick = { selectedScope = BlacklistScope.AUDIO_ONLY },
+              )
+              Text("Audio", style = MaterialTheme.typography.bodyMedium)
             }
           }
         }
@@ -492,7 +578,7 @@ private fun AddFolderDialog(
     confirmButton = {
       TextButton(
         onClick = {
-          onAddFolders(selectionState.selectedIds)
+          onAddFolders(selectionState.selectedIds, selectedScope)
           onDismiss()
         },
         enabled = selectionState.isInSelectionMode && !isLoading,
@@ -577,6 +663,30 @@ internal fun getSimplifiedStoragePath(uriString: String): String =
     uriString
   }
 
-private suspend fun scanAllVideoFolders(context: Application): List<VideoFolder> =
-  app.gyrolet.mpvrx.repository.MediaFileRepository
-    .getAllVideoFoldersFast(context = context)
+private suspend fun scanAllMediaFolders(context: Application): List<VideoFolder> {
+  val repoFolders = app.gyrolet.mpvrx.repository.MediaFileRepository
+    .getAllVideoFoldersFast(context = context, includeAudioOverride = true)
+
+  val songs = try {
+    app.gyrolet.mpvrx.ui.browser.music.MusicLibraryScanner.scanSongs(context)
+  } catch (_: Exception) {
+    emptyList()
+  }
+
+  val audioFolderPaths = songs.mapNotNull { java.io.File(it.path).parent }.toSet()
+  val existingPaths = repoFolders.map { it.path.lowercase() }.toSet()
+
+  val extraAudioFolders = audioFolderPaths.filter { path -> path.lowercase() !in existingPaths }.map { path ->
+    VideoFolder(
+      bucketId = path,
+      name = path.substringAfterLast('/'),
+      path = path,
+      videoCount = 0,
+      totalSize = 0L,
+      totalDuration = 0L,
+      lastModified = 0L,
+    )
+  }
+
+  return (repoFolders + extraAudioFolders).sortedBy { it.name.lowercase() }
+}


### PR DESCRIPTION
- Add BlacklistScope enum (BOTH, VIDEO_ONLY, AUDIO_ONLY) and blacklistedAudioFolders preference
- Add scope selection radio buttons to folder blacklisting dialog
- Add interactive scope badges in Folders preferences settings screen
- Filter songs and albums in MusicLibraryViewModel based on audio folder blacklist
- Scope folder filtering in FolderListViewModel for Music Folders sub-tab