### PR TITLE
Fix playback lifecycle and seek responsiveness

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVPipHelper.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MPVPipHelper.kt
@@ -24,13 +24,13 @@ import android.util.Rational
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import app.gyrolet.mpvrx.preferences.AudioPreferences
 import app.gyrolet.mpvrx.preferences.PlayerPreferences
 import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.utils.media.resolveSeekMode
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-
-import androidx.core.content.ContextCompat
 
 private const val PIP_INTENTS_FILTER = "pip_action"
 private const val PIP_INTENT_ACTION = "pip_action_code"
@@ -54,14 +54,50 @@ class MPVPipHelper(
   ) : this(activity, { mpvView }, isAudioPlayer, isVideoLoaded)
 
   private val playerPreferences: PlayerPreferences by inject()
+  private val audioPreferences: AudioPreferences by inject()
   private var pipReceiver: BroadcastReceiver? = null
+  private var ownsPipNotificationService = false
 
   fun onPictureInPictureModeChanged(isInPipMode: Boolean) {
     if (isInPipMode) {
       registerPipReceiver()
+      ensurePipNotificationService()
     } else {
       unregisterPipReceiver()
+      releasePipNotificationServiceIfNotNeeded()
     }
+  }
+
+  private fun ensurePipNotificationService() {
+    if (isAudioPlayer() || !isVideoLoaded() || !PlaybackSession.isInitialized) return
+    if (MediaPlaybackService.isForegroundActive()) {
+      ownsPipNotificationService = false
+      return
+    }
+
+    val backgroundPlaybackEnabled = audioPreferences.backgroundPlayback.get()
+    val serviceIntent = Intent(activity, MediaPlaybackService::class.java)
+    runCatching { ContextCompat.startForegroundService(activity, serviceIntent) }
+      .onSuccess {
+        // PiP needs media controls even when detached background playback is disabled. If regular
+        // background playback is enabled, that feature owns the service and it must survive PiP.
+        ownsPipNotificationService = !backgroundPlaybackEnabled
+      }.onFailure { error ->
+        ownsPipNotificationService = false
+        Log.e("MPVPipHelper", "Failed to start PiP media notification service", error)
+      }
+  }
+
+  private fun releasePipNotificationServiceIfNotNeeded() {
+    if (!ownsPipNotificationService) return
+    if (audioPreferences.backgroundPlayback.get()) {
+      ownsPipNotificationService = false
+      return
+    }
+
+    runCatching { activity.stopService(Intent(activity, MediaPlaybackService::class.java)) }
+      .onFailure { error -> Log.e("MPVPipHelper", "Failed to stop PiP media notification service", error) }
+    ownsPipNotificationService = false
   }
 
   @Suppress("UnspecifiedRegisterReceiverFlag")
@@ -210,5 +246,18 @@ class MPVPipHelper(
 
   fun onStop() {
     unregisterPipReceiver()
+
+    // A real video-player close should silence libmpv at onStop instead of waiting for onDestroy,
+    // which Android may defer while finishing its window transition. Background/Mini Player
+    // handoffs remain untouched because video background playback is enabled for those paths.
+    if (
+      !isAudioPlayer() &&
+      activity.isFinishing &&
+      !activity.isInPictureInPictureMode &&
+      !audioPreferences.backgroundPlayback.get()
+    ) {
+      releasePipNotificationServiceIfNotNeeded()
+      PlaybackSession.stop(clearQueue = false)
+    }
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -342,7 +342,6 @@ object PlaybackSession : MPVLib.EventObserver {
     releaseAuxiliaryNetworkStreams()
   }
 
-
   /** Native destruction is reserved for process-level shutdown or an unrecoverable init reset. */
   fun destroy() {
     nativeLock.withLock {
@@ -530,8 +529,6 @@ object PlaybackSession : MPVLib.EventObserver {
       MPVLib.setPropertyString("http-header-fields", headerFields)
       MPVLib.setPropertyString("force-media-title", "")
 
-
-
       // Keep the native core paused while tracks/decoder/output are being replaced. When a valid
       // render Surface is attached, explicitly make vid=auto file-local to this new load. This
       // prevents a preceding vid=no from producing "No video or audio streams selected" on
@@ -554,9 +551,10 @@ object PlaybackSession : MPVLib.EventObserver {
 
   fun command(vararg command: String) {
     withCore(Unit) {
-      if (command.firstOrNull() == "seek") beginSeekAudioGuardLocked()
-      if (handleAmbientShaderCommandLocked(command)) return@withCore
-      MPVLib.command(*command)
+      val resolvedCommand = normalizeSeekCommand(command)
+      if (shouldGuardSeekAudio(resolvedCommand)) beginSeekAudioGuardLocked()
+      if (handleAmbientShaderCommandLocked(resolvedCommand)) return@withCore
+      MPVLib.command(*resolvedCommand)
     }
   }
 
@@ -567,10 +565,28 @@ object PlaybackSession : MPVLib.EventObserver {
   ): Boolean =
     nativeLock.withLock {
       if (!initialized || _state.value.generation != expectedGeneration) return@withLock false
-      if (command.firstOrNull() == "seek") beginSeekAudioGuardLocked()
-      if (!handleAmbientShaderCommandLocked(command)) MPVLib.command(*command)
+      val resolvedCommand = normalizeSeekCommand(command)
+      if (shouldGuardSeekAudio(resolvedCommand)) beginSeekAudioGuardLocked()
+      if (!handleAmbientShaderCommandLocked(resolvedCommand)) MPVLib.command(*resolvedCommand)
       true
     }
+
+  /**
+   * Normal relative skips already use keyframes in mpv. Keep those commands on mpv's lightweight
+   * default path (matching mpvKt) and reserve the extra audio guard for explicitly exact seeks.
+   */
+  private fun normalizeSeekCommand(command: Array<out String>): Array<out String> =
+    if (command.size == 3 && command[0] == "seek" && command[2] == "relative+keyframes") {
+      arrayOf("seek", command[1], "relative")
+    } else {
+      command
+    }
+
+  private fun shouldGuardSeekAudio(command: Array<out String>): Boolean =
+    command.firstOrNull() == "seek" &&
+      command.drop(2).any { argument ->
+        argument.split('+').any { flag -> flag == "exact" }
+      }
 
   fun commandNode(vararg command: String): MPVNode? = withCore(null) { MPVLib.commandNode(*command) }
 
@@ -894,9 +910,9 @@ object PlaybackSession : MPVLib.EventObserver {
   }
 
   /**
-   * Rapid keyframe/exact seeks can expose tiny decoded audio fragments between decoder flushes,
-   * which sounds like echo/warble while scrubbing. Temporarily mute only the active seek window;
-   * the user's original mute state is restored after mpv reports playback restart.
+   * Exact seeks can expose tiny decoded audio fragments between decoder flushes, which sounds like
+   * echo/warble while scrubbing. Fast keyframe-relative skips avoid this guard entirely so repeated
+   * 5–10 second seeks stay responsive; exact seek modes retain the protection.
    */
   private fun beginSeekAudioGuardLocked() {
     if (_state.value.paused || _state.value.phase !in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) return


### PR DESCRIPTION
## Summary
- keep the media foreground service available while video is in Picture-in-Picture, independent of the detached background-playback preference
- stop foreground video playback promptly when a finishing player has no background/Mini Player handoff
- keep ordinary relative seeks on mpv's lightweight path and reserve the seek audio guard for explicitly precise seeks

## Why
PiP notification ownership was tied to background-playback settings, player shutdown could wait until Activity destruction, and fast relative seeks were paying extra wrapper work that is unnecessary for normal keyframe seeking.

## Validation
- verified the branch is exactly one commit ahead of `master`
- verified only `MPVPipHelper.kt` and `PlaybackSession.kt` are changed
- preserved precise/exact seek behavior while normal relative skips use mpv's default fast path
- left decoder, HDR, release-flavor, and Dolby Vision paths untouched