### PR TITLE
feat(jellyfin): full Jellyfin integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,24 @@
 import com.android.build.api.variant.FilterConfiguration
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
+val localProperties =
+  Properties().apply {
+    val localFile = rootProject.file("local.properties")
+    if (localFile.exists()) {
+      localFile.inputStream().use { load(it) }
+    }
+  }
+
+val targetAbiProp = project.findProperty("targetAbi")?.toString() ?: localProperties.getProperty("targetAbi")
 val enableX86 = project.findProperty("enableX86") != "false"
 val x86Abis = if (enableX86) listOf("x86", "x86_64") else emptyList()
+val activeAbis =
+  if (!targetAbiProp.isNullOrBlank()) {
+    targetAbiProp.split(",").map { it.trim() }
+  } else {
+    listOf("arm64-v8a", "armeabi-v7a") + x86Abis
+  }
 val universalOnlyDistributions = setOf("noVulkan", "fongmi")
 
 plugins {
@@ -35,7 +51,7 @@ android {
 
     externalNativeBuild {
       cmake {
-        abiFilters += listOf("arm64-v8a", "armeabi-v7a") + x86Abis
+        abiFilters += activeAbis
       }
     }
   }
@@ -84,11 +100,8 @@ android {
     abi {
       isEnable = true
       reset()
-      include("armeabi-v7a", "arm64-v8a")
-      if (enableX86) {
-        include("x86", "x86_64")
-      }
-      isUniversalApk = true
+      include(*activeAbis.toTypedArray())
+      isUniversalApk = activeAbis.size > 1
     }
   }
 

--- a/app/schemas/app.gyrolet.mpvrx.database.MpvRxDatabase/15.json
+++ b/app/schemas/app.gyrolet.mpvrx.database.MpvRxDatabase/15.json
@@ -1,0 +1,862 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "f922d125d072e0f8c497eaf40cf75c12",
+    "entities": [
+      {
+        "tableName": "PlaybackStateEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mediaTitle` TEXT NOT NULL, `lastPosition` INTEGER NOT NULL, `playbackSpeed` REAL NOT NULL, `videoZoom` REAL NOT NULL, `sid` INTEGER NOT NULL, `secondarySid` INTEGER NOT NULL, `subDelay` INTEGER NOT NULL, `subSpeed` REAL NOT NULL, `aid` INTEGER NOT NULL, `audioDelay` INTEGER NOT NULL, `timeRemaining` INTEGER NOT NULL, `externalSubtitles` TEXT NOT NULL, `hasBeenWatched` INTEGER NOT NULL, PRIMARY KEY(`mediaTitle`))",
+        "fields": [
+          {
+            "fieldPath": "mediaTitle",
+            "columnName": "mediaTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPosition",
+            "columnName": "lastPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoZoom",
+            "columnName": "videoZoom",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sid",
+            "columnName": "sid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondarySid",
+            "columnName": "secondarySid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subDelay",
+            "columnName": "subDelay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subSpeed",
+            "columnName": "subSpeed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aid",
+            "columnName": "aid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDelay",
+            "columnName": "audioDelay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRemaining",
+            "columnName": "timeRemaining",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalSubtitles",
+            "columnName": "externalSubtitles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasBeenWatched",
+            "columnName": "hasBeenWatched",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "mediaTitle"
+          ]
+        }
+      },
+      {
+        "tableName": "RecentlyPlayedEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `videoTitle` TEXT, `duration` INTEGER NOT NULL, `fileSize` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `launchSource` TEXT, `playlistId` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoTitle",
+            "columnName": "videoTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchSource",
+            "columnName": "launchSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `size` INTEGER NOT NULL, `dateModified` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `fps` REAL NOT NULL, `hasEmbeddedSubtitles` INTEGER NOT NULL, `subtitleCodec` TEXT NOT NULL, `lastScanned` INTEGER NOT NULL, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fps",
+            "columnName": "fps",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasEmbeddedSubtitles",
+            "columnName": "hasEmbeddedSubtitles",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleCodec",
+            "columnName": "subtitleCodec",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScanned",
+            "columnName": "lastScanned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "path"
+          ]
+        }
+      },
+      {
+        "tableName": "network_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `protocol` TEXT NOT NULL, `host` TEXT NOT NULL, `port` INTEGER NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `path` TEXT NOT NULL, `isAnonymous` INTEGER NOT NULL, `lastConnected` INTEGER NOT NULL, `autoConnect` INTEGER NOT NULL, `useHttps` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnonymous",
+            "columnName": "isAnonymous",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoConnect",
+            "columnName": "autoConnect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "useHttps",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaylistEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `m3uSourceUrl` TEXT, `isM3uPlaylist` INTEGER NOT NULL, `userAgent` TEXT, `isAudio` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "m3uSourceUrl",
+            "columnName": "m3uSourceUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isM3uPlaylist",
+            "columnName": "isM3uPlaylist",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAgent",
+            "columnName": "userAgent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAudio",
+            "columnName": "isAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaylistItemEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `position` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL, `playCount` INTEGER NOT NULL, `lastPosition` INTEGER NOT NULL, `tvgId` TEXT, `tvgLogo` TEXT, `groupTitle` TEXT, `licenseType` TEXT, `licenseKey` TEXT, `userAgent` TEXT, `isFavorite` INTEGER NOT NULL, FOREIGN KEY(`playlistId`) REFERENCES `PlaylistEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "playCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPosition",
+            "columnName": "lastPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tvgId",
+            "columnName": "tvgId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tvgLogo",
+            "columnName": "tvgLogo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "groupTitle",
+            "columnName": "groupTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licenseType",
+            "columnName": "licenseType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licenseKey",
+            "columnName": "licenseKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userAgent",
+            "columnName": "userAgent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PlaylistItemEntity_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistItemEntity_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_PlaylistItemEntity_isFavorite",
+            "unique": false,
+            "columnNames": [
+              "isFavorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistItemEntity_isFavorite` ON `${TABLE_NAME}` (`isFavorite`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PlaylistEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "directory_scan_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`scanKey` TEXT NOT NULL, `path` TEXT NOT NULL, `rootPath` TEXT NOT NULL, `fingerprint` TEXT NOT NULL, `isNoMediaRoot` INTEGER NOT NULL, `videoCount` INTEGER NOT NULL, `totalSize` INTEGER NOT NULL, `totalDuration` INTEGER NOT NULL, `lastModified` INTEGER NOT NULL, `hasSubfolders` INTEGER NOT NULL, `lastScanned` INTEGER NOT NULL, PRIMARY KEY(`scanKey`, `path`))",
+        "fields": [
+          {
+            "fieldPath": "scanKey",
+            "columnName": "scanKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootPath",
+            "columnName": "rootPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fingerprint",
+            "columnName": "fingerprint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNoMediaRoot",
+            "columnName": "isNoMediaRoot",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoCount",
+            "columnName": "videoCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSize",
+            "columnName": "totalSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalDuration",
+            "columnName": "totalDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasSubfolders",
+            "columnName": "hasSubfolders",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScanned",
+            "columnName": "lastScanned",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "scanKey",
+            "path"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_directory_scan_index_scanKey_rootPath",
+            "unique": false,
+            "columnNames": [
+              "scanKey",
+              "rootPath"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_directory_scan_index_scanKey_rootPath` ON `${TABLE_NAME}` (`scanKey`, `rootPath`)"
+          },
+          {
+            "name": "index_directory_scan_index_scanKey_isNoMediaRoot",
+            "unique": false,
+            "columnNames": [
+              "scanKey",
+              "isNoMediaRoot"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_directory_scan_index_scanKey_isNoMediaRoot` ON `${TABLE_NAME}` (`scanKey`, `isNoMediaRoot`)"
+          }
+        ]
+      },
+      {
+        "tableName": "secure_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `originalPath` TEXT NOT NULL, `secureFilePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `dateHidden` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalPath",
+            "columnName": "originalPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secureFilePath",
+            "columnName": "secureFilePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateHidden",
+            "columnName": "dateHidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_secure_media_secureFilePath",
+            "unique": true,
+            "columnNames": [
+              "secureFilePath"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_secure_media_secureFilePath` ON `${TABLE_NAME}` (`secureFilePath`)"
+          }
+        ]
+      },
+      {
+        "tableName": "network_stream_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stableKey` TEXT NOT NULL, `entryType` TEXT NOT NULL, `canonicalSourceUri` TEXT NOT NULL, `infoHash` TEXT, `fileIndex` INTEGER, `filePath` TEXT, `fileName` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `groupTitle` TEXT, `overview` TEXT, `releaseYear` TEXT, `mediaType` TEXT, PRIMARY KEY(`stableKey`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stableKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryType",
+            "columnName": "entryType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalSourceUri",
+            "columnName": "canonicalSourceUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "infoHash",
+            "columnName": "infoHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileIndex",
+            "columnName": "fileIndex",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "groupTitle",
+            "columnName": "groupTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseYear",
+            "columnName": "releaseYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stableKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_network_stream_entries_entryType_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "entryType",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_network_stream_entries_entryType_updatedAt` ON `${TABLE_NAME}` (`entryType`, `updatedAt`)"
+          },
+          {
+            "name": "index_network_stream_entries_infoHash_fileIndex",
+            "unique": true,
+            "columnNames": [
+              "infoHash",
+              "fileIndex"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_network_stream_entries_infoHash_fileIndex` ON `${TABLE_NAME}` (`infoHash`, `fileIndex`)"
+          }
+        ]
+      },
+      {
+        "tableName": "jellyfin_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `serverUrl` TEXT NOT NULL, `userId` TEXT NOT NULL, `username` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `lastConnected` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverUrl",
+            "columnName": "serverUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f922d125d072e0f8c497eaf40cf75c12')"
+    ]
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -1,0 +1,592 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.data.jellyfin
+
+import android.util.Log
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinAuthResult
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinItem
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinUser
+import app.gyrolet.mpvrx.utils.media.PlaybackSubtitleTrack
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+class JellyfinClient(
+  private val httpClient: OkHttpClient,
+  private val json: Json,
+) {
+  companion object {
+    const val TICKS_PER_SECOND = 10_000_000L
+    private const val TAG = "JellyfinClient"
+    private const val CLIENT_NAME = "mpvRx"
+    private const val DEVICE_NAME = "Android"
+    private const val DEVICE_ID = "mpvrx-android-player"
+    private const val VERSION = "2.1.0"
+    private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
+    fun normalizeUrl(rawUrl: String): String {
+      var url = rawUrl.trim()
+      if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
+        url = "http://$url"
+      }
+      return url.removeSuffix("/")
+    }
+
+    fun authHeader(token: String? = null): String {
+      val base = "MediaBrowser Client=\"$CLIENT_NAME\", Device=\"$DEVICE_NAME\", DeviceId=\"$DEVICE_ID\", Version=\"$VERSION\""
+      return if (!token.isNullOrBlank()) "$base, Token=\"$token\"" else base
+    }
+
+    fun getStreamUrl(
+      serverUrl: String,
+      itemId: String,
+      token: String,
+      isAudio: Boolean = false,
+    ): String {
+      val base = normalizeUrl(serverUrl)
+      val endpoint = if (isAudio) "Audio" else "Videos"
+      return "$base/$endpoint/$itemId/stream?static=true&api_key=$token"
+    }
+
+    fun getImageUrl(
+      serverUrl: String,
+      itemId: String,
+      imageTag: String? = null,
+      imageType: String = "Primary",
+      maxWidth: Int = 400,
+      token: String? = null,
+    ): String {
+      val base = normalizeUrl(serverUrl)
+      val tagParam = if (!imageTag.isNullOrBlank()) "&tag=$imageTag" else ""
+      val tokenParam = if (!token.isNullOrBlank()) "&api_key=$token" else ""
+      return "$base/Items/$itemId/Images/$imageType?maxWidth=$maxWidth&quality=90$tagParam$tokenParam"
+    }
+
+    fun getBackdropUrl(
+      serverUrl: String,
+      itemId: String,
+      imageTag: String? = null,
+      maxWidth: Int = 1280,
+      token: String? = null,
+    ): String {
+      val base = normalizeUrl(serverUrl)
+      val tagParam = if (!imageTag.isNullOrBlank()) "&tag=$imageTag" else ""
+      val tokenParam = if (!token.isNullOrBlank()) "&api_key=$token" else ""
+      return "$base/Items/$itemId/Images/Backdrop/0?maxWidth=$maxWidth&quality=80$tagParam$tokenParam"
+    }
+  }
+
+  suspend fun authenticate(
+    serverUrl: String,
+    username: String,
+    password: String,
+  ): Result<JellyfinAuthResult> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/AuthenticateByName"
+        val payload =
+          JsonObject(
+            mapOf(
+              "Username" to kotlinx.serialization.json.JsonPrimitive(username),
+              "Pw" to kotlinx.serialization.json.JsonPrimitive(password),
+            ),
+          ).toString()
+
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader())
+            .addHeader("Content-Type", "application/json")
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Authentication failed: HTTP ${response.code} ${response.message}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val accessToken = root["AccessToken"]?.jsonPrimitive?.content ?: throw IOException("Missing AccessToken in response")
+          val userObj = root["User"]?.jsonObject ?: throw IOException("Missing User object in response")
+          val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id in response")
+          val uname = userObj["Name"]?.jsonPrimitive?.content ?: username
+          val serverId = root["ServerId"]?.jsonPrimitive?.content
+
+          JellyfinAuthResult(
+            accessToken = accessToken,
+            userId = userId,
+            username = uname,
+            serverId = serverId,
+          )
+        }
+      }
+    }
+
+  suspend fun validateToken(
+    serverUrl: String,
+    token: String,
+  ): Result<JellyfinUser> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/Me"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Token validation failed: HTTP ${response.code} ${response.message}")
+          }
+          val bodyStr = response.body.string()
+          val userObj = json.parseToJsonElement(bodyStr).jsonObject
+          val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id")
+          val uname = userObj["Name"]?.jsonPrimitive?.content ?: "User"
+          val serverId = userObj["ServerId"]?.jsonPrimitive?.content
+
+          JellyfinUser(
+            id = userId,
+            name = uname,
+            serverId = serverId,
+          )
+        }
+      }
+    }
+
+  suspend fun getUserLibraries(
+    serverUrl: String,
+    userId: String,
+    token: String,
+  ): Result<List<JellyfinItem>> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/$userId/Views"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Failed to load libraries: HTTP ${response.code}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val itemsArray = root["Items"]?.jsonArray ?: JsonArray(emptyList())
+          itemsArray.map { parseItem(it.jsonObject) }
+        }
+      }
+    }
+
+  suspend fun getResumeItems(
+    serverUrl: String,
+    userId: String,
+    token: String,
+    limit: Int = 12,
+  ): Result<List<JellyfinItem>> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint =
+          "$base/Users/$userId/Items/Resume?Limit=$limit&Fields=Overview,PrimaryImageAspectRatio,UserData,SeriesName,SeasonName,IndexNumber,ParentIndexNumber,MediaSources"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Failed to load resume items: HTTP ${response.code}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val itemsArray = root["Items"]?.jsonArray ?: JsonArray(emptyList())
+          itemsArray.map { parseItem(it.jsonObject) }
+        }
+      }
+    }
+
+  suspend fun getItems(
+    serverUrl: String,
+    userId: String,
+    parentId: String? = null,
+    searchTerm: String? = null,
+    sortBy: app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy = app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.NAME,
+    sortOrder: app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder = app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder.ASCENDING,
+    isPlayed: Boolean? = null,
+    startIndex: Int = 0,
+    limit: Int = 100,
+    token: String,
+  ): Result<app.gyrolet.mpvrx.domain.jellyfin.JellyfinQueryResult> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val urlBuilder =
+          StringBuilder(
+            "$base/Users/$userId/Items?Fields=Overview,PrimaryImageAspectRatio,UserData,ChildCount,MediaSources,ProductionYear,SeriesName,SeasonName,IndexNumber,ParentIndexNumber&StartIndex=$startIndex&Limit=$limit&SortBy=${sortBy.apiValue}&SortOrder=${sortOrder.apiValue}",
+          )
+
+        if (!parentId.isNullOrBlank()) {
+          urlBuilder.append("&ParentId=$parentId")
+        }
+        if (!searchTerm.isNullOrBlank()) {
+          urlBuilder.append("&SearchTerm=${java.net.URLEncoder.encode(searchTerm, "UTF-8")}&Recursive=true")
+        }
+        if (isPlayed != null) {
+          val filter = if (isPlayed) "IsPlayed" else "IsUnplayed"
+          urlBuilder.append("&Filters=$filter")
+        }
+
+        val request =
+          Request
+            .Builder()
+            .url(urlBuilder.toString())
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Failed to load items: HTTP ${response.code}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val totalRecordCount = root["TotalRecordCount"]?.jsonPrimitive?.intOrNull ?: 0
+          val itemsArray = root["Items"]?.jsonArray ?: JsonArray(emptyList())
+          val items = itemsArray.map { parseItem(it.jsonObject) }
+          app.gyrolet.mpvrx.domain.jellyfin.JellyfinQueryResult(
+            items = items,
+            totalRecordCount = if (totalRecordCount > 0) totalRecordCount else items.size,
+            startIndex = startIndex,
+          )
+        }
+      }
+    }
+
+  suspend fun getSeasons(
+    serverUrl: String,
+    userId: String,
+    seriesId: String,
+    token: String,
+  ): Result<List<JellyfinItem>> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Shows/$seriesId/Seasons?UserId=$userId&Fields=Overview,PrimaryImageAspectRatio,UserData"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Failed to load seasons: HTTP ${response.code}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val itemsArray = root["Items"]?.jsonArray ?: JsonArray(emptyList())
+          itemsArray.map { parseItem(it.jsonObject) }
+        }
+      }
+    }
+
+  suspend fun getEpisodes(
+    serverUrl: String,
+    userId: String,
+    seriesId: String,
+    seasonId: String,
+    token: String,
+  ): Result<List<JellyfinItem>> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Shows/$seriesId/Episodes?SeasonId=$seasonId&UserId=$userId&Fields=Overview,PrimaryImageAspectRatio,UserData,MediaSources,IndexNumber"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Failed to load episodes: HTTP ${response.code}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val itemsArray = root["Items"]?.jsonArray ?: JsonArray(emptyList())
+          itemsArray.map { parseItem(it.jsonObject) }
+        }
+      }
+    }
+
+  fun getStreamUrl(
+    serverUrl: String,
+    itemId: String,
+    token: String,
+    isAudio: Boolean = false,
+  ): String = Companion.getStreamUrl(serverUrl, itemId, token, isAudio)
+
+  fun getImageUrl(
+    serverUrl: String,
+    itemId: String,
+    imageTag: String? = null,
+    imageType: String = "Primary",
+    maxWidth: Int = 400,
+    token: String? = null,
+  ): String = Companion.getImageUrl(serverUrl, itemId, imageTag, imageType, maxWidth, token)
+
+  fun getBackdropUrl(
+    serverUrl: String,
+    itemId: String,
+    imageTag: String? = null,
+    maxWidth: Int = 1280,
+    token: String? = null,
+  ): String = Companion.getBackdropUrl(serverUrl, itemId, imageTag, maxWidth, token)
+
+  suspend fun getSubtitleTracks(
+    serverUrl: String,
+    token: String,
+    userId: String,
+    itemId: String,
+  ): Result<List<PlaybackSubtitleTrack>> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/$userId/Items/$itemId?Fields=MediaStreams"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            return@use emptyList<PlaybackSubtitleTrack>()
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          val streams = root["MediaStreams"]?.jsonArray ?: return@use emptyList<PlaybackSubtitleTrack>()
+          val mediaSourceId = root["MediaSources"]?.jsonArray?.firstOrNull()?.jsonObject?.get("Id")?.jsonPrimitive?.content ?: itemId
+
+          streams.mapNotNull { element ->
+            val stream = element.jsonObject
+            val type = stream["Type"]?.jsonPrimitive?.content ?: return@mapNotNull null
+            if (!type.equals("Subtitle", ignoreCase = true)) return@mapNotNull null
+
+            val isExternal = stream["IsExternal"]?.jsonPrimitive?.booleanOrNull ?: false
+            if (!isExternal) return@mapNotNull null
+
+            val index = stream["Index"]?.jsonPrimitive?.intOrNull ?: return@mapNotNull null
+            val codec = stream["Codec"]?.jsonPrimitive?.content ?: "srt"
+            val language = stream["Language"]?.jsonPrimitive?.content
+            val displayTitle = stream["DisplayTitle"]?.jsonPrimitive?.content ?: language ?: "Subtitle #$index"
+            val deliveryUrl = stream["DeliveryUrl"]?.jsonPrimitive?.content
+
+            val subUrl =
+              if (!deliveryUrl.isNullOrBlank()) {
+                if (deliveryUrl.startsWith("http")) deliveryUrl else "$base$deliveryUrl"
+              } else {
+                "$base/Videos/$itemId/$mediaSourceId/Subtitles/$index/Stream.$codec"
+              }
+
+            val finalUrl = if (subUrl.contains("?")) "$subUrl&api_key=$token" else "$subUrl?api_key=$token"
+            PlaybackSubtitleTrack(
+              url = finalUrl,
+              label = displayTitle,
+              languageCode = language,
+            )
+          }
+        }
+      }
+    }
+
+  suspend fun reportPlaybackStart(
+    serverUrl: String,
+    token: String,
+    itemId: String,
+    positionTicks: Long = 0L,
+  ) = withContext(Dispatchers.IO) {
+    runCatching {
+      val base = normalizeUrl(serverUrl)
+      val endpoint = "$base/Sessions/Playing"
+      val payload =
+        JsonObject(
+          mapOf(
+            "ItemId" to kotlinx.serialization.json.JsonPrimitive(itemId),
+            "PositionTicks" to kotlinx.serialization.json.JsonPrimitive(positionTicks),
+          ),
+        ).toString()
+
+      val request =
+        Request
+          .Builder()
+          .url(endpoint)
+          .addHeader("X-Emby-Authorization", authHeader(token))
+          .addHeader("X-Emby-Token", token)
+          .addHeader("Content-Type", "application/json")
+          .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+          .build()
+
+      httpClient.newCall(request).execute().close()
+    }.onFailure { Log.w(TAG, "Failed reporting playback start: ${it.message}") }
+  }
+
+  suspend fun reportPlaybackProgress(
+    serverUrl: String,
+    token: String,
+    itemId: String,
+    positionTicks: Long,
+    isPaused: Boolean = false,
+  ) = withContext(Dispatchers.IO) {
+    runCatching {
+      val base = normalizeUrl(serverUrl)
+      val endpoint = "$base/Sessions/Playing/Progress"
+      val payload =
+        JsonObject(
+          mapOf(
+            "ItemId" to kotlinx.serialization.json.JsonPrimitive(itemId),
+            "PositionTicks" to kotlinx.serialization.json.JsonPrimitive(positionTicks),
+            "IsPaused" to kotlinx.serialization.json.JsonPrimitive(isPaused),
+          ),
+        ).toString()
+
+      val request =
+        Request
+          .Builder()
+          .url(endpoint)
+          .addHeader("X-Emby-Authorization", authHeader(token))
+          .addHeader("X-Emby-Token", token)
+          .addHeader("Content-Type", "application/json")
+          .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+          .build()
+
+      httpClient.newCall(request).execute().close()
+    }.onFailure { Log.w(TAG, "Failed reporting playback progress: ${it.message}") }
+  }
+
+  suspend fun reportPlaybackStopped(
+    serverUrl: String,
+    token: String,
+    itemId: String,
+    positionTicks: Long,
+  ) = withContext(Dispatchers.IO) {
+    runCatching {
+      val base = normalizeUrl(serverUrl)
+      val endpoint = "$base/Sessions/Playing/Stopped"
+      val payload =
+        JsonObject(
+          mapOf(
+            "ItemId" to kotlinx.serialization.json.JsonPrimitive(itemId),
+            "PositionTicks" to kotlinx.serialization.json.JsonPrimitive(positionTicks),
+          ),
+        ).toString()
+
+      val request =
+        Request
+          .Builder()
+          .url(endpoint)
+          .addHeader("X-Emby-Authorization", authHeader(token))
+          .addHeader("X-Emby-Token", token)
+          .addHeader("Content-Type", "application/json")
+          .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+          .build()
+
+      httpClient.newCall(request).execute().close()
+    }.onFailure { Log.w(TAG, "Failed reporting playback stop: ${it.message}") }
+  }
+
+  private fun parseItem(obj: JsonObject): JellyfinItem {
+    val id = obj["Id"]?.jsonPrimitive?.content ?: ""
+    val name = obj["Name"]?.jsonPrimitive?.content ?: ""
+    val type = obj["Type"]?.jsonPrimitive?.content ?: obj["CollectionType"]?.jsonPrimitive?.content ?: "Folder"
+    val collectionType = obj["CollectionType"]?.jsonPrimitive?.content
+    val overview = obj["Overview"]?.jsonPrimitive?.content
+    val runTimeTicks = obj["RunTimeTicks"]?.jsonPrimitive?.longOrNull
+    val isFolder = obj["IsFolder"]?.jsonPrimitive?.booleanOrNull ?: (type == "CollectionFolder" || type == "Folder" || type == "Series" || type == "Season")
+    val productionYear = obj["ProductionYear"]?.jsonPrimitive?.intOrNull
+    val communityRating = obj["CommunityRating"]?.jsonPrimitive?.content?.toDoubleOrNull()
+    val seriesName = obj["SeriesName"]?.jsonPrimitive?.content
+    val seasonName = obj["SeasonName"]?.jsonPrimitive?.content
+    val indexNumber = obj["IndexNumber"]?.jsonPrimitive?.intOrNull
+    val parentIndexNumber = obj["ParentIndexNumber"]?.jsonPrimitive?.intOrNull
+    val childCount = obj["ChildCount"]?.jsonPrimitive?.intOrNull
+    val container = obj["Container"]?.jsonPrimitive?.content
+
+    val imageTagsObj = obj["ImageTags"]?.jsonObject
+    val primaryImageTag = imageTagsObj?.get("Primary")?.jsonPrimitive?.content
+    val backdropImageTags = obj["BackdropImageTags"]?.jsonArray?.firstOrNull()?.jsonPrimitive?.content
+
+    val userDataObj = obj["UserData"]?.jsonObject
+    val playbackPositionTicks = userDataObj?.get("PlaybackPositionTicks")?.jsonPrimitive?.longOrNull
+    val isPlayed = userDataObj?.get("Played")?.jsonPrimitive?.booleanOrNull ?: false
+
+    return JellyfinItem(
+      id = id,
+      name = name,
+      type = type,
+      collectionType = collectionType,
+      overview = overview,
+      runTimeTicks = runTimeTicks,
+      playbackPositionTicks = playbackPositionTicks,
+      isPlayed = isPlayed,
+      seriesName = seriesName,
+      seasonName = seasonName,
+      indexNumber = indexNumber,
+      parentIndexNumber = parentIndexNumber,
+      productionYear = productionYear,
+      communityRating = communityRating,
+      isFolder = isFolder,
+      primaryImageTag = primaryImageTag,
+      backdropImageTag = backdropImageTags,
+      childCount = childCount,
+      container = container,
+    )
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -559,6 +559,54 @@ class JellyfinClient(
     }.onFailure { Log.w(TAG, "Failed reporting playback stop: ${it.message}") }
   }
 
+  suspend fun markPlayed(
+    serverUrl: String,
+    userId: String,
+    itemId: String,
+    token: String,
+  ): Result<Unit> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/$userId/PlayedItems/$itemId"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .post(ByteArray(0).toRequestBody(null))
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) throw IOException("Failed to mark as played: HTTP ${response.code}")
+        }
+      }
+    }
+
+  suspend fun markUnplayed(
+    serverUrl: String,
+    userId: String,
+    itemId: String,
+    token: String,
+  ): Result<Unit> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/$userId/PlayedItems/$itemId"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .delete()
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) throw IOException("Failed to mark as unplayed: HTTP ${response.code}")
+        }
+      }
+    }
+
   private fun parseItem(obj: JsonObject): JellyfinItem {
     val id = obj["Id"]?.jsonPrimitive?.content ?: ""
     val name = obj["Name"]?.jsonPrimitive?.content ?: ""

--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -133,12 +133,17 @@ class JellyfinClient(
           val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id in response")
           val uname = userObj["Name"]?.jsonPrimitive?.content ?: username
           val serverId = root["ServerId"]?.jsonPrimitive?.content
+          val configObj = userObj["Configuration"]?.jsonObject
+          val audioLang = configObj?.get("AudioLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+          val subLang = configObj?.get("SubtitleLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
 
           JellyfinAuthResult(
             accessToken = accessToken,
             userId = userId,
             username = uname,
             serverId = serverId,
+            audioLanguage = audioLang,
+            subtitleLanguage = subLang,
           )
         }
       }
@@ -171,10 +176,16 @@ class JellyfinClient(
           val uname = userObj["Name"]?.jsonPrimitive?.content ?: "User"
           val serverId = userObj["ServerId"]?.jsonPrimitive?.content
 
+          val configObj = userObj["Configuration"]?.jsonObject
+          val audioLang = configObj?.get("AudioLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+          val subLang = configObj?.get("SubtitleLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+
           JellyfinUser(
             id = userId,
             name = uname,
             serverId = serverId,
+            audioLanguage = audioLang,
+            subtitleLanguage = subLang,
           )
         }
       }

--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -302,8 +302,14 @@ class JellyfinClient(
           val totalRecordCount = root["TotalRecordCount"]?.jsonPrimitive?.intOrNull ?: 0
           val itemsArray = root["Items"]?.jsonArray ?: JsonArray(emptyList())
           val items = itemsArray.map { parseItem(it.jsonObject) }
+          val sortedItems =
+            if (!searchTerm.isNullOrBlank()) {
+              items.sortedBy { it.searchPriority }
+            } else {
+              items
+            }
           app.gyrolet.mpvrx.domain.jellyfin.JellyfinQueryResult(
-            items = items,
+            items = sortedItems,
             totalRecordCount = if (totalRecordCount > 0) totalRecordCount else items.size,
             startIndex = startIndex,
           )

--- a/app/src/main/java/app/gyrolet/mpvrx/database/MpvRxDatabase.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/database/MpvRxDatabase.kt
@@ -22,7 +22,9 @@ import app.gyrolet.mpvrx.database.dao.PlaylistDao
 import app.gyrolet.mpvrx.database.dao.RecentlyPlayedDao
 import app.gyrolet.mpvrx.database.dao.SecureMediaDao
 import app.gyrolet.mpvrx.database.dao.VideoMetadataDao
+import app.gyrolet.mpvrx.database.dao.JellyfinServerDao
 import app.gyrolet.mpvrx.database.entities.DirectoryScanEntity
+import app.gyrolet.mpvrx.database.entities.JellyfinServerEntity
 import app.gyrolet.mpvrx.database.entities.NetworkStreamEntryEntity
 import app.gyrolet.mpvrx.database.entities.PlaybackStateEntity
 import app.gyrolet.mpvrx.database.entities.PlaylistEntity
@@ -43,8 +45,9 @@ import app.gyrolet.mpvrx.domain.network.NetworkConnection
     DirectoryScanEntity::class,
     SecureMediaEntity::class,
     NetworkStreamEntryEntity::class,
+    JellyfinServerEntity::class,
   ],
-  version = 14,
+  version = 15,
   exportSchema = true,
 )
 @TypeConverters(NetworkProtocolConverter::class, NetworkStreamEntryTypeConverter::class)
@@ -64,4 +67,6 @@ abstract class MpvRxDatabase : RoomDatabase() {
   abstract fun directoryScanDao(): DirectoryScanDao
 
   abstract fun secureMediaDao(): SecureMediaDao
+
+  abstract fun jellyfinServerDao(): JellyfinServerDao
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/database/dao/JellyfinServerDao.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/database/dao/JellyfinServerDao.kt
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import app.gyrolet.mpvrx.database.entities.JellyfinServerEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface JellyfinServerDao {
+  @Query("SELECT * FROM jellyfin_servers ORDER BY lastConnected DESC")
+  fun getAllServers(): Flow<List<JellyfinServerEntity>>
+
+  @Query("SELECT * FROM jellyfin_servers WHERE id = :id LIMIT 1")
+  suspend fun getServerById(id: Long): JellyfinServerEntity?
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insert(server: JellyfinServerEntity): Long
+
+  @Update
+  suspend fun update(server: JellyfinServerEntity)
+
+  @Delete
+  suspend fun delete(server: JellyfinServerEntity)
+
+  @Query("DELETE FROM jellyfin_servers WHERE id = :id")
+  suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/database/entities/JellyfinServerEntity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/database/entities/JellyfinServerEntity.kt
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+
+@Entity(tableName = "jellyfin_servers")
+data class JellyfinServerEntity(
+  @PrimaryKey(autoGenerate = true)
+  val id: Long = 0,
+  val name: String,
+  val serverUrl: String,
+  val userId: String,
+  val username: String,
+  val accessToken: String,
+  val lastConnected: Long = 0,
+) {
+  fun toDomain(): JellyfinServer =
+    JellyfinServer(
+      id = id,
+      name = name,
+      serverUrl = serverUrl,
+      userId = userId,
+      username = username,
+      accessToken = accessToken,
+      lastConnected = lastConnected,
+    )
+
+  companion object {
+    fun fromDomain(server: JellyfinServer): JellyfinServerEntity =
+      JellyfinServerEntity(
+        id = server.id,
+        name = server.name,
+        serverUrl = server.serverUrl,
+        userId = server.userId,
+        username = server.username,
+        accessToken = server.accessToken,
+        lastConnected = server.lastConnected,
+      )
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/di/DatabaseModule.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/di/DatabaseModule.kt
@@ -662,6 +662,25 @@ val MIGRATION_13_14 =
     }
   }
 
+val MIGRATION_14_15 =
+  object : Migration(14, 15) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL(
+        """
+        CREATE TABLE IF NOT EXISTS `jellyfin_servers` (
+          `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+          `name` TEXT NOT NULL,
+          `serverUrl` TEXT NOT NULL,
+          `userId` TEXT NOT NULL,
+          `username` TEXT NOT NULL,
+          `accessToken` TEXT NOT NULL,
+          `lastConnected` INTEGER NOT NULL DEFAULT 0
+        )
+        """.trimIndent(),
+      )
+    }
+  }
+
 val DatabaseModule =
   module {
     single<Json> {
@@ -690,6 +709,7 @@ val DatabaseModule =
           MIGRATION_11_12,
           MIGRATION_12_13,
           MIGRATION_13_14,
+          MIGRATION_14_15,
         ).build()
     }
 
@@ -747,6 +767,24 @@ val DatabaseModule =
     single {
       app.gyrolet.mpvrx.database.repository.SecureFolderRepository(
         dao = get<MpvRxDatabase>().secureMediaDao(),
+      )
+    }
+
+    single {
+      get<MpvRxDatabase>().jellyfinServerDao()
+    }
+
+    single {
+      app.gyrolet.mpvrx.data.jellyfin.JellyfinClient(
+        httpClient = get(),
+        json = get(),
+      )
+    }
+
+    single {
+      app.gyrolet.mpvrx.repository.JellyfinRepository(
+        dao = get(),
+        client = get(),
       )
     }
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
@@ -105,6 +105,8 @@ data class JellyfinAuthResult(
   val userId: String,
   val username: String,
   val serverId: String? = null,
+  val audioLanguage: String? = null,
+  val subtitleLanguage: String? = null,
 )
 
 @Serializable
@@ -112,4 +114,6 @@ data class JellyfinUser(
   val id: String,
   val name: String,
   val serverId: String? = null,
+  val audioLanguage: String? = null,
+  val subtitleLanguage: String? = null,
 )

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.domain.jellyfin
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
+
+@Immutable
+@Serializable
+data class JellyfinServer(
+  val id: Long = 0,
+  val name: String,
+  val serverUrl: String,
+  val userId: String,
+  val username: String,
+  val accessToken: String,
+  val lastConnected: Long = 0,
+)
+
+enum class JellyfinAuthMode {
+  CREDENTIALS,
+  TOKEN,
+}
+
+enum class JellyfinSortBy(val apiValue: String, val displayName: String) {
+  NAME("SortName", "Title"),
+  DATE_ADDED("DateCreated", "Recently Added"),
+  PREMIERE_DATE("PremiereDate", "Release Date"),
+  RATING("CommunityRating", "Rating"),
+  RUNTIME("Runtime", "Duration"),
+}
+
+enum class JellyfinSortOrder(val apiValue: String, val displayName: String) {
+  ASCENDING("Ascending", "Ascending"),
+  DESCENDING("Descending", "Descending"),
+}
+
+@Immutable
+data class JellyfinQueryResult(
+  val items: List<JellyfinItem>,
+  val totalRecordCount: Int,
+  val startIndex: Int,
+)
+
+@Immutable
+@Serializable
+data class JellyfinItem(
+  val id: String,
+  val name: String,
+  val type: String, // CollectionFolder, Movie, Series, Season, Episode, Audio, Folder, etc.
+  val collectionType: String? = null,
+  val overview: String? = null,
+  val runTimeTicks: Long? = null,
+  val playbackPositionTicks: Long? = null,
+  val isPlayed: Boolean = false,
+  val seriesName: String? = null,
+  val seasonName: String? = null,
+  val indexNumber: Int? = null, // Episode number
+  val parentIndexNumber: Int? = null, // Season number
+  val productionYear: Int? = null,
+  val communityRating: Double? = null,
+  val isFolder: Boolean = false,
+  val primaryImageTag: String? = null,
+  val backdropImageTag: String? = null,
+  val childCount: Int? = null,
+  val container: String? = null,
+) {
+  val isVideo: Boolean
+    get() = type == "Movie" || type == "Episode" || type == "Video"
+
+  val isAudio: Boolean
+    get() = type == "Audio"
+
+  val isSeries: Boolean
+    get() = type == "Series"
+
+  val isSeason: Boolean
+    get() = type == "Season"
+
+  val durationSeconds: Long
+    get() = (runTimeTicks ?: 0L) / 10_000_000L
+
+  val resumePositionSeconds: Long
+    get() = (playbackPositionTicks ?: 0L) / 10_000_000L
+
+  val progressPercent: Float
+    get() {
+      val dur = runTimeTicks ?: return 0f
+      val pos = playbackPositionTicks ?: return 0f
+      if (dur <= 0L) return 0f
+      return (pos.toFloat() / dur.toFloat()).coerceIn(0f, 1f)
+    }
+}
+
+@Serializable
+data class JellyfinAuthResult(
+  val accessToken: String,
+  val userId: String,
+  val username: String,
+  val serverId: String? = null,
+)
+
+@Serializable
+data class JellyfinUser(
+  val id: String,
+  val name: String,
+  val serverId: String? = null,
+)

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
@@ -97,6 +97,18 @@ data class JellyfinItem(
       if (dur <= 0L) return 0f
       return (pos.toFloat() / dur.toFloat()).coerceIn(0f, 1f)
     }
+
+  val searchPriority: Int
+    get() =
+      when (type) {
+        "Series" -> 0
+        "Movie" -> 1
+        "CollectionFolder", "Folder" -> 2
+        "Season" -> 3
+        "Episode" -> 4
+        "Audio" -> 5
+        else -> 6
+      }
 }
 
 @Serializable

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/thumbnail/ThumbnailRepository.kt
@@ -15,6 +15,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.os.Build
 import android.util.LruCache
 import app.gyrolet.mpvrx.data.network.proxy.NetworkStreamingProxy
@@ -118,7 +119,7 @@ class ThumbnailRepository(
     withContext(Dispatchers.IO) {
       val key = thumbnailKey(video, widthPx, heightPx)
 
-      if (isNetworkUrl(video.path) && !appearancePreferences.showNetworkThumbnails.get()) {
+      if (isNetworkUrl(video.path) && !isNetworkThumbnailAllowed(video.path)) {
         return@withContext null
       }
 
@@ -179,7 +180,7 @@ class ThumbnailRepository(
     heightPx: Int,
   ): Bitmap? =
     withContext(Dispatchers.IO) {
-      if (isNetworkUrl(video.path) && !appearancePreferences.showNetworkThumbnails.get()) {
+      if (isNetworkUrl(video.path) && !isNetworkThumbnailAllowed(video.path)) {
         return@withContext null
       }
 
@@ -203,7 +204,7 @@ class ThumbnailRepository(
     widthPx: Int,
     heightPx: Int,
   ): Bitmap? {
-    if (isNetworkUrl(video.path) && !appearancePreferences.showNetworkThumbnails.get()) {
+    if (isNetworkUrl(video.path) && !isNetworkThumbnailAllowed(video.path)) {
       return null
     }
 
@@ -624,6 +625,18 @@ class ThumbnailRepository(
     widthPx: Int,
     heightPx: Int,
   ): Bitmap? {
+    val jellyfinImageUrls = extractJellyfinImageUrls(video.path, maxOf(widthPx, heightPx, 400))
+    for (url in jellyfinImageUrls) {
+      val jellyfinBitmap = fetchHttpImage(url)
+      if (jellyfinBitmap != null) {
+        return scaleBitmap(jellyfinBitmap, widthPx, heightPx)
+      }
+    }
+
+    if (!appearancePreferences.showNetworkThumbnails.get()) {
+      return null
+    }
+
     val strategy =
       browserPreferences.thumbnailMode.get().toThumbnailStrategy(
         browserPreferences.thumbnailFramePosition.get(),
@@ -639,6 +652,64 @@ class ThumbnailRepository(
 
     return scaleBitmap(rotated, widthPx, heightPx)
   }
+
+  private fun isNetworkThumbnailAllowed(path: String): Boolean =
+    extractJellyfinImageUrls(path).isNotEmpty() || appearancePreferences.showNetworkThumbnails.get()
+
+  private fun extractJellyfinImageUrls(url: String, maxWidth: Int = 400): List<String> =
+    runCatching {
+      val uri = Uri.parse(url)
+      val pathSegments = uri.pathSegments
+      val videosIndex = pathSegments.indexOf("Videos")
+      val itemsIndex = pathSegments.indexOf("Items")
+      val audioIndex = pathSegments.indexOf("Audio")
+      val targetIndex =
+        when {
+          videosIndex != -1 -> videosIndex
+          itemsIndex != -1 -> itemsIndex
+          audioIndex != -1 -> audioIndex
+          else -> -1
+        }
+      if (targetIndex == -1 || targetIndex + 1 >= pathSegments.size) return emptyList()
+      val itemId = pathSegments[targetIndex + 1]
+      val apiKey = uri.getQueryParameter("api_key") ?: uri.getQueryParameter("ApiKey")
+      val scheme = uri.scheme ?: "http"
+      val authority = uri.encodedAuthority ?: return emptyList()
+      val subPathSegments = pathSegments.subList(0, targetIndex)
+      val base =
+        if (subPathSegments.isEmpty()) {
+          "$scheme://$authority"
+        } else {
+          "$scheme://$authority/" + subPathSegments.joinToString("/")
+        }
+      val tokenParam = if (!apiKey.isNullOrBlank()) "&api_key=$apiKey" else ""
+      listOf(
+        "$base/Items/$itemId/Images/Primary?maxWidth=$maxWidth&quality=80$tokenParam",
+        "$base/Items/$itemId/Images/Primary?fallback=true&maxWidth=$maxWidth&quality=80$tokenParam",
+        "$base/Items/$itemId/Images/Thumb?maxWidth=$maxWidth&quality=80$tokenParam",
+        "$base/Items/$itemId/Images/Backdrop/0?maxWidth=$maxWidth&quality=80$tokenParam",
+      )
+    }.getOrDefault(emptyList())
+
+  private suspend fun fetchHttpImage(url: String): Bitmap? =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val connection =
+          (java.net.URL(url).openConnection() as java.net.HttpURLConnection).apply {
+            connectTimeout = 4000
+            readTimeout = 6000
+            instanceFollowRedirects = true
+            setRequestProperty("User-Agent", "mpvRx/1.0")
+          }
+        if (connection.responseCode in 200..299) {
+          connection.inputStream.use { stream ->
+            BitmapFactory.decodeStream(stream)
+          }
+        } else {
+          null
+        }
+      }.getOrNull()
+    }
 
   private fun extractNetworkVideoFrame(
     url: String,

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
@@ -58,6 +58,7 @@ class AppearancePreferences(
   val showRecentsTab = preferenceStore.getBoolean("show_recents_tab", true)
   val showPlaylistsTab = preferenceStore.getBoolean("show_playlists_tab", true)
   val showNetworkTab = preferenceStore.getBoolean("show_network_tab", false)
+  val showJellyfinTab = preferenceStore.getBoolean("show_jellyfin_tab", false)
   val showQuickPlayFab = preferenceStore.getBoolean("show_quick_play_fab", true)
   val quickPlayFabDirect = preferenceStore.getBoolean("quick_play_fab_direct", false)
 

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/BrowserPreferences.kt
@@ -46,6 +46,7 @@ class BrowserPreferences(
   val networkSortType = preferenceStore.getEnum("network_sort_type", NetworkSortType.Title)
   val networkSortOrder = preferenceStore.getEnum("network_sort_order", SortOrder.Ascending)
   val networkLayoutMode = preferenceStore.getEnum("network_layout_mode", MediaLayoutMode.LIST)
+  val jellyfinLayoutMode = preferenceStore.getEnum("jellyfin_layout_mode", MediaLayoutMode.GRID)
 
   val folderViewMode = preferenceStore.getEnum("folder_view_mode", FolderViewMode.AlbumView)
   val dualPaneForTablet = preferenceStore.getBoolean("dual_pane_for_tablet", true)

--- a/app/src/main/java/app/gyrolet/mpvrx/repository/JellyfinRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/repository/JellyfinRepository.kt
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.repository
+
+import app.gyrolet.mpvrx.data.jellyfin.JellyfinClient
+import app.gyrolet.mpvrx.database.dao.JellyfinServerDao
+import app.gyrolet.mpvrx.database.entities.JellyfinServerEntity
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinAuthResult
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinItem
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinUser
+import app.gyrolet.mpvrx.utils.media.PlaybackSubtitleTrack
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class JellyfinRepository(
+  private val dao: JellyfinServerDao,
+  private val client: JellyfinClient,
+) {
+  val allServers: Flow<List<JellyfinServer>> =
+    dao.getAllServers().map { list -> list.map { it.toDomain() } }
+
+  suspend fun getServerById(id: Long): JellyfinServer? =
+    dao.getServerById(id)?.toDomain()
+
+  suspend fun saveServer(server: JellyfinServer): Long =
+    dao.insert(JellyfinServerEntity.fromDomain(server))
+
+  suspend fun updateServer(server: JellyfinServer) =
+    dao.update(JellyfinServerEntity.fromDomain(server))
+
+  suspend fun deleteServer(server: JellyfinServer) =
+    dao.delete(JellyfinServerEntity.fromDomain(server))
+
+  suspend fun authenticate(
+    serverUrl: String,
+    username: String,
+    password: String,
+  ): Result<JellyfinAuthResult> =
+    client.authenticate(serverUrl, username, password)
+
+  suspend fun validateToken(
+    serverUrl: String,
+    token: String,
+  ): Result<JellyfinUser> =
+    client.validateToken(serverUrl, token)
+
+  suspend fun getLibraries(server: JellyfinServer): Result<List<JellyfinItem>> =
+    client.getUserLibraries(server.serverUrl, server.userId, server.accessToken)
+
+  suspend fun getResumeItems(
+    server: JellyfinServer,
+    limit: Int = 12,
+  ): Result<List<JellyfinItem>> =
+    client.getResumeItems(server.serverUrl, server.userId, server.accessToken, limit)
+
+  suspend fun getItems(
+    server: JellyfinServer,
+    parentId: String? = null,
+    searchTerm: String? = null,
+    sortBy: app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy = app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.NAME,
+    sortOrder: app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder = app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder.ASCENDING,
+    isPlayed: Boolean? = null,
+    startIndex: Int = 0,
+    limit: Int = 100,
+  ): Result<app.gyrolet.mpvrx.domain.jellyfin.JellyfinQueryResult> =
+    client.getItems(
+      serverUrl = server.serverUrl,
+      userId = server.userId,
+      parentId = parentId,
+      searchTerm = searchTerm,
+      sortBy = sortBy,
+      sortOrder = sortOrder,
+      isPlayed = isPlayed,
+      startIndex = startIndex,
+      limit = limit,
+      token = server.accessToken,
+    )
+
+  suspend fun getSeasons(
+    server: JellyfinServer,
+    seriesId: String,
+  ): Result<List<JellyfinItem>> =
+    client.getSeasons(
+      serverUrl = server.serverUrl,
+      userId = server.userId,
+      seriesId = seriesId,
+      token = server.accessToken,
+    )
+
+  suspend fun getEpisodes(
+    server: JellyfinServer,
+    seriesId: String,
+    seasonId: String,
+  ): Result<List<JellyfinItem>> =
+    client.getEpisodes(
+      serverUrl = server.serverUrl,
+      userId = server.userId,
+      seriesId = seriesId,
+      seasonId = seasonId,
+      token = server.accessToken,
+    )
+
+  suspend fun getSubtitleTracks(
+    server: JellyfinServer,
+    itemId: String,
+  ): Result<List<PlaybackSubtitleTrack>> =
+    client.getSubtitleTracks(
+      serverUrl = server.serverUrl,
+      token = server.accessToken,
+      userId = server.userId,
+      itemId = itemId,
+    )
+
+  fun getStreamUrl(
+    server: JellyfinServer,
+    item: JellyfinItem,
+  ): String =
+    client.getStreamUrl(
+      serverUrl = server.serverUrl,
+      itemId = item.id,
+      token = server.accessToken,
+      isAudio = item.isAudio,
+    )
+
+  fun getImageUrl(
+    server: JellyfinServer,
+    item: JellyfinItem,
+    maxWidth: Int = 400,
+  ): String =
+    client.getImageUrl(
+      serverUrl = server.serverUrl,
+      itemId = item.id,
+      imageTag = item.primaryImageTag,
+      maxWidth = maxWidth,
+      token = server.accessToken,
+    )
+
+  fun getBackdropUrl(
+    server: JellyfinServer,
+    item: JellyfinItem,
+    maxWidth: Int = 1280,
+  ): String =
+    client.getBackdropUrl(
+      serverUrl = server.serverUrl,
+      itemId = item.id,
+      imageTag = item.backdropImageTag,
+      maxWidth = maxWidth,
+      token = server.accessToken,
+    )
+
+  suspend fun reportPlaybackStart(
+    serverUrl: String,
+    token: String,
+    itemId: String,
+    positionTicks: Long,
+  ) = client.reportPlaybackStart(serverUrl, token, itemId, positionTicks)
+
+  suspend fun reportPlaybackProgress(
+    serverUrl: String,
+    token: String,
+    itemId: String,
+    positionTicks: Long,
+    isPaused: Boolean = false,
+  ) = client.reportPlaybackProgress(serverUrl, token, itemId, positionTicks, isPaused)
+
+  suspend fun reportPlaybackStopped(
+    serverUrl: String,
+    token: String,
+    itemId: String,
+    positionTicks: Long,
+  ) = client.reportPlaybackStopped(serverUrl, token, itemId, positionTicks)
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/repository/JellyfinRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/repository/JellyfinRepository.kt
@@ -177,4 +177,26 @@ class JellyfinRepository(
     itemId: String,
     positionTicks: Long,
   ) = client.reportPlaybackStopped(serverUrl, token, itemId, positionTicks)
+
+  suspend fun markPlayed(
+    server: JellyfinServer,
+    item: JellyfinItem,
+  ): Result<Unit> =
+    client.markPlayed(
+      serverUrl = server.serverUrl,
+      userId = server.userId,
+      itemId = item.id,
+      token = server.accessToken,
+    )
+
+  suspend fun markUnplayed(
+    server: JellyfinServer,
+    item: JellyfinItem,
+  ): Result<Unit> =
+    client.markUnplayed(
+      serverUrl = server.serverUrl,
+      userId = server.userId,
+      itemId = item.id,
+      token = server.accessToken,
+    )
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -105,6 +105,7 @@ object MainScreen : Screen {
     RECENTS,
     PLAYLISTS,
     NETWORK,
+    JELLYFIN,
   }
 
   // Use a companion object to store state more persistently
@@ -144,8 +145,8 @@ object MainScreen : Screen {
     NavigationBarState.updateBottomBarVisibility(shouldShow)
   }
 
+  @SuppressLint("ComposableNaming")
   @Composable
-  @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
   override fun Content() {
     var selectedTab by remember {
       mutableStateOf(persistentSelectedTab)
@@ -161,6 +162,7 @@ object MainScreen : Screen {
     val showRecentsTab by appearancePreferences.showRecentsTab.collectAsState()
     val showPlaylistsTab by appearancePreferences.showPlaylistsTab.collectAsState()
     val showNetworkTab by appearancePreferences.showNetworkTab.collectAsState()
+    val showJellyfinTab by appearancePreferences.showJellyfinTab.collectAsState()
     val hideNavigationBar = NavigationBarState.shouldHideNavigationBar
     val isPermissionDenied = NavigationBarState.isPermissionDenied
     val isDualPaneFolderSelected = NavigationBarState.isDualPaneFolderSelected
@@ -169,17 +171,20 @@ object MainScreen : Screen {
     val visibleTabs =
       remember(
         showHomeTab,
+        showMusicTab,
         showRecentsTab,
         showPlaylistsTab,
         showNetworkTab,
+        showJellyfinTab,
       ) {
-      buildList {
-        if (showHomeTab) add(MainTab.HOME)
-        if (showMusicTab) add(MainTab.MUSIC)
-        if (showRecentsTab) add(MainTab.RECENTS)
-        if (showPlaylistsTab) add(MainTab.PLAYLISTS)
-        if (showNetworkTab) add(MainTab.NETWORK)
-      }
+        buildList {
+          if (showHomeTab) add(MainTab.HOME)
+          if (showMusicTab) add(MainTab.MUSIC)
+          if (showRecentsTab) add(MainTab.RECENTS)
+          if (showPlaylistsTab) add(MainTab.PLAYLISTS)
+          if (showNetworkTab) add(MainTab.NETWORK)
+          if (showJellyfinTab) add(MainTab.JELLYFIN)
+        }
       }
 
     // Track whether the floating pill nav bar is on screen so the mini player can
@@ -306,6 +311,14 @@ object MainScreen : Screen {
       Box(modifier = Modifier.fillMaxSize()) {
         val fabBottomPadding = 88.dp
         val contentBottomPadding = fabBottomPadding + miniPlayerNavClearance
+        val context = androidx.compose.ui.platform.LocalContext.current
+        val jellyfinViewModel: app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel =
+          androidx.lifecycle.viewmodel.compose.viewModel(
+            factory =
+              app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel.factory(
+                context.applicationContext as android.app.Application,
+              ),
+          )
 
         if (visibleTabs.isEmpty()) {
           CompositionLocalProvider(
@@ -332,6 +345,7 @@ object MainScreen : Screen {
                 MainTab.RECENTS -> RecentlyPlayedScreen.Content()
                 MainTab.PLAYLISTS -> PlaylistScreen.Content()
                 MainTab.NETWORK -> NetworkStreamingScreen.Content()
+                MainTab.JELLYFIN -> app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinContent(viewModel = jellyfinViewModel)
               }
             }
           }
@@ -539,18 +553,26 @@ private fun TelegramPillNavigationBar(
                         tint = contentColor,
                         modifier = Modifier.size(22.dp),
                       )
+                    MainScreen.MainTab.JELLYFIN ->
+                      Icon(
+                        Icons.RoundedFilled.VideoLibrary,
+                        contentDescription = "Jellyfin",
+                        tint = contentColor,
+                        modifier = Modifier.size(22.dp),
+                      )
                   }
                 }
                 Spacer(modifier = Modifier.height(3.dp))
-                  Text(
-                    text =
-                      when (tab) {
-                        MainScreen.MainTab.HOME -> "Home"
-                        MainScreen.MainTab.MUSIC -> "Music"
-                        MainScreen.MainTab.RECENTS -> "Recents"
-                        MainScreen.MainTab.PLAYLISTS -> "Playlists"
-                        MainScreen.MainTab.NETWORK -> "Network"
-                      },
+                Text(
+                  text =
+                    when (tab) {
+                      MainScreen.MainTab.HOME -> stringResource(R.string.ui_home)
+                      MainScreen.MainTab.MUSIC -> stringResource(R.string.ui_music)
+                      MainScreen.MainTab.RECENTS -> stringResource(R.string.ui_recents)
+                      MainScreen.MainTab.PLAYLISTS -> stringResource(R.string.ui_playlists)
+                      MainScreen.MainTab.NETWORK -> stringResource(R.string.ui_network)
+                      MainScreen.MainTab.JELLYFIN -> stringResource(R.string.ui_jellyfin)
+                    },
                   style = MaterialTheme.typography.labelSmall,
                   fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
                   color = contentColor,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -554,8 +555,8 @@ private fun TelegramPillNavigationBar(
                         modifier = Modifier.size(22.dp),
                       )
                     MainScreen.MainTab.JELLYFIN ->
-                      Icon(
-                        Icons.RoundedFilled.VideoLibrary,
+                      androidx.compose.material3.Icon(
+                        painter = painterResource(R.drawable.ic_jellyfin),
                         contentDescription = "Jellyfin",
                         tint = contentColor,
                         modifier = Modifier.size(22.dp),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/VideoCard.kt
@@ -166,7 +166,7 @@ fun VideoCard(
     } else if (video.isAudio && video.title.isNotBlank()) {
       video.title
     } else {
-      video.displayName.substringBeforeLast('.')
+      app.gyrolet.mpvrx.utils.storage.FileTypeUtils.stripExtension(video.displayName)
     }
 
   val selectionInset = 2.dp

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/BrowserSortDialogs.kt
@@ -1140,3 +1140,87 @@ fun MusicSortDialog(
       },
   )
 }
+
+@Composable
+fun JellyfinSortDialog(
+  isOpen: Boolean,
+  onDismiss: () -> Unit,
+  sortBy: app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy,
+  onSortByChange: (app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy) -> Unit,
+  sortOrder: app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder,
+  onSortOrderChange: (app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder) -> Unit,
+  isUnplayedOnly: Boolean,
+  onUnplayedOnlyChange: (Boolean) -> Unit,
+  layoutMode: MediaLayoutMode = MediaLayoutMode.GRID,
+  onLayoutModeChange: (MediaLayoutMode) -> Unit = {},
+) {
+  SortDialog(
+    isOpen = isOpen,
+    onDismiss = onDismiss,
+    title = stringResource(R.string.sort_view_options),
+    sortType = sortBy.displayName,
+    onSortTypeChange = { typeName ->
+      app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.entries
+        .find { it.displayName == typeName }
+        ?.let(onSortByChange)
+    },
+    sortOrderAsc = sortOrder == app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder.ASCENDING,
+    onSortOrderChange = { isAsc ->
+      onSortOrderChange(
+        if (isAsc) {
+          app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder.ASCENDING
+        } else {
+          app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder.DESCENDING
+        },
+      )
+    },
+    types =
+      listOf(
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.NAME.displayName,
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.DATE_ADDED.displayName,
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.PREMIERE_DATE.displayName,
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.RATING.displayName,
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.RUNTIME.displayName,
+      ),
+    icons =
+      listOf(
+        Icons.RoundedFilled.Title,
+        Icons.RoundedFilled.CalendarToday,
+        Icons.RoundedFilled.Movie,
+        Icons.RoundedFilled.SwapVert,
+        Icons.RoundedFilled.AccessTime,
+      ),
+    getLabelForType = { type, _ ->
+      when (type) {
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.NAME.displayName -> Pair("A-Z", "Z-A")
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.DATE_ADDED.displayName -> Pair("Oldest", "Newest")
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.PREMIERE_DATE.displayName -> Pair("Oldest", "Newest")
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.RATING.displayName -> Pair("Lowest", "Highest")
+        app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy.RUNTIME.displayName -> Pair("Shortest", "Longest")
+        else -> Pair("Asc", "Desc")
+      }
+    },
+    visibilityToggles =
+      listOf(
+        VisibilityToggle(
+          label = "Unplayed Only",
+          checked = isUnplayedOnly,
+          onCheckedChange = onUnplayedOnlyChange,
+        ),
+      ),
+    layoutModeSelector =
+      ViewModeSelector(
+        label = "Layout",
+        firstOptionLabel = "List",
+        secondOptionLabel = "Grid",
+        firstOptionIcon = Icons.RoundedFilled.ViewList,
+        secondOptionIcon = Icons.RoundedFilled.GridView,
+        isFirstOptionSelected = layoutMode == MediaLayoutMode.LIST,
+        onViewModeChange = { isList ->
+          onLayoutModeChange(if (isList) MediaLayoutMode.LIST else MediaLayoutMode.GRID)
+        },
+      ),
+    showSortOptions = true,
+  )
+}
+

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/AddJellyfinServerDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/AddJellyfinServerDialog.kt
@@ -1,0 +1,343 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.browser.jellyfin
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinAuthMode
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+import app.gyrolet.mpvrx.ui.icons.Icon
+import app.gyrolet.mpvrx.ui.icons.Icons
+
+@Composable
+fun AddJellyfinServerDialog(
+  isOpen: Boolean,
+  isLoading: Boolean,
+  errorMessage: String?,
+  onDismiss: () -> Unit,
+  onConnect: (serverUrl: String, serverName: String, authMode: JellyfinAuthMode, username: String, password: String, token: String) -> Unit,
+) {
+  if (!isOpen) return
+
+  var serverUrl by remember { mutableStateOf("") }
+  var serverName by remember { mutableStateOf("") }
+  var authMode by remember { mutableStateOf(JellyfinAuthMode.CREDENTIALS) }
+  var username by remember { mutableStateOf("") }
+  var password by remember { mutableStateOf("") }
+  var token by remember { mutableStateOf("") }
+
+  val canConnect =
+    serverUrl.isNotBlank() &&
+      when (authMode) {
+        JellyfinAuthMode.CREDENTIALS -> username.isNotBlank()
+        JellyfinAuthMode.TOKEN -> token.isNotBlank()
+      }
+
+  AlertDialog(
+    onDismissRequest = { if (!isLoading) onDismiss() },
+    title = {
+      Text(
+        text = "Add Jellyfin Server",
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+      )
+    },
+    text = {
+      Column(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        OutlinedTextField(
+          value = serverUrl,
+          onValueChange = { serverUrl = it },
+          label = { Text("Server URL") },
+          placeholder = { Text("http://192.168.1.100:8096") },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth(),
+          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+        )
+
+        OutlinedTextField(
+          value = serverName,
+          onValueChange = { serverName = it },
+          label = { Text("Display Name (Optional)") },
+          placeholder = { Text("Home Jellyfin") },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth(),
+        )
+
+        Text(
+          text = "Authentication Method",
+          style = MaterialTheme.typography.bodyMedium,
+          fontWeight = FontWeight.SemiBold,
+        )
+
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          FilterChip(
+            selected = authMode == JellyfinAuthMode.CREDENTIALS,
+            onClick = { authMode = JellyfinAuthMode.CREDENTIALS },
+            label = { Text("Username & Password") },
+          )
+          FilterChip(
+            selected = authMode == JellyfinAuthMode.TOKEN,
+            onClick = { authMode = JellyfinAuthMode.TOKEN },
+            label = { Text("API Token") },
+          )
+        }
+
+        if (authMode == JellyfinAuthMode.CREDENTIALS) {
+          OutlinedTextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Username") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+          )
+
+          OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth(),
+          )
+        } else {
+          OutlinedTextField(
+            value = token,
+            onValueChange = { token = it },
+            label = { Text("Access Token / API Key") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        if (!errorMessage.isNullOrBlank()) {
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+            text = errorMessage,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+          )
+        }
+      }
+    },
+    confirmButton = {
+      Button(
+        onClick = {
+          onConnect(serverUrl, serverName, authMode, username, password, token)
+        },
+        enabled = canConnect && !isLoading,
+      ) {
+        if (isLoading) {
+          CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            strokeWidth = 2.dp,
+            color = MaterialTheme.colorScheme.onPrimary,
+          )
+          Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text("Connect")
+      }
+    },
+    dismissButton = {
+      TextButton(
+        onClick = onDismiss,
+        enabled = !isLoading,
+      ) {
+        Text("Cancel")
+      }
+    },
+  )
+}
+
+@Composable
+fun ManageJellyfinServersDialog(
+  isOpen: Boolean,
+  servers: List<JellyfinServer>,
+  activeServer: JellyfinServer?,
+  onDismiss: () -> Unit,
+  onSelectServer: (JellyfinServer) -> Unit,
+  onDeleteServer: (JellyfinServer) -> Unit,
+  onAddServerClick: () -> Unit,
+) {
+  if (!isOpen) return
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = {
+      Text(
+        text = "Jellyfin Servers",
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+      )
+    },
+    text = {
+      Column(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        if (servers.isEmpty()) {
+          Text(
+            text = "No servers connected yet.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        } else {
+          servers.forEach { server ->
+            val isSelected = server.id == activeServer?.id
+            Surface(
+              shape = RoundedCornerShape(12.dp),
+              color =
+                if (isSelected) {
+                  MaterialTheme.colorScheme.primaryContainer
+                } else {
+                  MaterialTheme.colorScheme.surfaceContainer
+                },
+              modifier =
+                Modifier
+                  .fillMaxWidth()
+                  .clip(RoundedCornerShape(12.dp))
+                  .clickable {
+                    onSelectServer(server)
+                    onDismiss()
+                  },
+            ) {
+              Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+              ) {
+                Icon(
+                  imageVector = Icons.RoundedFilled.BringYourOwnIp,
+                  contentDescription = null,
+                  tint =
+                    if (isSelected) {
+                      MaterialTheme.colorScheme.primary
+                    } else {
+                      MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                  modifier = Modifier.size(24.dp),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                  Text(
+                    text = server.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                    color =
+                      if (isSelected) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                      } else {
+                        MaterialTheme.colorScheme.onSurface
+                      },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                  )
+                  Text(
+                    text = server.serverUrl,
+                    style = MaterialTheme.typography.bodySmall,
+                    color =
+                      if (isSelected) {
+                        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                      } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                      },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                  )
+                }
+                IconButton(
+                  onClick = { onDeleteServer(server) },
+                  modifier = Modifier.size(32.dp),
+                ) {
+                  Icon(
+                    imageVector = Icons.RoundedFilled.Delete,
+                    contentDescription = "Remove Server",
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(18.dp),
+                  )
+                }
+              }
+            }
+          }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+          onClick = {
+            onDismiss()
+            onAddServerClick()
+          },
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          Icon(
+            imageVector = Icons.RoundedFilled.Add,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+          )
+          Spacer(modifier = Modifier.width(8.dp))
+          Text("Add New Server")
+        }
+      }
+    },
+    confirmButton = {
+      TextButton(onClick = onDismiss) {
+        Text("Done")
+      }
+    },
+  )
+}
+

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
@@ -1,0 +1,628 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.browser.jellyfin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.data.jellyfin.JellyfinClient
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinItem
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+import app.gyrolet.mpvrx.presentation.components.RemoteImage
+import app.gyrolet.mpvrx.ui.icons.Icon
+import app.gyrolet.mpvrx.ui.icons.Icons
+
+@Composable
+fun JellyfinLibraryCard(
+  item: JellyfinItem,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Card(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clickable(onClick = onClick),
+    shape = RoundedCornerShape(16.dp),
+    colors =
+      CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+      ),
+  ) {
+    Row(
+      modifier = Modifier.padding(16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      Box(
+        modifier =
+          Modifier
+            .size(48.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+      ) {
+        val icon =
+          when (item.collectionType?.lowercase() ?: item.type.lowercase()) {
+            "movies", "tvshows" -> Icons.RoundedFilled.Movie
+            "music" -> Icons.RoundedFilled.Audiotrack
+            else -> Icons.RoundedFilled.Folder
+          }
+        Icon(
+          imageVector = icon,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+          modifier = Modifier.size(24.dp),
+        )
+      }
+
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = item.name,
+          style = MaterialTheme.typography.titleMedium,
+          fontWeight = FontWeight.SemiBold,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        val typeLabel =
+          when (item.collectionType?.lowercase()) {
+            "movies" -> "Movies"
+            "tvshows" -> "TV Shows"
+            "music" -> "Music"
+            "books" -> "Books"
+            "homevideos" -> "Home Videos"
+            "photos" -> "Photos"
+            else ->
+              when (item.type) {
+                "CollectionFolder" -> "Collection"
+                "Folder" -> "Folder"
+                else -> item.type.replace(Regex("([a-z])([A-Z])"), "$1 $2")
+              }
+          }
+        Text(
+          text = typeLabel,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
+      Icon(
+        imageVector = Icons.RoundedFilled.ChevronRight,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+}
+
+@Composable
+fun JellyfinPosterCard(
+  item: JellyfinItem,
+  server: JellyfinServer,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val imageUrl =
+    JellyfinClient.getImageUrl(
+      serverUrl = server.serverUrl,
+      itemId = item.id,
+      imageTag = item.primaryImageTag,
+      maxWidth = 400,
+      token = server.accessToken,
+    )
+
+  Card(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(12.dp))
+        .clickable(onClick = onClick),
+    shape = RoundedCornerShape(12.dp),
+    colors =
+      CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+      ),
+  ) {
+    Column {
+      Box(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .aspectRatio(2f / 3f)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+      ) {
+        if (!item.primaryImageTag.isNullOrBlank()) {
+          RemoteImage(
+            url = imageUrl,
+            contentDescription = item.name,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+          )
+        } else {
+          Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+          ) {
+            val placeholderIcon =
+              when {
+                item.isAudio -> Icons.RoundedFilled.Audiotrack
+                item.isFolder -> Icons.RoundedFilled.Folder
+                else -> Icons.RoundedFilled.VideoLibrary
+              }
+            Icon(
+              imageVector = placeholderIcon,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+              modifier = Modifier.size(36.dp),
+            )
+          }
+        }
+
+        // Progress bar if partially watched
+        if (item.progressPercent > 0.02f && !item.isPlayed) {
+          LinearProgressIndicator(
+            progress = { item.progressPercent },
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .height(4.dp),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f),
+          )
+        }
+
+        // Unplayed badge / checkmark
+        if (item.isPlayed) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+            modifier =
+              Modifier
+                .padding(6.dp)
+                .size(20.dp)
+                .align(Alignment.TopEnd),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Check,
+              contentDescription = "Played",
+              tint = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.padding(3.dp),
+            )
+          }
+        }
+      }
+
+      Column(modifier = Modifier.padding(8.dp)) {
+        Text(
+          text = item.name,
+          style = MaterialTheme.typography.bodyMedium,
+          fontWeight = FontWeight.Medium,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        val subtitle =
+          item.productionYear?.toString()
+            ?: if (item.isSeries && item.childCount != null) "${item.childCount} Seasons" else item.type
+        Text(
+          text = subtitle,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+fun JellyfinEpisodeCard(
+  item: JellyfinItem,
+  server: JellyfinServer,
+  onPlay: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val imageUrl =
+    JellyfinClient.getImageUrl(
+      serverUrl = server.serverUrl,
+      itemId = item.id,
+      imageTag = item.primaryImageTag,
+      maxWidth = 300,
+      token = server.accessToken,
+    )
+
+  Card(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clickable(onClick = onPlay),
+    shape = RoundedCornerShape(12.dp),
+    colors =
+      CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+      ),
+  ) {
+    Row(
+      modifier = Modifier.padding(10.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Box(
+        modifier =
+          Modifier
+            .width(96.dp)
+            .aspectRatio(16f / 9f)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+      ) {
+        if (!item.primaryImageTag.isNullOrBlank()) {
+          RemoteImage(
+            url = imageUrl,
+            contentDescription = item.name,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+          )
+        } else {
+          Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.PlayArrow,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+
+        if (item.progressPercent > 0.02f && !item.isPlayed) {
+          LinearProgressIndicator(
+            progress = { item.progressPercent },
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .height(3.dp),
+            color = MaterialTheme.colorScheme.primary,
+          )
+        }
+      }
+
+      Column(modifier = Modifier.weight(1f)) {
+        val epPrefix = if (item.indexNumber != null) "E${item.indexNumber} • " else ""
+        Text(
+          text = "$epPrefix${item.name}",
+          style = MaterialTheme.typography.bodyMedium,
+          fontWeight = FontWeight.SemiBold,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        if (!item.overview.isNullOrBlank()) {
+          Text(
+            text = item.overview,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+          )
+        }
+        if (item.durationSeconds > 0) {
+          val mins = item.durationSeconds / 60
+          Text(
+            text = "$mins min",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+          )
+        }
+      }
+
+      IconButton(onClick = onPlay) {
+        Icon(
+          imageVector = Icons.RoundedFilled.PlayArrow,
+          contentDescription = "Play",
+          tint = MaterialTheme.colorScheme.primary,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+fun JellyfinListItemCard(
+  item: JellyfinItem,
+  server: JellyfinServer,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val imageUrl =
+    JellyfinClient.getImageUrl(
+      serverUrl = server.serverUrl,
+      itemId = item.id,
+      imageTag = item.primaryImageTag,
+      maxWidth = 200,
+      token = server.accessToken,
+    )
+
+  Card(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(12.dp))
+        .clickable(onClick = onClick),
+    shape = RoundedCornerShape(12.dp),
+    colors =
+      CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+      ),
+  ) {
+    Row(
+      modifier = Modifier.padding(10.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      Box(
+        modifier =
+          Modifier
+            .size(width = 64.dp, height = 90.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+      ) {
+        if (!item.primaryImageTag.isNullOrBlank()) {
+          RemoteImage(
+            url = imageUrl,
+            contentDescription = item.name,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+          )
+        } else {
+          Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+          ) {
+            val placeholderIcon =
+              when {
+                item.isAudio -> Icons.RoundedFilled.Audiotrack
+                item.isFolder -> Icons.RoundedFilled.Folder
+                else -> Icons.RoundedFilled.VideoLibrary
+              }
+            Icon(
+              imageVector = placeholderIcon,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+              modifier = Modifier.size(28.dp),
+            )
+          }
+        }
+
+        if (item.progressPercent > 0.02f && !item.isPlayed) {
+          LinearProgressIndicator(
+            progress = { item.progressPercent },
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .height(3.dp),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f),
+          )
+        }
+
+        if (item.isPlayed) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+            modifier =
+              Modifier
+                .padding(4.dp)
+                .size(16.dp)
+                .align(Alignment.TopEnd),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Check,
+              contentDescription = "Played",
+              tint = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.padding(2.dp),
+            )
+          }
+        }
+      }
+
+      Column(
+        modifier = Modifier.weight(1f),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+      ) {
+        Text(
+          text = item.name,
+          style = MaterialTheme.typography.titleSmall,
+          fontWeight = FontWeight.SemiBold,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        val details =
+          buildList {
+            item.productionYear?.let { add(it.toString()) }
+            if (item.isSeries && item.childCount != null) {
+              add("${item.childCount} Seasons")
+            } else {
+              add(item.type)
+            }
+            item.communityRating?.let { add("★ $it") }
+          }.joinToString(" • ")
+
+        Text(
+          text = details,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+
+        if (!item.overview.isNullOrBlank()) {
+          Text(
+            text = item.overview,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.outline,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+          )
+        }
+      }
+
+      Icon(
+        imageVector = Icons.RoundedFilled.ChevronRight,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(20.dp),
+      )
+    }
+  }
+}
+
+@Composable
+fun JellyfinResumeCard(
+  item: JellyfinItem,
+  server: JellyfinServer,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val imageUrl =
+    if (!item.backdropImageTag.isNullOrBlank()) {
+      JellyfinClient.getBackdropUrl(
+        serverUrl = server.serverUrl,
+        itemId = item.id,
+        imageTag = item.backdropImageTag,
+        maxWidth = 500,
+        token = server.accessToken,
+      )
+    } else {
+      JellyfinClient.getImageUrl(
+        serverUrl = server.serverUrl,
+        itemId = item.id,
+        imageTag = item.primaryImageTag,
+        maxWidth = 400,
+        token = server.accessToken,
+      )
+    }
+
+  Card(
+    modifier =
+      modifier
+        .width(220.dp)
+        .clip(RoundedCornerShape(12.dp))
+        .clickable(onClick = onClick),
+    shape = RoundedCornerShape(12.dp),
+    colors =
+      CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+      ),
+  ) {
+    Column {
+      Box(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .aspectRatio(16f / 9f)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+      ) {
+        RemoteImage(
+          url = imageUrl,
+          contentDescription = item.name,
+          contentScale = ContentScale.Crop,
+          modifier = Modifier.fillMaxSize(),
+        )
+
+        // Play icon overlay
+        Surface(
+          shape = CircleShape,
+          color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
+          modifier =
+            Modifier
+              .size(36.dp)
+              .align(Alignment.Center),
+        ) {
+          Box(contentAlignment = Alignment.Center) {
+            Icon(
+              imageVector = Icons.RoundedFilled.PlayArrow,
+              contentDescription = "Play",
+              tint = MaterialTheme.colorScheme.onPrimaryContainer,
+              modifier = Modifier.size(20.dp),
+            )
+          }
+        }
+
+        // Progress bar at bottom of thumbnail
+        if (item.progressPercent > 0.01f) {
+          LinearProgressIndicator(
+            progress = { item.progressPercent },
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .height(3.dp),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.5f),
+          )
+        }
+      }
+
+      Column(modifier = Modifier.padding(8.dp)) {
+        val title = item.seriesName ?: item.name
+        val subtitle =
+          if (item.seriesName != null && item.indexNumber != null) {
+            "S${item.parentIndexNumber ?: 1}:E${item.indexNumber} • ${item.name}"
+          } else {
+            item.type
+          }
+
+        Text(
+          text = title,
+          style = MaterialTheme.typography.bodyMedium,
+          fontWeight = FontWeight.SemiBold,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+          text = subtitle,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
@@ -9,8 +9,10 @@
 
 package app.gyrolet.mpvrx.ui.browser.jellyfin
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -129,12 +131,15 @@ fun JellyfinLibraryCard(
   }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun JellyfinPosterCard(
   item: JellyfinItem,
   server: JellyfinServer,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  onLongClick: (() -> Unit)? = null,
+  isSelected: Boolean = false,
 ) {
   val imageUrl =
     JellyfinClient.getImageUrl(
@@ -145,16 +150,26 @@ fun JellyfinPosterCard(
       token = server.accessToken,
     )
 
+  val containerColor =
+    if (isSelected) {
+      MaterialTheme.colorScheme.primaryContainer
+    } else {
+      MaterialTheme.colorScheme.surfaceContainer
+    }
+
   Card(
     modifier =
       modifier
         .fillMaxWidth()
         .clip(RoundedCornerShape(12.dp))
-        .clickable(onClick = onClick),
+        .combinedClickable(
+          onClick = onClick,
+          onLongClick = onLongClick,
+        ),
     shape = RoundedCornerShape(12.dp),
     colors =
       CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        containerColor = containerColor,
       ),
   ) {
     Column {
@@ -206,8 +221,25 @@ fun JellyfinPosterCard(
           )
         }
 
-        // Unplayed badge / checkmark
-        if (item.isPlayed) {
+        // Selection or Played checkmark badge
+        if (isSelected) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary,
+            modifier =
+              Modifier
+                .padding(6.dp)
+                .size(22.dp)
+                .align(Alignment.TopEnd),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Check,
+              contentDescription = "Selected",
+              tint = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.padding(3.dp),
+            )
+          }
+        } else if (item.isPlayed) {
           Surface(
             shape = CircleShape,
             color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
@@ -249,12 +281,15 @@ fun JellyfinPosterCard(
   }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun JellyfinEpisodeCard(
   item: JellyfinItem,
   server: JellyfinServer,
   onPlay: () -> Unit,
   modifier: Modifier = Modifier,
+  onLongClick: (() -> Unit)? = null,
+  isSelected: Boolean = false,
 ) {
   val imageUrl =
     JellyfinClient.getImageUrl(
@@ -265,15 +300,26 @@ fun JellyfinEpisodeCard(
       token = server.accessToken,
     )
 
+  val containerColor =
+    if (isSelected) {
+      MaterialTheme.colorScheme.primaryContainer
+    } else {
+      MaterialTheme.colorScheme.surfaceContainer
+    }
+
   Card(
     modifier =
       modifier
         .fillMaxWidth()
-        .clickable(onClick = onPlay),
+        .clip(RoundedCornerShape(12.dp))
+        .combinedClickable(
+          onClick = onPlay,
+          onLongClick = onLongClick,
+        ),
     shape = RoundedCornerShape(12.dp),
     colors =
       CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        containerColor = containerColor,
       ),
   ) {
     Row(
@@ -320,6 +366,42 @@ fun JellyfinEpisodeCard(
             color = MaterialTheme.colorScheme.primary,
           )
         }
+
+        if (isSelected) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary,
+            modifier =
+              Modifier
+                .padding(4.dp)
+                .size(20.dp)
+                .align(Alignment.TopEnd),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Check,
+              contentDescription = "Selected",
+              tint = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.padding(2.dp),
+            )
+          }
+        } else if (item.isPlayed) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+            modifier =
+              Modifier
+                .padding(4.dp)
+                .size(18.dp)
+                .align(Alignment.TopEnd),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Check,
+              contentDescription = "Played",
+              tint = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.padding(2.dp),
+            )
+          }
+        }
       }
 
       Column(modifier = Modifier.weight(1f)) {
@@ -361,12 +443,15 @@ fun JellyfinEpisodeCard(
   }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun JellyfinListItemCard(
   item: JellyfinItem,
   server: JellyfinServer,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  onLongClick: (() -> Unit)? = null,
+  isSelected: Boolean = false,
 ) {
   val imageUrl =
     JellyfinClient.getImageUrl(
@@ -377,16 +462,26 @@ fun JellyfinListItemCard(
       token = server.accessToken,
     )
 
+  val containerColor =
+    if (isSelected) {
+      MaterialTheme.colorScheme.primaryContainer
+    } else {
+      MaterialTheme.colorScheme.surfaceContainer
+    }
+
   Card(
     modifier =
       modifier
         .fillMaxWidth()
         .clip(RoundedCornerShape(12.dp))
-        .clickable(onClick = onClick),
+        .combinedClickable(
+          onClick = onClick,
+          onLongClick = onLongClick,
+        ),
     shape = RoundedCornerShape(12.dp),
     colors =
       CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        containerColor = containerColor,
       ),
   ) {
     Row(
@@ -441,7 +536,24 @@ fun JellyfinListItemCard(
           )
         }
 
-        if (item.isPlayed) {
+        if (isSelected) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary,
+            modifier =
+              Modifier
+                .padding(4.dp)
+                .size(20.dp)
+                .align(Alignment.TopEnd),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Check,
+              contentDescription = "Selected",
+              tint = MaterialTheme.colorScheme.onPrimary,
+              modifier = Modifier.padding(2.dp),
+            )
+          }
+        } else if (item.isPlayed) {
           Surface(
             shape = CircleShape,
             color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
@@ -512,12 +624,16 @@ fun JellyfinListItemCard(
   }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun JellyfinResumeCard(
   item: JellyfinItem,
   server: JellyfinServer,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  onLongClick: (() -> Unit)? = null,
+  isSelected: Boolean = false,
+  isInSelectionMode: Boolean = false,
 ) {
   val imageUrl =
     if (!item.backdropImageTag.isNullOrBlank()) {
@@ -538,16 +654,26 @@ fun JellyfinResumeCard(
       )
     }
 
+  val containerColor =
+    if (isSelected) {
+      MaterialTheme.colorScheme.primaryContainer
+    } else {
+      MaterialTheme.colorScheme.surfaceContainer
+    }
+
   Card(
     modifier =
       modifier
         .width(220.dp)
         .clip(RoundedCornerShape(12.dp))
-        .clickable(onClick = onClick),
+        .combinedClickable(
+          onClick = onClick,
+          onLongClick = onLongClick,
+        ),
     shape = RoundedCornerShape(12.dp),
     colors =
       CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        containerColor = containerColor,
       ),
   ) {
     Column {
@@ -565,22 +691,48 @@ fun JellyfinResumeCard(
           modifier = Modifier.fillMaxSize(),
         )
 
-        // Play icon overlay
-        Surface(
-          shape = CircleShape,
-          color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
-          modifier =
-            Modifier
-              .size(36.dp)
-              .align(Alignment.Center),
-        ) {
-          Box(contentAlignment = Alignment.Center) {
-            Icon(
-              imageVector = Icons.RoundedFilled.PlayArrow,
-              contentDescription = "Play",
-              tint = MaterialTheme.colorScheme.onPrimaryContainer,
-              modifier = Modifier.size(20.dp),
-            )
+        // Selection overlay
+        if (isSelected) {
+          Box(
+            modifier =
+              Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)),
+            contentAlignment = Alignment.Center,
+          ) {
+            Surface(
+              shape = CircleShape,
+              color = MaterialTheme.colorScheme.primary,
+              modifier = Modifier.size(32.dp),
+            ) {
+              Box(contentAlignment = Alignment.Center) {
+                Icon(
+                  imageVector = Icons.RoundedFilled.Check,
+                  contentDescription = null,
+                  tint = MaterialTheme.colorScheme.onPrimary,
+                  modifier = Modifier.size(18.dp),
+                )
+              }
+            }
+          }
+        } else if (!isInSelectionMode) {
+          // Play icon overlay (only when not in selection mode)
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),
+            modifier =
+              Modifier
+                .size(36.dp)
+                .align(Alignment.Center),
+          ) {
+            Box(contentAlignment = Alignment.Center) {
+              Icon(
+                imageVector = Icons.RoundedFilled.PlayArrow,
+                contentDescription = "Play",
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(20.dp),
+              )
+            }
           }
         }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
@@ -10,7 +10,14 @@
 package app.gyrolet.mpvrx.ui.browser.jellyfin
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -23,6 +30,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -46,14 +54,22 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FloatingActionButtonMenu
+import androidx.compose.material3.FloatingActionButtonMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleFloatingActionButton
+import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -80,12 +96,14 @@ import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
 import app.gyrolet.mpvrx.preferences.BrowserPreferences
 import app.gyrolet.mpvrx.preferences.MediaLayoutMode
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
-import app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight
 import app.gyrolet.mpvrx.presentation.components.pullrefresh.PullRefreshBox
+import app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight
+import app.gyrolet.mpvrx.ui.browser.NavigationBarState
 import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.browser.components.ExpressiveScrollBar
 import app.gyrolet.mpvrx.ui.browser.components.fastScrollGlyph
 import app.gyrolet.mpvrx.ui.browser.dialogs.JellyfinSortDialog
+import app.gyrolet.mpvrx.ui.browser.selection.rememberSelectionManager
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.ui.utils.LocalBackStack
@@ -107,16 +125,40 @@ fun JellyfinContent(
   var isManageServersOpen by rememberSaveable { mutableStateOf(false) }
   var isSearching by rememberSaveable { mutableStateOf(false) }
   var isSortDialogOpen by rememberSaveable { mutableStateOf(false) }
+  var infoItem by remember { mutableStateOf<JellyfinItem?>(null) }
   val searchFocusRequester = remember { FocusRequester() }
 
-  // Intercept back button if searching or browsing inside a Jellyfin folder
-  BackHandler(enabled = isSearching || uiState.breadcrumbs.isNotEmpty()) {
-    if (isSearching) {
-      isSearching = false
-      viewModel.onSearchQueryChanged("")
-      viewModel.refresh()
-    } else {
-      viewModel.navigateBack()
+  val selectionManager =
+    rememberSelectionManager(
+      items = uiState.currentItems,
+      getId = { it.id },
+      onDeleteItems = { _, _ -> Pair(0, 0) },
+    )
+
+  DisposableEffect(selectionManager.isInSelectionMode) {
+    NavigationBarState.updateSelectionState(
+      inSelectionMode = selectionManager.isInSelectionMode,
+      onlyVideos = true,
+    )
+    onDispose {
+      NavigationBarState.updateSelectionState(inSelectionMode = false)
+    }
+  }
+
+  // Intercept back button if searching, selecting, or browsing inside a Jellyfin folder
+  BackHandler(enabled = isSearching || selectionManager.isInSelectionMode || uiState.breadcrumbs.isNotEmpty()) {
+    when {
+      isSearching -> {
+        isSearching = false
+        viewModel.onSearchQueryChanged("")
+        viewModel.refresh()
+      }
+      selectionManager.isInSelectionMode -> {
+        selectionManager.clear()
+      }
+      else -> {
+        viewModel.navigateBack()
+      }
     }
   }
 
@@ -195,10 +237,15 @@ fun JellyfinContent(
     } else {
       BrowserTopBar(
         title = pageTitle,
-        isInSelectionMode = false,
-        selectedCount = 0,
+        isInSelectionMode = selectionManager.isInSelectionMode,
+        selectedCount = selectionManager.selectedCount,
         totalCount = uiState.currentItems.size,
-        onCancelSelection = { },
+        onCancelSelection = { selectionManager.clear() },
+        onSelectAll = { selectionManager.selectAll() },
+        onInvertSelection = { selectionManager.invertSelection() },
+        onDeselectAll = { selectionManager.clear() },
+        onPlayClick = { viewModel.playSelected(context, selectionManager.getSelectedItems()) },
+        isSingleSelection = selectionManager.isSingleSelection,
         onBackClick = if (uiState.breadcrumbs.isNotEmpty()) { { viewModel.navigateBack() } } else null,
         onSortClick = { isSortDialogOpen = true },
         onSearchClick = { isSearching = true },
@@ -206,11 +253,18 @@ fun JellyfinContent(
           backstack.add(app.gyrolet.mpvrx.ui.preferences.PreferencesScreen)
         },
         additionalActions = {
-          IconButton(onClick = { isManageServersOpen = true }) {
-            Icon(
-              imageVector = Icons.RoundedFilled.BringYourOwnIp,
-              contentDescription = "Manage Servers",
-            )
+          if (!selectionManager.isInSelectionMode) {
+            IconButton(
+              onClick = { isManageServersOpen = true },
+              modifier = Modifier.padding(horizontal = 2.dp),
+            ) {
+              Icon(
+                imageVector = Icons.RoundedFilled.BringYourOwnIp,
+                contentDescription = "Manage Servers",
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.secondary,
+              )
+            }
           }
         },
       )
@@ -264,298 +318,505 @@ fun JellyfinContent(
       }
     }
 
-    // Main Body Content with Pull-To-Refresh
+    // Main Body Content with Pull-To-Refresh and FAB / Multi-select overlays
     val isRefreshing = remember { mutableStateOf(false) }
-    PullRefreshBox(
-      isRefreshing = isRefreshing,
-      onRefresh = { viewModel.refresh() },
+    val navigationBarHeight = LocalNavigationBarHeight.current
+
+    Box(
       modifier =
         Modifier
           .fillMaxSize()
           .weight(1f),
     ) {
-      Box(
+      PullRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = { viewModel.refresh() },
         modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
       ) {
-        when {
-          // No servers configured
-          uiState.servers.isEmpty() -> {
-          EmptyServersView(onAddClick = { isAddDialogOpen = true })
-        }
+        Box(
+          modifier = Modifier.fillMaxSize(),
+          contentAlignment = Alignment.Center,
+        ) {
+          when {
+            // No servers configured
+            uiState.servers.isEmpty() -> {
+              EmptyServersView(onAddClick = { isAddDialogOpen = true })
+            }
 
-        // Loading state (initial)
-        uiState.isLoading && uiState.libraries.isEmpty() && uiState.currentItems.isEmpty() -> {
-          CircularProgressIndicator()
-        }
+            // Loading state (initial)
+            uiState.isLoading && uiState.libraries.isEmpty() && uiState.currentItems.isEmpty() -> {
+              CircularProgressIndicator()
+            }
 
-        // Error state
-        uiState.error != null && uiState.libraries.isEmpty() && uiState.currentItems.isEmpty() -> {
-          ErrorView(
-            message = uiState.error ?: "An error occurred",
-            onRetry = { viewModel.refresh() },
-          )
-        }
+            // Error state
+            uiState.error != null && uiState.libraries.isEmpty() && uiState.currentItems.isEmpty() -> {
+              ErrorView(
+                message = uiState.error ?: "An error occurred",
+                onRetry = { viewModel.refresh() },
+              )
+            }
 
-        // Root View: Continue Watching carousel + Libraries
-        uiState.breadcrumbs.isEmpty() && uiState.searchQuery.isBlank() -> {
-          val listState = rememberLazyListState()
-          val navigationBarHeight = LocalNavigationBarHeight.current
-          val hasEnoughLibraries = uiState.libraries.size > 6
-          val scrollbarAlpha by animateFloatAsState(
-            targetValue = if (hasEnoughLibraries) 1f else 0f,
-            label = "scrollbarAlpha",
-          )
+            // Root View: Continue Watching carousel + Libraries
+            uiState.breadcrumbs.isEmpty() && uiState.searchQuery.isBlank() -> {
+              val listState = rememberLazyListState()
+              val hasEnoughLibraries = uiState.libraries.size > 6
+              val scrollbarAlpha by animateFloatAsState(
+                targetValue = if (hasEnoughLibraries) 1f else 0f,
+                label = "scrollbarAlpha",
+              )
 
-          Box(modifier = Modifier.fillMaxSize()) {
-            LazyColumn(
-              state = listState,
-              modifier = Modifier.fillMaxSize(),
-              contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = navigationBarHeight + 16.dp),
-              verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-              // Continue Watching carousel
-              if (uiState.resumeItems.isNotEmpty()) {
-                item {
-                  Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                      text = "Continue Watching",
-                      style = MaterialTheme.typography.titleMedium,
-                      fontWeight = FontWeight.Bold,
-                    )
-                    LazyRow(
-                      horizontalArrangement = Arrangement.spacedBy(12.dp),
-                      contentPadding = PaddingValues(vertical = 4.dp),
-                    ) {
-                      items(uiState.resumeItems, key = { it.id }) { resumeItem ->
-                        uiState.activeServer?.let { server ->
-                          JellyfinResumeCard(
-                            item = resumeItem,
-                            server = server,
-                            onClick = { viewModel.playItem(context, resumeItem) },
-                          )
+              Box(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                  state = listState,
+                  modifier = Modifier.fillMaxSize(),
+                  contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = navigationBarHeight + 80.dp),
+                  verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                  // Continue Watching carousel
+                  if (uiState.resumeItems.isNotEmpty()) {
+                    item {
+                      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                          text = "Continue Watching",
+                          style = MaterialTheme.typography.titleMedium,
+                          fontWeight = FontWeight.Bold,
+                        )
+                        LazyRow(
+                          horizontalArrangement = Arrangement.spacedBy(12.dp),
+                          contentPadding = PaddingValues(vertical = 4.dp),
+                        ) {
+                          items(uiState.resumeItems, key = { it.id }) { resumeItem ->
+                            uiState.activeServer?.let { server ->
+                              JellyfinResumeCard(
+                                item = resumeItem,
+                                server = server,
+                                isSelected = selectionManager.isSelected(resumeItem),
+                                isInSelectionMode = selectionManager.isInSelectionMode,
+                                onClick = {
+                                  if (selectionManager.isInSelectionMode) {
+                                    selectionManager.toggle(resumeItem)
+                                  } else {
+                                    viewModel.playItem(context, resumeItem)
+                                  }
+                                },
+                                onLongClick = { selectionManager.handleLongClick(resumeItem) },
+                              )
+                            }
+                          }
                         }
                       }
                     }
                   }
-                }
-              }
 
-              // Libraries Section
-              item {
-                Text(
-                  text = "Libraries",
-                  style = MaterialTheme.typography.titleMedium,
-                  fontWeight = FontWeight.Bold,
-                )
-              }
-
-              items(uiState.libraries, key = { it.id }) { library ->
-                JellyfinLibraryCard(
-                  item = library,
-                  onClick = { viewModel.navigateToItem(library) },
-                )
-              }
-            }
-
-            if (hasEnoughLibraries && scrollbarAlpha > 0.01f) {
-              ExpressiveScrollBar(
-                listState = listState,
-                dragLabelProvider = { index ->
-                  fastScrollGlyph(uiState.libraries.getOrNull(index)?.name)
-                },
-                modifier =
-                  Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
-                    .graphicsLayer { alpha = scrollbarAlpha },
-              )
-            }
-          }
-        }
-
-        // Level View: Inside a Library / Folder / Show / Season / Search results
-        else -> {
-          val items = uiState.currentItems
-          val allEpisodes = items.isNotEmpty() && items.all { it.type == "Episode" }
-          val isListMode = layoutMode == MediaLayoutMode.LIST || allEpisodes
-
-          if (items.isEmpty() && !uiState.isLoading) {
-            Text(
-              text = "No media found in this folder",
-              style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-          } else if (isListMode) {
-            val listState =
-              remember(uiState.breadcrumbs, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
-                LazyListState()
-              }
-            val navigationBarHeight = LocalNavigationBarHeight.current
-            val hasEnoughItems = items.size > 6
-            val scrollbarAlpha by animateFloatAsState(
-              targetValue = if (hasEnoughItems) 1f else 0f,
-              label = "scrollbarAlpha",
-            )
-
-            val shouldLoadMore =
-              remember {
-                derivedStateOf {
-                  val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                  items.isNotEmpty() && lastVisibleIndex >= items.size - 5
-                }
-              }
-
-            LaunchedEffect(shouldLoadMore.value) {
-              if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoading && !uiState.isLoadingMore) {
-                viewModel.loadMoreItems()
-              }
-            }
-
-            Box(modifier = Modifier.fillMaxSize()) {
-              LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = navigationBarHeight + 16.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-              ) {
-                items(items, key = { it.id }) { item ->
-                  uiState.activeServer?.let { server ->
-                    if (allEpisodes || item.type == "Episode") {
-                      JellyfinEpisodeCard(
-                        item = item,
-                        server = server,
-                        onPlay = { viewModel.playItem(context, item) },
-                      )
-                    } else {
-                      JellyfinListItemCard(
-                        item = item,
-                        server = server,
-                        onClick = {
-                          if (item.isFolder || item.isSeries || item.isSeason) {
-                            viewModel.navigateToItem(item)
-                          } else {
-                            viewModel.playItem(context, item)
-                          }
-                        },
-                      )
-                    }
-                  }
-                }
-                if (uiState.isLoadingMore) {
+                  // Libraries Section
                   item {
-                    Box(
-                      modifier =
-                        Modifier
-                          .fillMaxWidth()
-                          .padding(16.dp),
-                      contentAlignment = Alignment.Center,
-                    ) {
-                      CircularProgressIndicator(modifier = Modifier.size(28.dp))
-                    }
+                    Text(
+                      text = "Libraries",
+                      style = MaterialTheme.typography.titleMedium,
+                      fontWeight = FontWeight.Bold,
+                    )
                   }
-                }
-              }
 
-              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
-                ExpressiveScrollBar(
-                  listState = listState,
-                  dragLabelProvider = { index ->
-                    fastScrollGlyph(items.getOrNull(index)?.name)
-                  },
-                  modifier =
-                    Modifier
-                      .align(Alignment.CenterEnd)
-                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
-                      .graphicsLayer { alpha = scrollbarAlpha },
-                )
-              }
-            }
-          } else {
-            val gridState =
-              remember(uiState.breadcrumbs, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
-                LazyGridState()
-              }
-            val navigationBarHeight = LocalNavigationBarHeight.current
-            val hasEnoughItems = items.size > 6
-            val scrollbarAlpha by animateFloatAsState(
-              targetValue = if (hasEnoughItems) 1f else 0f,
-              label = "scrollbarAlpha",
-            )
-
-            val shouldLoadMore =
-              remember {
-                derivedStateOf {
-                  val lastVisibleIndex = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                  items.isNotEmpty() && lastVisibleIndex >= items.size - 8
-                }
-              }
-
-            LaunchedEffect(shouldLoadMore.value) {
-              if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoading && !uiState.isLoadingMore) {
-                viewModel.loadMoreItems()
-              }
-            }
-
-            Box(modifier = Modifier.fillMaxSize()) {
-              LazyVerticalGrid(
-                state = gridState,
-                columns = GridCells.Adaptive(minSize = 130.dp),
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 12.dp, end = 12.dp, top = 8.dp, bottom = navigationBarHeight + 16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-              ) {
-                items(items, key = { it.id }) { item ->
-                  uiState.activeServer?.let { server ->
-                    JellyfinPosterCard(
-                      item = item,
-                      server = server,
-                      onClick = {
-                        if (item.isFolder || item.isSeries || item.isSeason) {
-                          viewModel.navigateToItem(item)
-                        } else {
-                          viewModel.playItem(context, item)
-                        }
-                      },
+                  items(uiState.libraries, key = { it.id }) { library ->
+                    JellyfinLibraryCard(
+                      item = library,
+                      onClick = { viewModel.navigateToItem(library) },
                     )
                   }
                 }
 
-                if (uiState.isLoadingMore) {
-                  item(span = { GridItemSpan(maxLineSpan) }) {
-                    Box(
-                      modifier =
-                        Modifier
-                          .fillMaxWidth()
-                          .padding(16.dp),
-                      contentAlignment = Alignment.Center,
-                    ) {
-                      CircularProgressIndicator(modifier = Modifier.size(28.dp))
-                    }
-                  }
+                if (hasEnoughLibraries && scrollbarAlpha > 0.01f) {
+                  ExpressiveScrollBar(
+                    listState = listState,
+                    dragLabelProvider = { index ->
+                      fastScrollGlyph(uiState.libraries.getOrNull(index)?.name)
+                    },
+                    modifier =
+                      Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 80.dp)
+                        .graphicsLayer { alpha = scrollbarAlpha },
+                  )
                 }
               }
+            }
 
-              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
-                ExpressiveScrollBar(
-                  gridState = gridState,
-                  dragLabelProvider = { index ->
-                    fastScrollGlyph(items.getOrNull(index)?.name)
-                  },
-                  modifier =
-                    Modifier
-                      .align(Alignment.CenterEnd)
-                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
-                      .graphicsLayer { alpha = scrollbarAlpha },
+            // Level View: Inside a Library / Folder / Show / Season / Search results
+            else -> {
+              val items = uiState.currentItems
+              val allEpisodes = items.isNotEmpty() && items.all { it.type == "Episode" }
+              val isListMode = layoutMode == MediaLayoutMode.LIST || allEpisodes
+
+              if (items.isEmpty() && !uiState.isLoading) {
+                Text(
+                  text = "No media found in this folder",
+                  style = MaterialTheme.typography.bodyLarge,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+              } else if (isListMode) {
+                val listState =
+                  remember(uiState.breadcrumbs, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
+                    LazyListState()
+                  }
+                val hasEnoughItems = items.size > 6
+                val scrollbarAlpha by animateFloatAsState(
+                  targetValue = if (hasEnoughItems) 1f else 0f,
+                  label = "scrollbarAlpha",
+                )
+
+                val shouldLoadMore =
+                  remember {
+                    derivedStateOf {
+                      val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                      items.isNotEmpty() && lastVisibleIndex >= items.size - 5
+                    }
+                  }
+
+                LaunchedEffect(shouldLoadMore.value) {
+                  if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoading && !uiState.isLoadingMore) {
+                    viewModel.loadMoreItems()
+                  }
+                }
+
+                Box(modifier = Modifier.fillMaxSize()) {
+                  LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = navigationBarHeight + 80.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                  ) {
+                    items(items, key = { it.id }) { item ->
+                      uiState.activeServer?.let { server ->
+                        if (allEpisodes || item.type == "Episode") {
+                          JellyfinEpisodeCard(
+                            item = item,
+                            server = server,
+                            onPlay = {
+                              if (selectionManager.isInSelectionMode) {
+                                selectionManager.toggle(item)
+                              } else {
+                                viewModel.playItem(context, item)
+                              }
+                            },
+                            onLongClick = { selectionManager.handleLongClick(item) },
+                            isSelected = selectionManager.isSelected(item),
+                          )
+                        } else {
+                          JellyfinListItemCard(
+                            item = item,
+                            server = server,
+                            onClick = {
+                              if (selectionManager.isInSelectionMode) {
+                                selectionManager.toggle(item)
+                              } else if (item.isFolder || item.isSeries || item.isSeason) {
+                                viewModel.navigateToItem(item)
+                              } else {
+                                viewModel.playItem(context, item)
+                              }
+                            },
+                            onLongClick = { selectionManager.handleLongClick(item) },
+                            isSelected = selectionManager.isSelected(item),
+                          )
+                        }
+                      }
+                    }
+                    if (uiState.isLoadingMore) {
+                      item {
+                        Box(
+                          modifier =
+                            Modifier
+                              .fillMaxWidth()
+                              .padding(16.dp),
+                          contentAlignment = Alignment.Center,
+                        ) {
+                          CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                        }
+                      }
+                    }
+                  }
+
+                  if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                    ExpressiveScrollBar(
+                      listState = listState,
+                      dragLabelProvider = { index ->
+                        fastScrollGlyph(items.getOrNull(index)?.name)
+                      },
+                      modifier =
+                        Modifier
+                          .align(Alignment.CenterEnd)
+                          .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 80.dp)
+                          .graphicsLayer { alpha = scrollbarAlpha },
+                    )
+                  }
+                }
+              } else {
+                val gridState =
+                  remember(uiState.breadcrumbs, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
+                    LazyGridState()
+                  }
+                val hasEnoughItems = items.size > 6
+                val scrollbarAlpha by animateFloatAsState(
+                  targetValue = if (hasEnoughItems) 1f else 0f,
+                  label = "scrollbarAlpha",
+                )
+
+                val shouldLoadMore =
+                  remember {
+                    derivedStateOf {
+                      val lastVisibleIndex = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                      items.isNotEmpty() && lastVisibleIndex >= items.size - 8
+                    }
+                  }
+
+                LaunchedEffect(shouldLoadMore.value) {
+                  if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoading && !uiState.isLoadingMore) {
+                    viewModel.loadMoreItems()
+                  }
+                }
+
+                Box(modifier = Modifier.fillMaxSize()) {
+                  LazyVerticalGrid(
+                    state = gridState,
+                    columns = GridCells.Adaptive(minSize = 130.dp),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(start = 12.dp, end = 12.dp, top = 8.dp, bottom = navigationBarHeight + 80.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                  ) {
+                    items(items, key = { it.id }) { item ->
+                      uiState.activeServer?.let { server ->
+                        JellyfinPosterCard(
+                          item = item,
+                          server = server,
+                          onClick = {
+                            if (selectionManager.isInSelectionMode) {
+                              selectionManager.toggle(item)
+                            } else if (item.isFolder || item.isSeries || item.isSeason) {
+                              viewModel.navigateToItem(item)
+                            } else {
+                              viewModel.playItem(context, item)
+                            }
+                          },
+                          onLongClick = { selectionManager.handleLongClick(item) },
+                          isSelected = selectionManager.isSelected(item),
+                        )
+                      }
+                    }
+
+                    if (uiState.isLoadingMore) {
+                      item(span = { GridItemSpan(maxLineSpan) }) {
+                        Box(
+                          modifier =
+                            Modifier
+                              .fillMaxWidth()
+                              .padding(16.dp),
+                          contentAlignment = Alignment.Center,
+                        ) {
+                          CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                        }
+                      }
+                    }
+                  }
+
+                  if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                    ExpressiveScrollBar(
+                      gridState = gridState,
+                      dragLabelProvider = { index ->
+                        fastScrollGlyph(items.getOrNull(index)?.name)
+                      },
+                      modifier =
+                        Modifier
+                          .align(Alignment.CenterEnd)
+                          .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 80.dp)
+                          .graphicsLayer { alpha = scrollbarAlpha },
+                    )
+                  }
+                }
               }
             }
           }
         }
       }
+
+      // Multi-Select Floating Action Pill (smoothly replaces bottom nav bar)
+      androidx.compose.animation.AnimatedVisibility(
+        visible = selectionManager.isInSelectionMode,
+        enter =
+          slideInVertically(
+            animationSpec =
+              spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMediumLow,
+              ),
+            initialOffsetY = { fullHeight -> fullHeight * 2 },
+          ) + fadeIn(),
+        exit =
+          slideOutVertically(
+            animationSpec =
+              spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMedium,
+              ),
+            targetOffsetY = { fullHeight -> fullHeight * 2 },
+          ) + fadeOut(),
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .align(Alignment.BottomCenter)
+            .navigationBarsPadding()
+            .padding(bottom = 12.dp),
+      ) {
+        val selectedItems = selectionManager.getSelectedItems()
+        val playableCount = selectedItems.count { it.isVideo }
+
+        Box(
+          modifier = Modifier.fillMaxWidth(),
+          contentAlignment = Alignment.Center,
+        ) {
+          Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 6.dp,
+            shadowElevation = 8.dp,
+          ) {
+            Row(
+              modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.spacedBy(0.dp),
+            ) {
+              if (playableCount > 0) {
+                IconButton(
+                  onClick = {
+                    viewModel.playSelected(context, selectedItems)
+                    selectionManager.clear()
+                  },
+                ) {
+                  Icon(
+                    imageVector = Icons.RoundedFilled.PlayArrow,
+                    contentDescription = "Play",
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                  )
+                }
+              }
+
+              IconButton(
+                onClick = {
+                  viewModel.markSelectedPlayed(selectedItems, true)
+                  selectionManager.clear()
+                },
+              ) {
+                Icon(
+                  imageVector = Icons.RoundedFilled.CheckCircle,
+                  contentDescription = "Mark watched",
+                  modifier = Modifier.size(24.dp),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+              }
+
+              IconButton(
+                onClick = {
+                  viewModel.markSelectedPlayed(selectedItems, false)
+                  selectionManager.clear()
+                },
+              ) {
+                Icon(
+                  imageVector = Icons.RoundedFilled.RemoveCircle,
+                  contentDescription = "Mark unwatched",
+                  modifier = Modifier.size(24.dp),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+              }
+
+              if (selectedItems.size == 1) {
+                IconButton(
+                  onClick = { infoItem = selectedItems.first() },
+                ) {
+                  Icon(
+                    imageVector = Icons.RoundedFilled.Info,
+                    contentDescription = "Info",
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (!selectionManager.isInSelectionMode && uiState.activeServer != null && (uiState.currentItems.isNotEmpty() || uiState.resumeItems.isNotEmpty())) {
+        // Expressive Floating Action Button Menu
+        var isFabExpanded by remember { mutableStateOf(false) }
+
+        FloatingActionButtonMenu(
+          modifier =
+            Modifier
+              .align(Alignment.BottomEnd)
+              .padding(end = 16.dp, bottom = navigationBarHeight + 16.dp),
+          expanded = isFabExpanded,
+          button = {
+            ToggleFloatingActionButton(
+              modifier =
+                Modifier.animateFloatingActionButton(
+                  visible = !isSearching,
+                  alignment = Alignment.BottomEnd,
+                ),
+              checked = isFabExpanded,
+              onCheckedChange = { isFabExpanded = !isFabExpanded },
+            ) {
+              val checkedProgress = if (isFabExpanded) 1f else 0f
+              val imageVector by remember {
+                derivedStateOf {
+                  if (isFabExpanded) Icons.RoundedFilled.Close else Icons.RoundedFilled.PlayArrow
+                }
+              }
+              Icon(
+                imageVector = imageVector,
+                contentDescription = "Quick Menu",
+                modifier = Modifier.animateIcon({ checkedProgress }),
+              )
+            }
+          },
+        ) {
+          FloatingActionButtonMenuItem(
+            onClick = {
+              isFabExpanded = false
+              viewModel.resumeLastPlayed(context)
+            },
+            icon = { Icon(Icons.RoundedFilled.PlayArrow, contentDescription = null) },
+            text = { Text("Resume") },
+          )
+
+          FloatingActionButtonMenuItem(
+            onClick = {
+              isFabExpanded = false
+              viewModel.playRandom(context)
+            },
+            icon = { Icon(Icons.RoundedFilled.Shuffle, contentDescription = null) },
+            text = { Text("Play Random") },
+          )
+
+          FloatingActionButtonMenuItem(
+            onClick = {
+              isFabExpanded = false
+              isManageServersOpen = true
+            },
+            icon = { Icon(Icons.RoundedFilled.BringYourOwnIp, contentDescription = null) },
+            text = { Text("Switch Server") },
+          )
+
+          FloatingActionButtonMenuItem(
+            onClick = {
+              isFabExpanded = false
+              isSearching = true
+            },
+            icon = { Icon(Icons.RoundedFilled.Search, contentDescription = null) },
+            text = { Text("Search") },
+          )
+        }
+      }
     }
-  }
   }
 
   // Standard Material 3 Sort Dialog (matches Home and Network Browser)
@@ -609,6 +870,78 @@ fun JellyfinContent(
       )
     },
   )
+
+  // Item Info Bottom Sheet
+  infoItem?.let { item ->
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+      onDismissRequest = { infoItem = null },
+      sheetState = sheetState,
+    ) {
+      Column(
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Text(
+          text = item.name,
+          style = MaterialTheme.typography.titleLarge,
+          fontWeight = FontWeight.Bold,
+          maxLines = 2,
+          overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+        )
+        HorizontalDivider()
+
+        @Composable
+        fun InfoRow(label: String, value: String) {
+          Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text(
+              text = label,
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+              modifier = Modifier.width(100.dp),
+            )
+            Text(
+              text = value,
+              style = MaterialTheme.typography.bodyMedium,
+            )
+          }
+        }
+
+        InfoRow("Type", item.type.replace(Regex("([a-z])([A-Z])"), "$1 $2"))
+        item.seriesName?.let { InfoRow("Series", it) }
+        item.parentIndexNumber?.let { s ->
+          item.indexNumber?.let { e ->
+            InfoRow("Episode", "S$s E$e")
+          }
+        }
+        item.productionYear?.let { InfoRow("Year", it.toString()) }
+        item.communityRating?.let { InfoRow("Rating", "%.1f / 10".format(it)) }
+        if (item.durationSeconds > 0) {
+          val h = item.durationSeconds / 3600
+          val m = (item.durationSeconds % 3600) / 60
+          val s = item.durationSeconds % 60
+          val dur = if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+          InfoRow("Duration", dur)
+        }
+        item.container?.let { InfoRow("Container", it.uppercase()) }
+        if (item.childCount != null && item.childCount > 0) {
+          InfoRow("Items", item.childCount.toString())
+        }
+        item.overview?.let {
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+            text = it,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+      }
+    }
+  }
 }
 
 @Composable

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
@@ -1,0 +1,689 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.browser.jellyfin
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.R
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinItem
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+import app.gyrolet.mpvrx.preferences.BrowserPreferences
+import app.gyrolet.mpvrx.preferences.MediaLayoutMode
+import app.gyrolet.mpvrx.preferences.preference.collectAsState
+import app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight
+import app.gyrolet.mpvrx.presentation.components.pullrefresh.PullRefreshBox
+import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
+import app.gyrolet.mpvrx.ui.browser.components.ExpressiveScrollBar
+import app.gyrolet.mpvrx.ui.browser.components.fastScrollGlyph
+import app.gyrolet.mpvrx.ui.browser.dialogs.JellyfinSortDialog
+import app.gyrolet.mpvrx.ui.icons.Icon
+import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.utils.LocalBackStack
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun JellyfinContent(
+  viewModel: JellyfinViewModel,
+  modifier: Modifier = Modifier,
+) {
+  val uiState by viewModel.uiState.collectAsState()
+  val context = LocalContext.current
+  val backstack = LocalBackStack.current
+  val browserPreferences = koinInject<BrowserPreferences>()
+  val layoutMode by browserPreferences.jellyfinLayoutMode.collectAsState()
+
+  var isAddDialogOpen by remember { mutableStateOf(false) }
+  var isManageServersOpen by rememberSaveable { mutableStateOf(false) }
+  var isSearching by rememberSaveable { mutableStateOf(false) }
+  var isSortDialogOpen by rememberSaveable { mutableStateOf(false) }
+  val searchFocusRequester = remember { FocusRequester() }
+
+  // Intercept back button if searching or browsing inside a Jellyfin folder
+  BackHandler(enabled = isSearching || uiState.breadcrumbs.isNotEmpty()) {
+    if (isSearching) {
+      isSearching = false
+      viewModel.onSearchQueryChanged("")
+      viewModel.refresh()
+    } else {
+      viewModel.navigateBack()
+    }
+  }
+
+  LaunchedEffect(isSearching) {
+    if (isSearching) {
+      searchFocusRequester.requestFocus()
+    }
+  }
+
+  val pageTitle =
+    when {
+      uiState.breadcrumbs.isNotEmpty() -> uiState.breadcrumbs.last().title
+      uiState.activeServer != null -> uiState.activeServer!!.name
+      else -> stringResource(R.string.ui_jellyfin)
+    }
+
+  Column(
+    modifier =
+      modifier
+        .fillMaxSize()
+        .background(MaterialTheme.colorScheme.background),
+  ) {
+    // Top Bar (Material 3 Expressive BrowserTopBar / SearchBar)
+    if (isSearching) {
+      Box(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+      ) {
+        SearchBar(
+          inputField = {
+            SearchBarDefaults.InputField(
+              query = uiState.searchQuery,
+              onQueryChange = {
+                viewModel.onSearchQueryChanged(it)
+                viewModel.performSearch(it)
+              },
+              onSearch = { viewModel.performSearch(uiState.searchQuery) },
+              expanded = false,
+              onExpandedChange = { },
+              placeholder = { Text(stringResource(R.string.settings_search_title)) },
+              leadingIcon = {
+                Icon(
+                  imageVector = Icons.RoundedFilled.Search,
+                  contentDescription = stringResource(R.string.settings_search_title),
+                )
+              },
+              trailingIcon = {
+                IconButton(
+                  onClick = {
+                    if (uiState.searchQuery.isNotEmpty()) {
+                      viewModel.onSearchQueryChanged("")
+                      viewModel.refresh()
+                    } else {
+                      isSearching = false
+                    }
+                  },
+                ) {
+                  Icon(
+                    imageVector = Icons.RoundedFilled.Close,
+                    contentDescription = stringResource(R.string.generic_cancel),
+                  )
+                }
+              },
+              modifier = Modifier.focusRequester(searchFocusRequester),
+            )
+          },
+          expanded = false,
+          onExpandedChange = { },
+          modifier = Modifier.fillMaxWidth(),
+          shape = RoundedCornerShape(28.dp),
+          tonalElevation = 6.dp,
+        ) { }
+      }
+    } else {
+      BrowserTopBar(
+        title = pageTitle,
+        isInSelectionMode = false,
+        selectedCount = 0,
+        totalCount = uiState.currentItems.size,
+        onCancelSelection = { },
+        onBackClick = if (uiState.breadcrumbs.isNotEmpty()) { { viewModel.navigateBack() } } else null,
+        onSortClick = { isSortDialogOpen = true },
+        onSearchClick = { isSearching = true },
+        onSettingsClick = {
+          backstack.add(app.gyrolet.mpvrx.ui.preferences.PreferencesScreen)
+        },
+        additionalActions = {
+          IconButton(onClick = { isManageServersOpen = true }) {
+            Icon(
+              imageVector = Icons.RoundedFilled.BringYourOwnIp,
+              contentDescription = "Manage Servers",
+            )
+          }
+        },
+      )
+    }
+
+    // Breadcrumbs Trail (When inside subfolders)
+    if (uiState.breadcrumbs.isNotEmpty() && !isSearching) {
+      Row(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = "Libraries",
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.primary,
+          modifier =
+            Modifier
+              .clip(RoundedCornerShape(4.dp))
+              .clickable {
+                while (uiState.breadcrumbs.isNotEmpty()) {
+                  viewModel.navigateBack()
+                }
+              }.padding(horizontal = 4.dp, vertical = 2.dp),
+        )
+        uiState.breadcrumbs.forEachIndexed { index, crumb ->
+          Icon(
+            imageVector = Icons.RoundedFilled.ChevronRight,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+          val isLast = index == uiState.breadcrumbs.lastIndex
+          Text(
+            text = crumb.title,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = if (isLast) FontWeight.Bold else FontWeight.Normal,
+            color = if (isLast) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.primary,
+            modifier =
+              Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .clickable(enabled = !isLast) {
+                  val steps = uiState.breadcrumbs.size - 1 - index
+                  repeat(steps) { viewModel.navigateBack() }
+                }.padding(horizontal = 4.dp, vertical = 2.dp),
+          )
+        }
+      }
+    }
+
+    // Main Body Content with Pull-To-Refresh
+    val isRefreshing = remember { mutableStateOf(false) }
+    PullRefreshBox(
+      isRefreshing = isRefreshing,
+      onRefresh = { viewModel.refresh() },
+      modifier =
+        Modifier
+          .fillMaxSize()
+          .weight(1f),
+    ) {
+      Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+      ) {
+        when {
+          // No servers configured
+          uiState.servers.isEmpty() -> {
+          EmptyServersView(onAddClick = { isAddDialogOpen = true })
+        }
+
+        // Loading state (initial)
+        uiState.isLoading && uiState.libraries.isEmpty() && uiState.currentItems.isEmpty() -> {
+          CircularProgressIndicator()
+        }
+
+        // Error state
+        uiState.error != null && uiState.libraries.isEmpty() && uiState.currentItems.isEmpty() -> {
+          ErrorView(
+            message = uiState.error ?: "An error occurred",
+            onRetry = { viewModel.refresh() },
+          )
+        }
+
+        // Root View: Continue Watching carousel + Libraries
+        uiState.breadcrumbs.isEmpty() && uiState.searchQuery.isBlank() -> {
+          val listState = rememberLazyListState()
+          val navigationBarHeight = LocalNavigationBarHeight.current
+          val hasEnoughLibraries = uiState.libraries.size > 6
+          val scrollbarAlpha by animateFloatAsState(
+            targetValue = if (hasEnoughLibraries) 1f else 0f,
+            label = "scrollbarAlpha",
+          )
+
+          Box(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+              state = listState,
+              modifier = Modifier.fillMaxSize(),
+              contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp, bottom = navigationBarHeight + 16.dp),
+              verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+              // Continue Watching carousel
+              if (uiState.resumeItems.isNotEmpty()) {
+                item {
+                  Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                      text = "Continue Watching",
+                      style = MaterialTheme.typography.titleMedium,
+                      fontWeight = FontWeight.Bold,
+                    )
+                    LazyRow(
+                      horizontalArrangement = Arrangement.spacedBy(12.dp),
+                      contentPadding = PaddingValues(vertical = 4.dp),
+                    ) {
+                      items(uiState.resumeItems, key = { it.id }) { resumeItem ->
+                        uiState.activeServer?.let { server ->
+                          JellyfinResumeCard(
+                            item = resumeItem,
+                            server = server,
+                            onClick = { viewModel.playItem(context, resumeItem) },
+                          )
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+
+              // Libraries Section
+              item {
+                Text(
+                  text = "Libraries",
+                  style = MaterialTheme.typography.titleMedium,
+                  fontWeight = FontWeight.Bold,
+                )
+              }
+
+              items(uiState.libraries, key = { it.id }) { library ->
+                JellyfinLibraryCard(
+                  item = library,
+                  onClick = { viewModel.navigateToItem(library) },
+                )
+              }
+            }
+
+            if (hasEnoughLibraries && scrollbarAlpha > 0.01f) {
+              ExpressiveScrollBar(
+                listState = listState,
+                dragLabelProvider = { index ->
+                  fastScrollGlyph(uiState.libraries.getOrNull(index)?.name)
+                },
+                modifier =
+                  Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
+                    .graphicsLayer { alpha = scrollbarAlpha },
+              )
+            }
+          }
+        }
+
+        // Level View: Inside a Library / Folder / Show / Season / Search results
+        else -> {
+          val items = uiState.currentItems
+          val allEpisodes = items.isNotEmpty() && items.all { it.type == "Episode" }
+          val isListMode = layoutMode == MediaLayoutMode.LIST || allEpisodes
+
+          if (items.isEmpty() && !uiState.isLoading) {
+            Text(
+              text = "No media found in this folder",
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          } else if (isListMode) {
+            val listState =
+              remember(uiState.breadcrumbs, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
+                LazyListState()
+              }
+            val navigationBarHeight = LocalNavigationBarHeight.current
+            val hasEnoughItems = items.size > 6
+            val scrollbarAlpha by animateFloatAsState(
+              targetValue = if (hasEnoughItems) 1f else 0f,
+              label = "scrollbarAlpha",
+            )
+
+            val shouldLoadMore =
+              remember {
+                derivedStateOf {
+                  val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                  items.isNotEmpty() && lastVisibleIndex >= items.size - 5
+                }
+              }
+
+            LaunchedEffect(shouldLoadMore.value) {
+              if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoading && !uiState.isLoadingMore) {
+                viewModel.loadMoreItems()
+              }
+            }
+
+            Box(modifier = Modifier.fillMaxSize()) {
+              LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = navigationBarHeight + 16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+              ) {
+                items(items, key = { it.id }) { item ->
+                  uiState.activeServer?.let { server ->
+                    if (allEpisodes || item.type == "Episode") {
+                      JellyfinEpisodeCard(
+                        item = item,
+                        server = server,
+                        onPlay = { viewModel.playItem(context, item) },
+                      )
+                    } else {
+                      JellyfinListItemCard(
+                        item = item,
+                        server = server,
+                        onClick = {
+                          if (item.isFolder || item.isSeries || item.isSeason) {
+                            viewModel.navigateToItem(item)
+                          } else {
+                            viewModel.playItem(context, item)
+                          }
+                        },
+                      )
+                    }
+                  }
+                }
+                if (uiState.isLoadingMore) {
+                  item {
+                    Box(
+                      modifier =
+                        Modifier
+                          .fillMaxWidth()
+                          .padding(16.dp),
+                      contentAlignment = Alignment.Center,
+                    ) {
+                      CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                    }
+                  }
+                }
+              }
+
+              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                ExpressiveScrollBar(
+                  listState = listState,
+                  dragLabelProvider = { index ->
+                    fastScrollGlyph(items.getOrNull(index)?.name)
+                  },
+                  modifier =
+                    Modifier
+                      .align(Alignment.CenterEnd)
+                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
+                      .graphicsLayer { alpha = scrollbarAlpha },
+                )
+              }
+            }
+          } else {
+            val gridState =
+              remember(uiState.breadcrumbs, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
+                LazyGridState()
+              }
+            val navigationBarHeight = LocalNavigationBarHeight.current
+            val hasEnoughItems = items.size > 6
+            val scrollbarAlpha by animateFloatAsState(
+              targetValue = if (hasEnoughItems) 1f else 0f,
+              label = "scrollbarAlpha",
+            )
+
+            val shouldLoadMore =
+              remember {
+                derivedStateOf {
+                  val lastVisibleIndex = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                  items.isNotEmpty() && lastVisibleIndex >= items.size - 8
+                }
+              }
+
+            LaunchedEffect(shouldLoadMore.value) {
+              if (shouldLoadMore.value && uiState.hasMore && !uiState.isLoading && !uiState.isLoadingMore) {
+                viewModel.loadMoreItems()
+              }
+            }
+
+            Box(modifier = Modifier.fillMaxSize()) {
+              LazyVerticalGrid(
+                state = gridState,
+                columns = GridCells.Adaptive(minSize = 130.dp),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(start = 12.dp, end = 12.dp, top = 8.dp, bottom = navigationBarHeight + 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+              ) {
+                items(items, key = { it.id }) { item ->
+                  uiState.activeServer?.let { server ->
+                    JellyfinPosterCard(
+                      item = item,
+                      server = server,
+                      onClick = {
+                        if (item.isFolder || item.isSeries || item.isSeason) {
+                          viewModel.navigateToItem(item)
+                        } else {
+                          viewModel.playItem(context, item)
+                        }
+                      },
+                    )
+                  }
+                }
+
+                if (uiState.isLoadingMore) {
+                  item(span = { GridItemSpan(maxLineSpan) }) {
+                    Box(
+                      modifier =
+                        Modifier
+                          .fillMaxWidth()
+                          .padding(16.dp),
+                      contentAlignment = Alignment.Center,
+                    ) {
+                      CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                    }
+                  }
+                }
+              }
+
+              if (hasEnoughItems && scrollbarAlpha > 0.01f) {
+                ExpressiveScrollBar(
+                  gridState = gridState,
+                  dragLabelProvider = { index ->
+                    fastScrollGlyph(items.getOrNull(index)?.name)
+                  },
+                  modifier =
+                    Modifier
+                      .align(Alignment.CenterEnd)
+                      .padding(end = 2.dp, top = 6.dp, bottom = navigationBarHeight + 6.dp)
+                      .graphicsLayer { alpha = scrollbarAlpha },
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  }
+
+  // Standard Material 3 Sort Dialog (matches Home and Network Browser)
+  JellyfinSortDialog(
+    isOpen = isSortDialogOpen,
+    onDismiss = { isSortDialogOpen = false },
+    sortBy = uiState.sortBy,
+    onSortByChange = { newSort ->
+      viewModel.setSort(newSort, uiState.sortOrder)
+    },
+    sortOrder = uiState.sortOrder,
+    onSortOrderChange = { newOrder ->
+      viewModel.setSort(uiState.sortBy, newOrder)
+    },
+    isUnplayedOnly = uiState.isUnplayedOnly,
+    onUnplayedOnlyChange = {
+      viewModel.toggleUnplayedOnly()
+    },
+    layoutMode = layoutMode,
+    onLayoutModeChange = { newMode ->
+      browserPreferences.jellyfinLayoutMode.set(newMode)
+    },
+  )
+
+  // Manage Servers Dialog
+  ManageJellyfinServersDialog(
+    isOpen = isManageServersOpen,
+    servers = uiState.servers,
+    activeServer = uiState.activeServer,
+    onDismiss = { isManageServersOpen = false },
+    onSelectServer = { viewModel.selectServer(it) },
+    onDeleteServer = { viewModel.deleteServer(it) },
+    onAddServerClick = { isAddDialogOpen = true },
+  )
+
+  // Add Server Dialog
+  AddJellyfinServerDialog(
+    isOpen = isAddDialogOpen,
+    isLoading = uiState.isAuthenticating,
+    errorMessage = uiState.authError,
+    onDismiss = { isAddDialogOpen = false },
+    onConnect = { serverUrl, serverName, authMode, username, password, token ->
+      viewModel.addServer(
+        serverUrl = serverUrl,
+        serverName = serverName,
+        authMode = authMode,
+        username = username,
+        password = password,
+        token = token,
+        onSuccess = { isAddDialogOpen = false },
+      )
+    },
+  )
+}
+
+@Composable
+private fun EmptyServersView(onAddClick: () -> Unit) {
+  Column(
+    modifier = Modifier.padding(32.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+  ) {
+    Surface(
+      shape = CircleShape,
+      color = MaterialTheme.colorScheme.primaryContainer,
+      modifier = Modifier.size(80.dp),
+    ) {
+      Box(contentAlignment = Alignment.Center) {
+        Icon(
+          imageVector = Icons.RoundedFilled.BringYourOwnIp,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+          modifier = Modifier.size(40.dp),
+        )
+      }
+    }
+    Spacer(modifier = Modifier.height(16.dp))
+    Text(
+      text = "Connect to Jellyfin",
+      style = MaterialTheme.typography.titleLarge,
+      fontWeight = FontWeight.Bold,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+      text = "Stream your media library directly with mpvRx hardware acceleration and zero transcoding.",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(20.dp))
+    Button(onClick = onAddClick) {
+      Icon(
+        imageVector = Icons.RoundedFilled.Add,
+        contentDescription = null,
+        modifier = Modifier.size(18.dp),
+      )
+      Spacer(modifier = Modifier.width(8.dp))
+      Text("Add Jellyfin Server")
+    }
+  }
+}
+
+@Composable
+private fun ErrorView(
+  message: String,
+  onRetry: () -> Unit,
+) {
+  Column(
+    modifier = Modifier.padding(24.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+  ) {
+    Icon(
+      imageVector = Icons.RoundedFilled.Info,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.error,
+      modifier = Modifier.size(48.dp),
+    )
+    Spacer(modifier = Modifier.height(12.dp))
+    Text(
+      text = message,
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.error,
+      textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    FilledTonalButton(onClick = onRetry) {
+      Text("Retry")
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
@@ -85,6 +85,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -287,11 +288,8 @@ fun JellyfinContent(
           modifier =
             Modifier
               .clip(RoundedCornerShape(4.dp))
-              .clickable {
-                while (uiState.breadcrumbs.isNotEmpty()) {
-                  viewModel.navigateBack()
-                }
-              }.padding(horizontal = 4.dp, vertical = 2.dp),
+              .clickable { viewModel.navigateToRoot() }
+              .padding(horizontal = 4.dp, vertical = 2.dp),
         )
         uiState.breadcrumbs.forEachIndexed { index, crumb ->
           Icon(
@@ -310,8 +308,7 @@ fun JellyfinContent(
               Modifier
                 .clip(RoundedCornerShape(4.dp))
                 .clickable(enabled = !isLast) {
-                  val steps = uiState.breadcrumbs.size - 1 - index
-                  repeat(steps) { viewModel.navigateBack() }
+                  viewModel.navigateToBreadcrumb(index)
                 }.padding(horizontal = 4.dp, vertical = 2.dp),
           )
         }
@@ -957,8 +954,8 @@ private fun EmptyServersView(onAddClick: () -> Unit) {
       modifier = Modifier.size(80.dp),
     ) {
       Box(contentAlignment = Alignment.Center) {
-        Icon(
-          imageVector = Icons.RoundedFilled.BringYourOwnIp,
+        androidx.compose.material3.Icon(
+          painter = painterResource(R.drawable.ic_jellyfin),
           contentDescription = null,
           tint = MaterialTheme.colorScheme.onPrimaryContainer,
           modifier = Modifier.size(40.dp),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -470,6 +470,7 @@ class JellyfinViewModel(
   fun playItem(
     context: Context,
     item: JellyfinItem,
+    startFromBeginning: Boolean = false,
   ) {
     val server = _uiState.value.activeServer ?: return
     val streamUrl = jellyfinRepository.getStreamUrl(server, item)
@@ -483,10 +484,14 @@ class JellyfinViewModel(
       }
 
     viewModelScope.launch(Dispatchers.IO) {
+      if (startFromBeginning) {
+        runCatching { playbackStateRepository.deleteByTitle(streamUrl) }
+      }
+
       // Concurrently run DB seed and external subtitle fetching
       val dbJob =
         async {
-          if (item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
+          if (!startFromBeginning && item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
             val positionSeconds = (item.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
             runCatching {
               playbackStateRepository.upsert(
@@ -521,18 +526,17 @@ class JellyfinViewModel(
           serverUrl = server.serverUrl,
           token = server.accessToken,
           itemId = item.id,
-          positionTicks = item.playbackPositionTicks ?: 0L,
+          positionTicks = if (startFromBeginning) 0L else (item.playbackPositionTicks ?: 0L),
         )
       }
 
       dbJob.await()
       val externalSubs = subsDeferred.await()
 
-      val currentList = _uiState.value.currentItems
-      val isEpisodePlayback = item.type == "Episode" || item.seriesName != null
+      // If playing an episode, extract surrounding episode playlist from current view
       val (playlistUris, playlistTitles, playlistIndex) =
-        if (isEpisodePlayback && currentList.isNotEmpty()) {
-          val episodeList = currentList.filter { it.type == "Episode" || it.isVideo }
+        if (item.type == "Episode") {
+          val episodeList = _uiState.value.currentItems.filter { it.type == "Episode" }
           if (episodeList.size > 1) {
             val uris = ArrayList<Uri>(episodeList.size)
             val titles = ArrayList<String>(episodeList.size)
@@ -579,6 +583,146 @@ class JellyfinViewModel(
         )
       }
     }
+  }
+
+  fun playSelected(
+    context: Context,
+    items: List<JellyfinItem>,
+  ) {
+    val server = _uiState.value.activeServer ?: return
+    val playable = items.filter { it.isVideo }
+    if (playable.isEmpty()) return
+    val firstItem = playable.first()
+    val streamUrl = jellyfinRepository.getStreamUrl(server, firstItem)
+    val posterUrl = jellyfinRepository.getImageUrl(server, firstItem)
+    val backdropUrl = jellyfinRepository.getBackdropUrl(server, firstItem)
+
+    val itemTitle =
+      when {
+        firstItem.seriesName != null && firstItem.indexNumber != null ->
+          "${firstItem.seriesName} S${firstItem.parentIndexNumber ?: 1}E${firstItem.indexNumber} - ${firstItem.name}"
+        else -> firstItem.name
+      }
+
+    val playlistUris = ArrayList<Uri>(playable.size)
+    val playlistTitles = ArrayList<String>(playable.size)
+    playable.forEach { item ->
+      playlistUris.add(Uri.parse(jellyfinRepository.getStreamUrl(server, item)))
+      playlistTitles.add(
+        when {
+          item.seriesName != null && item.indexNumber != null ->
+            "${item.seriesName} S${item.parentIndexNumber ?: 1}E${item.indexNumber} - ${item.name}"
+          else -> item.name
+        },
+      )
+    }
+
+    val headers =
+      mapOf(
+        "X-Emby-Token" to server.accessToken,
+        "X-Emby-Authorization" to JellyfinClient.authHeader(server.accessToken),
+      )
+
+    MediaUtils.playFile(
+      source = streamUrl,
+      context = context,
+      launchSource = "jellyfin_stream",
+      title = itemTitle,
+      headers = headers,
+      mediaDescription = firstItem.overview,
+      posterUrl = posterUrl,
+      backdropUrl = backdropUrl,
+      playlist = playlistUris,
+      playlistIndex = 0,
+      playlistTitles = playlistTitles,
+    )
+  }
+
+  fun togglePlayed(item: JellyfinItem) {
+    val server = _uiState.value.activeServer ?: return
+    viewModelScope.launch {
+      val targetPlayed = !item.isPlayed
+      val result =
+        if (targetPlayed) {
+          jellyfinRepository.markPlayed(server, item)
+        } else {
+          jellyfinRepository.markUnplayed(server, item)
+        }
+      result.onSuccess {
+        _uiState.update { state ->
+          state.copy(
+            currentItems =
+              state.currentItems.map {
+                if (it.id == item.id) {
+                  it.copy(
+                    isPlayed = targetPlayed,
+                    playbackPositionTicks = if (targetPlayed) 0L else it.playbackPositionTicks,
+                  )
+                } else {
+                  it
+                }
+              },
+          )
+        }
+      }
+    }
+  }
+
+  fun markSelectedPlayed(
+    items: List<JellyfinItem>,
+    played: Boolean,
+  ) {
+    val server = _uiState.value.activeServer ?: return
+    viewModelScope.launch {
+      val ids = items.map { it.id }.toSet()
+      items.forEach { item ->
+        launch {
+          if (played) {
+            jellyfinRepository.markPlayed(server, item)
+          } else {
+            jellyfinRepository.markUnplayed(server, item)
+          }
+        }
+      }
+      _uiState.update { state ->
+        state.copy(
+          currentItems =
+            state.currentItems.map {
+              if (it.id in ids) {
+                it.copy(
+                  isPlayed = played,
+                  playbackPositionTicks = if (played) 0L else it.playbackPositionTicks,
+                )
+              } else {
+                it
+              }
+            },
+        )
+      }
+    }
+  }
+
+  fun playRandom(context: Context) {
+    val items = _uiState.value.currentItems.filter { it.isVideo }
+    if (items.isNotEmpty()) {
+      playItem(context, items.random())
+    }
+  }
+
+  fun resumeLastPlayed(context: Context) {
+    viewModelScope.launch {
+      val server = _uiState.value.activeServer ?: return@launch
+      val resumeItems = jellyfinRepository.getResumeItems(server, limit = 1).getOrNull()
+      val itemToPlay = resumeItems?.firstOrNull() ?: _uiState.value.currentItems.firstOrNull { it.isVideo }
+      if (itemToPlay != null) {
+        playItem(context, itemToPlay)
+      }
+    }
+  }
+
+  fun getStreamUrl(item: JellyfinItem): String {
+    val server = _uiState.value.activeServer ?: return ""
+    return jellyfinRepository.getStreamUrl(server, item)
   }
 
   companion object {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -25,6 +25,8 @@ import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
 import app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy
 import app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder
 import app.gyrolet.mpvrx.domain.playbackstate.repository.PlaybackStateRepository
+import app.gyrolet.mpvrx.preferences.AudioPreferences
+import app.gyrolet.mpvrx.preferences.SubtitlesPreferences
 import app.gyrolet.mpvrx.repository.JellyfinRepository
 import app.gyrolet.mpvrx.utils.media.MediaUtils
 import app.gyrolet.mpvrx.utils.media.PlaybackSubtitleTrack
@@ -73,6 +75,8 @@ class JellyfinViewModel(
   KoinComponent {
   private val jellyfinRepository: JellyfinRepository by inject()
   private val playbackStateRepository: PlaybackStateRepository by inject()
+  private val subtitlesPreferences: SubtitlesPreferences by inject()
+  private val audioPreferences: AudioPreferences by inject()
 
   private val _uiState = MutableStateFlow(JellyfinUiState())
   val uiState: StateFlow<JellyfinUiState> = _uiState.asStateFlow()
@@ -385,6 +389,14 @@ class JellyfinViewModel(
           if (authMode == JellyfinAuthMode.CREDENTIALS) {
             val authResult =
               jellyfinRepository.authenticate(cleanUrl, username, password).getOrThrow()
+
+            if (subtitlesPreferences.preferredLanguages.get().isBlank() && !authResult.subtitleLanguage.isNullOrBlank()) {
+              subtitlesPreferences.preferredLanguages.set(authResult.subtitleLanguage)
+            }
+            if (audioPreferences.preferredLanguages.get().isBlank() && !authResult.audioLanguage.isNullOrBlank()) {
+              audioPreferences.preferredLanguages.set(authResult.audioLanguage)
+            }
+
             JellyfinServer(
               name = serverName.ifBlank { "Jellyfin (${authResult.username})" },
               serverUrl = cleanUrl,
@@ -395,6 +407,14 @@ class JellyfinViewModel(
             )
           } else {
             val user = jellyfinRepository.validateToken(cleanUrl, token).getOrThrow()
+
+            if (subtitlesPreferences.preferredLanguages.get().isBlank() && !user.subtitleLanguage.isNullOrBlank()) {
+              subtitlesPreferences.preferredLanguages.set(user.subtitleLanguage)
+            }
+            if (audioPreferences.preferredLanguages.get().isBlank() && !user.audioLanguage.isNullOrBlank()) {
+              audioPreferences.preferredLanguages.set(user.audioLanguage)
+            }
+
             JellyfinServer(
               name = serverName.ifBlank { "Jellyfin (${user.name})" },
               serverUrl = cleanUrl,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -1,0 +1,522 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.browser.jellyfin
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import app.gyrolet.mpvrx.data.jellyfin.JellyfinClient
+import app.gyrolet.mpvrx.database.entities.PlaybackStateEntity
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinAuthMode
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinItem
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortBy
+import app.gyrolet.mpvrx.domain.jellyfin.JellyfinSortOrder
+import app.gyrolet.mpvrx.domain.playbackstate.repository.PlaybackStateRepository
+import app.gyrolet.mpvrx.repository.JellyfinRepository
+import app.gyrolet.mpvrx.utils.media.MediaUtils
+import app.gyrolet.mpvrx.utils.media.PlaybackSubtitleTrack
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+data class JellyfinBreadcrumb(
+  val id: String,
+  val title: String,
+  val type: String = "Folder",
+)
+
+data class JellyfinUiState(
+  val servers: List<JellyfinServer> = emptyList(),
+  val activeServer: JellyfinServer? = null,
+  val libraries: List<JellyfinItem> = emptyList(),
+  val resumeItems: List<JellyfinItem> = emptyList(),
+  val currentItems: List<JellyfinItem> = emptyList(),
+  val breadcrumbs: List<JellyfinBreadcrumb> = emptyList(),
+  val sortBy: JellyfinSortBy = JellyfinSortBy.NAME,
+  val sortOrder: JellyfinSortOrder = JellyfinSortOrder.ASCENDING,
+  val isUnplayedOnly: Boolean = false,
+  val totalRecordCount: Int = 0,
+  val startIndex: Int = 0,
+  val isLoading: Boolean = false,
+  val isLoadingMore: Boolean = false,
+  val hasMore: Boolean = false,
+  val isAuthenticating: Boolean = false,
+  val error: String? = null,
+  val authError: String? = null,
+  val searchQuery: String = "",
+)
+
+class JellyfinViewModel(
+  application: Application,
+) : AndroidViewModel(application),
+  KoinComponent {
+  private val jellyfinRepository: JellyfinRepository by inject()
+  private val playbackStateRepository: PlaybackStateRepository by inject()
+
+  private val _uiState = MutableStateFlow(JellyfinUiState())
+  val uiState: StateFlow<JellyfinUiState> = _uiState.asStateFlow()
+
+  init {
+    loadServers()
+  }
+
+  fun loadServers() {
+    viewModelScope.launch {
+      jellyfinRepository.allServers.collect { servers ->
+        _uiState.update { state ->
+          val active = state.activeServer?.let { cur -> servers.find { it.id == cur.id } } ?: servers.firstOrNull()
+          state.copy(
+            servers = servers,
+            activeServer = active,
+          )
+        }
+        val currentActive = _uiState.value.activeServer
+        if (currentActive != null && _uiState.value.libraries.isEmpty()) {
+          loadLibraries(currentActive)
+        }
+      }
+    }
+  }
+
+  fun selectServer(server: JellyfinServer) {
+    _uiState.update {
+      it.copy(
+        activeServer = server,
+        breadcrumbs = emptyList(),
+        currentItems = emptyList(),
+        resumeItems = emptyList(),
+        searchQuery = "",
+        error = null,
+      )
+    }
+    loadLibraries(server)
+  }
+
+  fun refresh() {
+    val active = _uiState.value.activeServer ?: return
+    val currentCrumb = _uiState.value.breadcrumbs.lastOrNull()
+    if (currentCrumb == null) {
+      loadLibraries(active)
+    } else {
+      loadItems(active, currentCrumb.id, currentCrumb.type, resetPagination = true)
+    }
+  }
+
+  fun loadLibraries(server: JellyfinServer) {
+    viewModelScope.launch {
+      _uiState.update { it.copy(isLoading = true, error = null) }
+      loadResumeItems(server)
+      val result = jellyfinRepository.getLibraries(server)
+      result
+        .onSuccess { libs ->
+          _uiState.update { it.copy(libraries = libs, isLoading = false, error = null) }
+        }.onFailure { err ->
+          _uiState.update { it.copy(isLoading = false, error = err.message ?: "Failed to load libraries") }
+        }
+    }
+  }
+
+  fun loadResumeItems(server: JellyfinServer) {
+    viewModelScope.launch {
+      val result = jellyfinRepository.getResumeItems(server, limit = 12)
+      result.onSuccess { resumeList ->
+        _uiState.update { it.copy(resumeItems = resumeList) }
+      }
+    }
+  }
+
+  fun setSort(
+    sortBy: JellyfinSortBy,
+    sortOrder: JellyfinSortOrder,
+  ) {
+    _uiState.update { it.copy(sortBy = sortBy, sortOrder = sortOrder) }
+    val active = _uiState.value.activeServer ?: return
+    val currentCrumb = _uiState.value.breadcrumbs.lastOrNull() ?: return
+    loadItems(active, currentCrumb.id, currentCrumb.type, resetPagination = true)
+  }
+
+  fun toggleUnplayedOnly() {
+    val newFilter = !_uiState.value.isUnplayedOnly
+    _uiState.update { it.copy(isUnplayedOnly = newFilter) }
+    val active = _uiState.value.activeServer ?: return
+    val currentCrumb = _uiState.value.breadcrumbs.lastOrNull() ?: return
+    loadItems(active, currentCrumb.id, currentCrumb.type, resetPagination = true)
+  }
+
+  fun navigateToItem(item: JellyfinItem) {
+    val active = _uiState.value.activeServer ?: return
+    if (item.isFolder || item.isSeries || item.isSeason) {
+      val newCrumb = JellyfinBreadcrumb(id = item.id, title = item.name, type = item.type)
+      _uiState.update {
+        it.copy(
+          breadcrumbs = it.breadcrumbs + newCrumb,
+          searchQuery = "",
+        )
+      }
+      loadItems(active, item.id, item.type, resetPagination = true)
+    }
+  }
+
+  fun navigateBack(): Boolean {
+    val currentCrumbs = _uiState.value.breadcrumbs
+    if (currentCrumbs.isEmpty()) return false
+
+    val updatedCrumbs = currentCrumbs.dropLast(1)
+    _uiState.update {
+      it.copy(
+        breadcrumbs = updatedCrumbs,
+        searchQuery = "",
+      )
+    }
+    val active = _uiState.value.activeServer ?: return true
+    val parent = updatedCrumbs.lastOrNull()
+    if (parent == null) {
+      loadLibraries(active)
+    } else {
+      loadItems(active, parent.id, parent.type, resetPagination = true)
+    }
+    return true
+  }
+
+  private fun loadItems(
+    server: JellyfinServer,
+    parentId: String,
+    parentType: String,
+    resetPagination: Boolean = true,
+  ) {
+    val startIndex = if (resetPagination) 0 else _uiState.value.startIndex
+    val currentList = if (resetPagination) emptyList() else _uiState.value.currentItems
+
+    viewModelScope.launch {
+      if (resetPagination) {
+        _uiState.update {
+          it.copy(
+            isLoading = true,
+            currentItems = emptyList(),
+            startIndex = 0,
+            hasMore = false,
+            error = null,
+          )
+        }
+      } else {
+        _uiState.update { it.copy(isLoadingMore = true) }
+      }
+
+      val currentState = _uiState.value
+
+      when (parentType) {
+        "Series" -> {
+          val result = jellyfinRepository.getSeasons(server, parentId)
+          result
+            .onSuccess { items ->
+              _uiState.update {
+                it.copy(
+                  currentItems = items,
+                  totalRecordCount = items.size,
+                  hasMore = false,
+                  isLoading = false,
+                  isLoadingMore = false,
+                  error = null,
+                )
+              }
+            }.onFailure { err ->
+              _uiState.update {
+                it.copy(
+                  isLoading = false,
+                  isLoadingMore = false,
+                  error = err.message ?: "Failed to load seasons",
+                )
+              }
+            }
+        }
+
+        "Season" -> {
+          val seriesId = _uiState.value.breadcrumbs.dropLast(1).lastOrNull { it.type == "Series" }?.id ?: parentId
+          val result = jellyfinRepository.getEpisodes(server, seriesId, parentId)
+          result
+            .onSuccess { items ->
+              _uiState.update {
+                it.copy(
+                  currentItems = items,
+                  totalRecordCount = items.size,
+                  hasMore = false,
+                  isLoading = false,
+                  isLoadingMore = false,
+                  error = null,
+                )
+              }
+            }.onFailure { err ->
+              _uiState.update {
+                it.copy(
+                  isLoading = false,
+                  isLoadingMore = false,
+                  error = err.message ?: "Failed to load episodes",
+                )
+              }
+            }
+        }
+
+        else -> {
+          val result =
+            jellyfinRepository.getItems(
+              server = server,
+              parentId = parentId,
+              searchTerm = currentState.searchQuery.takeIf { it.isNotBlank() },
+              sortBy = currentState.sortBy,
+              sortOrder = currentState.sortOrder,
+              isPlayed = if (currentState.isUnplayedOnly) false else null,
+              startIndex = startIndex,
+              limit = 100,
+            )
+
+          result
+            .onSuccess { queryResult ->
+              val combined = currentList + queryResult.items
+              val hasMore = combined.size < queryResult.totalRecordCount
+              _uiState.update {
+                it.copy(
+                  currentItems = combined,
+                  totalRecordCount = queryResult.totalRecordCount,
+                  startIndex = combined.size,
+                  hasMore = hasMore,
+                  isLoading = false,
+                  isLoadingMore = false,
+                  error = null,
+                )
+              }
+            }.onFailure { err ->
+              _uiState.update {
+                it.copy(
+                  isLoading = false,
+                  isLoadingMore = false,
+                  error = err.message ?: "Failed to load items",
+                )
+              }
+            }
+        }
+      }
+    }
+  }
+
+  fun loadMoreItems() {
+    val state = _uiState.value
+    if (state.isLoading || state.isLoadingMore || !state.hasMore) return
+    val active = state.activeServer ?: return
+    val currentCrumb = state.breadcrumbs.lastOrNull() ?: return
+    loadItems(active, currentCrumb.id, currentCrumb.type, resetPagination = false)
+  }
+
+  fun onSearchQueryChanged(query: String) {
+    _uiState.update { it.copy(searchQuery = query) }
+  }
+
+  fun performSearch(query: String) {
+    val active = _uiState.value.activeServer ?: return
+    if (query.isBlank()) {
+      refresh()
+      return
+    }
+    viewModelScope.launch {
+      _uiState.update { it.copy(isLoading = true, currentItems = emptyList(), startIndex = 0, error = null) }
+      val currentCrumb = _uiState.value.breadcrumbs.lastOrNull()
+      val result =
+        jellyfinRepository.getItems(
+          server = active,
+          parentId = currentCrumb?.id,
+          searchTerm = query,
+          sortBy = _uiState.value.sortBy,
+          sortOrder = _uiState.value.sortOrder,
+          startIndex = 0,
+          limit = 100,
+        )
+      result
+        .onSuccess { queryResult ->
+          _uiState.update {
+            it.copy(
+              currentItems = queryResult.items,
+              totalRecordCount = queryResult.totalRecordCount,
+              startIndex = queryResult.items.size,
+              hasMore = queryResult.items.size < queryResult.totalRecordCount,
+              isLoading = false,
+            )
+          }
+        }.onFailure { err ->
+          _uiState.update { it.copy(isLoading = false, error = err.message) }
+        }
+    }
+  }
+
+  fun addServer(
+    serverUrl: String,
+    serverName: String,
+    authMode: JellyfinAuthMode,
+    username: String = "",
+    password: String = "",
+    token: String = "",
+    onSuccess: () -> Unit,
+  ) {
+    viewModelScope.launch {
+      _uiState.update { it.copy(isAuthenticating = true, authError = null) }
+      val cleanUrl = JellyfinClient.normalizeUrl(serverUrl)
+
+      try {
+        val serverToSave =
+          if (authMode == JellyfinAuthMode.CREDENTIALS) {
+            val authResult =
+              jellyfinRepository.authenticate(cleanUrl, username, password).getOrThrow()
+            JellyfinServer(
+              name = serverName.ifBlank { "Jellyfin (${authResult.username})" },
+              serverUrl = cleanUrl,
+              userId = authResult.userId,
+              username = authResult.username,
+              accessToken = authResult.accessToken,
+              lastConnected = System.currentTimeMillis(),
+            )
+          } else {
+            val user = jellyfinRepository.validateToken(cleanUrl, token).getOrThrow()
+            JellyfinServer(
+              name = serverName.ifBlank { "Jellyfin (${user.name})" },
+              serverUrl = cleanUrl,
+              userId = user.id,
+              username = user.name,
+              accessToken = token.trim(),
+              lastConnected = System.currentTimeMillis(),
+            )
+          }
+
+        val id = jellyfinRepository.saveServer(serverToSave)
+        val savedServer = serverToSave.copy(id = id)
+        _uiState.update {
+          it.copy(
+            isAuthenticating = false,
+            authError = null,
+            activeServer = savedServer,
+          )
+        }
+        loadLibraries(savedServer)
+        onSuccess()
+      } catch (e: Exception) {
+        _uiState.update {
+          it.copy(
+            isAuthenticating = false,
+            authError = e.localizedMessage ?: "Failed to connect to Jellyfin server",
+          )
+        }
+      }
+    }
+  }
+
+  fun deleteServer(server: JellyfinServer) {
+    viewModelScope.launch {
+      jellyfinRepository.deleteServer(server)
+      val remaining = jellyfinRepository.allServers.firstOrNull() ?: emptyList()
+      val newActive = remaining.firstOrNull { it.id != server.id }
+      _uiState.update {
+        it.copy(
+          activeServer = newActive,
+          breadcrumbs = emptyList(),
+          currentItems = emptyList(),
+          libraries = emptyList(),
+          resumeItems = emptyList(),
+        )
+      }
+      if (newActive != null) {
+        loadLibraries(newActive)
+      }
+    }
+  }
+
+  fun playItem(
+    context: Context,
+    item: JellyfinItem,
+  ) {
+    val server = _uiState.value.activeServer ?: return
+    val streamUrl = jellyfinRepository.getStreamUrl(server, item)
+    val posterUrl = jellyfinRepository.getImageUrl(server, item)
+    val backdropUrl = jellyfinRepository.getBackdropUrl(server, item)
+
+    val itemTitle =
+      when {
+        item.seriesName != null && item.indexNumber != null -> "${item.seriesName} S${item.parentIndexNumber ?: 1}E${item.indexNumber} - ${item.name}"
+        else -> item.name
+      }
+
+    viewModelScope.launch {
+      // If Jellyfin has saved playback position, seed it into PlaybackState
+      if (item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
+        val positionSeconds = (item.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
+        withContext(Dispatchers.IO) {
+          runCatching {
+            playbackStateRepository.upsert(
+              PlaybackStateEntity(
+                mediaTitle = streamUrl,
+                lastPosition = positionSeconds,
+                playbackSpeed = 1.0,
+                videoZoom = 0f,
+                sid = -1,
+                secondarySid = -1,
+                subDelay = 0,
+                subSpeed = 1.0,
+                aid = -1,
+                audioDelay = 0,
+                timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+              ),
+            )
+          }
+        }
+      }
+
+      // Fire scrobble start asynchronously
+      jellyfinRepository.reportPlaybackStart(
+        serverUrl = server.serverUrl,
+        token = server.accessToken,
+        itemId = item.id,
+        positionTicks = item.playbackPositionTicks ?: 0L,
+      )
+
+      val externalSubs: List<PlaybackSubtitleTrack> =
+        jellyfinRepository
+          .getSubtitleTracks(server = server, itemId = item.id)
+          .getOrDefault(emptyList())
+
+      MediaUtils.playFile(
+        source = streamUrl,
+        context = context,
+        launchSource = "jellyfin_stream",
+        title = itemTitle,
+        mediaDescription = item.overview,
+        posterUrl = posterUrl,
+        backdropUrl = backdropUrl,
+        subtitleTracks = externalSubs,
+      )
+    }
+  }
+
+  companion object {
+    fun factory(application: Application): ViewModelProvider.Factory =
+      viewModelFactory {
+        initializer {
+          JellyfinViewModel(application)
+        }
+      }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -11,6 +11,7 @@ package app.gyrolet.mpvrx.ui.browser.jellyfin
 
 import android.app.Application
 import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -507,16 +508,54 @@ class JellyfinViewModel(
       dbJob.await()
       val externalSubs = subsDeferred.await()
 
+      val currentList = _uiState.value.currentItems
+      val isEpisodePlayback = item.type == "Episode" || item.seriesName != null
+      val (playlistUris, playlistTitles, playlistIndex) =
+        if (isEpisodePlayback && currentList.isNotEmpty()) {
+          val episodeList = currentList.filter { it.type == "Episode" || it.isVideo }
+          if (episodeList.size > 1) {
+            val uris = ArrayList<Uri>(episodeList.size)
+            val titles = ArrayList<String>(episodeList.size)
+            var targetIdx = 0
+            episodeList.forEachIndexed { index, ep ->
+              if (ep.id == item.id) targetIdx = index
+              uris.add(Uri.parse(jellyfinRepository.getStreamUrl(server, ep)))
+              titles.add(
+                when {
+                  ep.seriesName != null && ep.indexNumber != null ->
+                    "${ep.seriesName} S${ep.parentIndexNumber ?: 1}E${ep.indexNumber} - ${ep.name}"
+                  else -> ep.name
+                },
+              )
+            }
+            Triple(uris, titles, targetIdx)
+          } else {
+            Triple(emptyList<Uri>(), emptyList<String>(), 0)
+          }
+        } else {
+          Triple(emptyList<Uri>(), emptyList<String>(), 0)
+        }
+
+      val headers =
+        mapOf(
+          "X-Emby-Token" to server.accessToken,
+          "X-Emby-Authorization" to JellyfinClient.authHeader(server.accessToken),
+        )
+
       withContext(Dispatchers.Main) {
         MediaUtils.playFile(
           source = streamUrl,
           context = context,
           launchSource = "jellyfin_stream",
           title = itemTitle,
+          headers = headers,
           mediaDescription = item.overview,
           posterUrl = posterUrl,
           backdropUrl = backdropUrl,
           subtitleTracks = externalSubs,
+          playlist = playlistUris,
+          playlistIndex = playlistIndex,
+          playlistTitles = playlistTitles,
         )
       }
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -203,6 +203,34 @@ class JellyfinViewModel(
     return true
   }
 
+  /** Navigate directly to a breadcrumb by index — avoids a loop of sequential navigateBack calls. */
+  fun navigateToBreadcrumb(index: Int) {
+    val currentCrumbs = _uiState.value.breadcrumbs
+    if (index < 0 || index >= currentCrumbs.size) return
+
+    val updatedCrumbs = currentCrumbs.take(index + 1)
+    _uiState.update {
+      it.copy(
+        breadcrumbs = updatedCrumbs,
+        searchQuery = "",
+      )
+    }
+    val active = _uiState.value.activeServer ?: return
+    val target = updatedCrumbs.last()
+    loadItems(active, target.id, target.type, resetPagination = true)
+  }
+
+  fun navigateToRoot() {
+    _uiState.update {
+      it.copy(
+        breadcrumbs = emptyList(),
+        searchQuery = "",
+      )
+    }
+    val active = _uiState.value.activeServer ?: return
+    loadLibraries(active)
+  }
+
   private fun loadItems(
     server: JellyfinServer,
     parentId: String,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -28,6 +28,7 @@ import app.gyrolet.mpvrx.repository.JellyfinRepository
 import app.gyrolet.mpvrx.utils.media.MediaUtils
 import app.gyrolet.mpvrx.utils.media.PlaybackSubtitleTrack
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -460,54 +461,64 @@ class JellyfinViewModel(
         else -> item.name
       }
 
-    viewModelScope.launch {
-      // If Jellyfin has saved playback position, seed it into PlaybackState
-      if (item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
-        val positionSeconds = (item.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
-        withContext(Dispatchers.IO) {
-          runCatching {
-            playbackStateRepository.upsert(
-              PlaybackStateEntity(
-                mediaTitle = streamUrl,
-                lastPosition = positionSeconds,
-                playbackSpeed = 1.0,
-                videoZoom = 0f,
-                sid = -1,
-                secondarySid = -1,
-                subDelay = 0,
-                subSpeed = 1.0,
-                aid = -1,
-                audioDelay = 0,
-                timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
-              ),
-            )
+    viewModelScope.launch(Dispatchers.IO) {
+      // Concurrently run DB seed and external subtitle fetching
+      val dbJob =
+        async {
+          if (item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
+            val positionSeconds = (item.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
+            runCatching {
+              playbackStateRepository.upsert(
+                PlaybackStateEntity(
+                  mediaTitle = streamUrl,
+                  lastPosition = positionSeconds,
+                  playbackSpeed = 1.0,
+                  videoZoom = 0f,
+                  sid = -1,
+                  secondarySid = -1,
+                  subDelay = 0,
+                  subSpeed = 1.0,
+                  aid = -1,
+                  audioDelay = 0,
+                  timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+                ),
+              )
+            }
           }
         }
+
+      val subsDeferred =
+        async {
+          jellyfinRepository
+            .getSubtitleTracks(server = server, itemId = item.id)
+            .getOrDefault(emptyList())
+        }
+
+      // Fire scrobble start non-blocking in background
+      launch {
+        jellyfinRepository.reportPlaybackStart(
+          serverUrl = server.serverUrl,
+          token = server.accessToken,
+          itemId = item.id,
+          positionTicks = item.playbackPositionTicks ?: 0L,
+        )
       }
 
-      // Fire scrobble start asynchronously
-      jellyfinRepository.reportPlaybackStart(
-        serverUrl = server.serverUrl,
-        token = server.accessToken,
-        itemId = item.id,
-        positionTicks = item.playbackPositionTicks ?: 0L,
-      )
+      dbJob.await()
+      val externalSubs = subsDeferred.await()
 
-      val externalSubs: List<PlaybackSubtitleTrack> =
-        jellyfinRepository
-          .getSubtitleTracks(server = server, itemId = item.id)
-          .getOrDefault(emptyList())
-
-      MediaUtils.playFile(
-        source = streamUrl,
-        context = context,
-        launchSource = "jellyfin_stream",
-        title = itemTitle,
-        mediaDescription = item.overview,
-        posterUrl = posterUrl,
-        backdropUrl = backdropUrl,
-        subtitleTracks = externalSubs,
-      )
+      withContext(Dispatchers.Main) {
+        MediaUtils.playFile(
+          source = streamUrl,
+          context = context,
+          launchSource = "jellyfin_stream",
+          title = itemTitle,
+          mediaDescription = item.overview,
+          posterUrl = posterUrl,
+          backdropUrl = backdropUrl,
+          subtitleTracks = externalSubs,
+        )
+      }
     }
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -105,6 +105,8 @@ import app.gyrolet.mpvrx.ui.browser.cards.NetworkConnectionCard
 import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.browser.dialogs.AddConnectionSheet
 import app.gyrolet.mpvrx.ui.browser.dialogs.EditConnectionSheet
+import app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinContent
+import app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel
 import app.gyrolet.mpvrx.ui.icons.AppIcon
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
@@ -121,6 +123,7 @@ private const val VIEWED_TORRENT_FILES_PREFS = "torrent_viewed_files"
 
 private enum class NetworkTab(val titleResId: Int) {
   LOCAL_NETWORK(R.string.ui_local_network),
+  JELLYFIN(R.string.ui_jellyfin),
   SYNC_PLAY(R.string.syncplay_title),
   TORRENT(R.string.ui_torrent_files),
 }
@@ -134,6 +137,8 @@ object NetworkStreamingScreen : Screen {
     val context = LocalContext.current
     val viewModel: NetworkStreamingViewModel =
       viewModel(factory = NetworkStreamingViewModel.factory(context.applicationContext as android.app.Application))
+    val jellyfinViewModel: JellyfinViewModel =
+      viewModel(factory = JellyfinViewModel.factory(context.applicationContext as android.app.Application))
     val torrentStreamingEngine = koinInject<TorrentStreamingEngine>()
     val streamEntryRepository = koinInject<NetworkStreamEntryRepository>()
     val wyzieSearchRepository = koinInject<WyzieSearchRepository>()
@@ -405,6 +410,9 @@ object NetworkStreamingScreen : Screen {
                   viewModel.updateConnection(conn.copy(autoConnect = autoConnect))
                 },
               )
+            }
+            NetworkTab.JELLYFIN -> {
+              JellyfinContent(viewModel = jellyfinViewModel)
             }
             NetworkTab.SYNC_PLAY -> {
               SyncPlayContent()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -105,8 +105,6 @@ import app.gyrolet.mpvrx.ui.browser.cards.NetworkConnectionCard
 import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.browser.dialogs.AddConnectionSheet
 import app.gyrolet.mpvrx.ui.browser.dialogs.EditConnectionSheet
-import app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinContent
-import app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel
 import app.gyrolet.mpvrx.ui.icons.AppIcon
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
@@ -123,7 +121,6 @@ private const val VIEWED_TORRENT_FILES_PREFS = "torrent_viewed_files"
 
 private enum class NetworkTab(val titleResId: Int) {
   LOCAL_NETWORK(R.string.ui_local_network),
-  JELLYFIN(R.string.ui_jellyfin),
   SYNC_PLAY(R.string.syncplay_title),
   TORRENT(R.string.ui_torrent_files),
 }
@@ -137,8 +134,6 @@ object NetworkStreamingScreen : Screen {
     val context = LocalContext.current
     val viewModel: NetworkStreamingViewModel =
       viewModel(factory = NetworkStreamingViewModel.factory(context.applicationContext as android.app.Application))
-    val jellyfinViewModel: JellyfinViewModel =
-      viewModel(factory = JellyfinViewModel.factory(context.applicationContext as android.app.Application))
     val torrentStreamingEngine = koinInject<TorrentStreamingEngine>()
     val streamEntryRepository = koinInject<NetworkStreamEntryRepository>()
     val wyzieSearchRepository = koinInject<WyzieSearchRepository>()
@@ -410,9 +405,6 @@ object NetworkStreamingScreen : Screen {
                   viewModel.updateConnection(conn.copy(autoConnect = autoConnect))
                 },
               )
-            }
-            NetworkTab.JELLYFIN -> {
-              JellyfinContent(viewModel = jellyfinViewModel)
             }
             NetworkTab.SYNC_PLAY -> {
               SyncPlayContent()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedViewModel.kt
@@ -271,12 +271,14 @@ class RecentlyPlayedViewModel(
     // Extract URI components
     val uri = Uri.parse(url)
 
-    // Prefer the title saved with the recent item so network streams keep their resolved name.
+    // Prefer non-generic title saved with the recent item so network streams keep their resolved name.
     val resolvedTitle =
-      parsedVideoTitle
-        ?.takeIf { it.isNotBlank() }
+      parsedVideoTitle?.takeIf { !isGenericStreamName(it) }
+        ?: entity?.videoTitle?.takeIf { !isGenericStreamName(it) }
+        ?: entity?.fileName?.takeIf { !isGenericStreamName(it) }
+        ?: uri.lastPathSegment?.takeIf { !isGenericStreamName(it) }
+        ?: parsedVideoTitle?.takeIf { it.isNotBlank() }
         ?: entity?.fileName?.takeIf { it.isNotBlank() }
-        ?: uri.lastPathSegment?.takeIf { it.isNotBlank() }
         ?: "Stream"
     val displayName = resolvedTitle
 
@@ -540,6 +542,19 @@ class RecentlyPlayedViewModel(
   }
 
   companion object {
+    private val GENERIC_STREAM_NAMES =
+      setOf(
+        "stream",
+        "stream.mkv",
+        "stream.mp4",
+        "stream.ts",
+        "stream.webm",
+        "stream.avi",
+      )
+
+    fun isGenericStreamName(name: String?): Boolean =
+      name.isNullOrBlank() || name.trim().lowercase() in GENERIC_STREAM_NAMES
+
     fun factory(application: Application): ViewModelProvider.Factory =
       viewModelFactory {
         initializer {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -3103,7 +3103,9 @@ class PlayerActivity :
   }
 
   private fun getPreferredCurrentTitle(): String =
-    getPlaylistItemByIndex(playlistIndex)?.fileName?.takeIf { it.isNotBlank() } ?: fileName
+    getPlaylistItemByIndex(playlistIndex)?.fileName?.takeIf { it.isNotBlank() }
+      ?: networkPlaylistTitles.getOrNull(playlistIndex)?.takeIf { it.isNotBlank() }
+      ?: fileName
 
   private fun shouldForceCurrentMediaTitle(): Boolean =
     getPlaylistItemByIndex(playlistIndex)?.fileName?.isNotBlank() == true ||
@@ -4293,8 +4295,19 @@ class PlayerActivity :
           else -> "normal"
         }
 
-      // Prioritize intent title first if provided and valid
-      val intentTitle = intent.getStringExtra("title")
+      // Prioritize explicit title from playlist or intent
+      val resolvedExplicitTitle =
+        getPlaylistItemByIndex(playlistIndex)?.fileName?.takeIf { it.isNotBlank() }
+          ?: networkPlaylistTitles.getOrNull(playlistIndex)?.takeIf { it.isNotBlank() }
+          ?: intent.getStringExtra("title")
+          ?: intent.getStringExtra("torrent_media_title")
+
+      val resolvedFileName =
+        if (fileName.isBlank() || fileName.equals("stream.mkv", ignoreCase = true) || fileName.equals("stream", ignoreCase = true)) {
+          resolvedExplicitTitle ?: fileName
+        } else {
+          fileName
+        }
 
       // Get parsed video title from MPV
       val mpvTitle =
@@ -4304,8 +4317,8 @@ class PlayerActivity :
 
       val videoTitle =
         when {
-          !HttpUtils.isLikelyJunkTitle(intentTitle) -> intentTitle
-          !HttpUtils.isLikelyJunkTitle(mpvTitle) && mpvTitle != fileName -> mpvTitle
+          !HttpUtils.isLikelyJunkTitle(resolvedExplicitTitle) -> resolvedExplicitTitle
+          !HttpUtils.isLikelyJunkTitle(mpvTitle) && mpvTitle != resolvedFileName -> mpvTitle
           else -> null
         }
 
@@ -4343,7 +4356,7 @@ class PlayerActivity :
 
       RecentlyPlayedOps.addRecentlyPlayed(
         filePath = filePath,
-        fileName = fileName,
+        fileName = resolvedFileName,
         videoTitle = videoTitle,
         duration = duration,
         fileSize = fileSize,
@@ -4353,7 +4366,7 @@ class PlayerActivity :
       )
 
       Log.d(TAG, "Saved recently played: $filePath")
-      Log.d(TAG, "  - fileName: $fileName")
+      Log.d(TAG, "  - fileName: $resolvedFileName")
       Log.d(TAG, "  - videoTitle: $videoTitle")
       Log.d(TAG, "  - duration: ${duration}ms")
       Log.d(TAG, "  - size: ${fileSize}B")
@@ -5861,17 +5874,20 @@ class PlayerActivity :
       viewModel.setMediaTitle(fileName)
     }
 
-    // Update media session metadata
-    lifecycleScope.launch {
+    // Update media session metadata and save recently played
+    lifecycleScope.launch(Dispatchers.IO) {
       kotlinx.coroutines.delay(100) // Wait for MPV to load the file
       val durationMs = (PlaybackSession.getPropertyDouble("duration")?.times(1000))?.toLong() ?: 0L
-      updateMediaSessionMetadata(
-        title = fileName,
-        durationMs = durationMs,
-      )
-      syncBackgroundPlaybackService(updateThumbnail = true)
-      // Refresh playlist items to update the currently playing indicator
-      viewModel.refreshPlaylistItems()
+      withContext(Dispatchers.Main) {
+        updateMediaSessionMetadata(
+          title = fileName,
+          durationMs = durationMs,
+        )
+        syncBackgroundPlaybackService(updateThumbnail = true)
+        // Refresh playlist items to update the currently playing indicator
+        viewModel.refreshPlaylistItems()
+      }
+      saveRecentlyPlayedForUri(uri, fileName)
     }
   }
 
@@ -6056,11 +6072,28 @@ class PlayerActivity :
           }
         }
 
+      val isGenericStream =
+        name.isBlank() ||
+          name.equals("stream.mkv", ignoreCase = true) ||
+          name.equals("stream", ignoreCase = true) ||
+          name.equals("stream.mp4", ignoreCase = true) ||
+          name.equals("stream.ts", ignoreCase = true)
+
+      val resolvedName =
+        if (isGenericStream) {
+          getPlaylistItemByIndex(playlistIndex)?.fileName?.takeIf { it.isNotBlank() }
+            ?: networkPlaylistTitles.getOrNull(playlistIndex)?.takeIf { it.isNotBlank() }
+            ?: intent.getStringExtra("title")
+            ?: name
+        } else {
+          name
+        }
+
       // Get parsed video title from MPV
       val videoTitle =
         runCatching {
           PlaybackSession.getPropertyString("media-title")
-        }.getOrNull()?.takeIf { it.isNotBlank() && it != name }
+        }.getOrNull()?.takeIf { it.isNotBlank() && it != resolvedName && !HttpUtils.isLikelyJunkTitle(it) }
 
       // Get duration and file size from MPV
       val duration =
@@ -6096,7 +6129,7 @@ class PlayerActivity :
 
       RecentlyPlayedOps.addRecentlyPlayed(
         filePath = filePath,
-        fileName = name,
+        fileName = resolvedName,
         videoTitle = videoTitle,
         duration = duration,
         fileSize = fileSize,
@@ -6170,7 +6203,11 @@ class PlayerActivity :
 
   private fun loadNetworkPlaylistMetadata(intent: Intent) {
     networkPlaylistPaths = intent.getStringArrayListExtra("network_playlist_paths") ?: emptyList()
-    networkPlaylistTitles = intent.getStringArrayListExtra("network_playlist_titles") ?: emptyList()
+    networkPlaylistTitles =
+      intent.getStringArrayListExtra("network_playlist_titles")
+        ?: intent.getStringArrayListExtra("playlist_titles")
+        ?: intent.getStringArrayListExtra("titles")
+        ?: emptyList()
     networkPlaylistHeaders = emptyList()
     networkPlaylistConnectionId = intent.getLongExtra("network_playlist_connection_id", -1L)
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerNodes.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerNodes.kt
@@ -75,4 +75,15 @@ data class TrackNode(
   val isAlbumArtwork = albumArt == true || image == true
   val isSubtitle = type == "sub"
   val isSelected = selected == true
+
+  val effectiveTitle: String?
+    get() =
+      title?.takeIf { it.isNotBlank() }
+        ?: metadata?.entries?.firstOrNull { it.key.equals("title", ignoreCase = true) }?.value?.takeIf { it.isNotBlank() }
+        ?: metadata?.entries?.firstOrNull { it.key.equals("handler_name", ignoreCase = true) }?.value?.takeIf { it.isNotBlank() && !it.contains("handler", ignoreCase = true) }
+
+  val effectiveLang: String?
+    get() =
+      lang?.takeIf { it.isNotBlank() }
+        ?: metadata?.entries?.firstOrNull { it.key.equals("language", ignoreCase = true) || it.key.equals("lang", ignoreCase = true) }?.value?.takeIf { it.isNotBlank() }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -19,6 +19,7 @@ import android.media.AudioManager
 import android.net.Uri
 import android.os.BatteryManager
 import android.os.SystemClock
+import `is`.xyz.mpv.MPVNode
 import android.provider.OpenableColumns
 import android.provider.Settings
 import android.util.DisplayMetrics
@@ -501,20 +502,67 @@ class PlayerViewModel : ViewModel(),
   private val _preciseDuration = MutableStateFlow(0f)
   val preciseDuration = _preciseDuration.asStateFlow()
 
+  private fun parseTracks(node: MPVNode?): List<TrackNode> {
+    val fromNode = runCatching { node?.toObject<List<TrackNode>>(json) }.getOrNull()
+    if (!fromNode.isNullOrEmpty()) {
+      return fromNode
+    }
+    val trackCount = PlaybackSession.getPropertyInt("track-list/count") ?: 0
+    if (trackCount <= 0) return emptyList()
+    val fallbackList = mutableListOf<TrackNode>()
+    for (i in 0 until trackCount) {
+      val id = PlaybackSession.getPropertyInt("track-list/$i/id") ?: continue
+      val type = PlaybackSession.getPropertyString("track-list/$i/type") ?: continue
+      val title =
+        PlaybackSession.getPropertyString("track-list/$i/title")
+          ?: PlaybackSession.getPropertyString("track-list/$i/metadata/by-key/title")
+          ?: PlaybackSession.getPropertyString("track-list/$i/metadata/by-key/TITLE")
+      val lang =
+        PlaybackSession.getPropertyString("track-list/$i/lang")
+          ?: PlaybackSession.getPropertyString("track-list/$i/metadata/by-key/language")
+          ?: PlaybackSession.getPropertyString("track-list/$i/metadata/by-key/lang")
+      val selected = PlaybackSession.getPropertyBoolean("track-list/$i/selected")
+      val external = PlaybackSession.getPropertyBoolean("track-list/$i/external")
+      val default = PlaybackSession.getPropertyBoolean("track-list/$i/default")
+      val forced = PlaybackSession.getPropertyBoolean("track-list/$i/forced")
+      val codec = PlaybackSession.getPropertyString("track-list/$i/codec")
+      val codecDesc = PlaybackSession.getPropertyString("track-list/$i/codec-desc")
+      val externalFilename = PlaybackSession.getPropertyString("track-list/$i/external-filename")
+      val image = PlaybackSession.getPropertyBoolean("track-list/$i/image")
+      val albumArt = PlaybackSession.getPropertyBoolean("track-list/$i/albumart")
+      fallbackList.add(
+        TrackNode(
+          id = id,
+          type = type,
+          title = title,
+          lang = lang,
+          selected = selected,
+          external = external,
+          default = default,
+          forced = forced,
+          codec = codec,
+          codecDesc = codecDesc,
+          externalFilename = externalFilename,
+          image = image,
+          albumArt = albumArt,
+        ),
+      )
+    }
+    return fallbackList
+  }
+
   // These MPV-backed state flows must be initialized before any init block collects them.
   val subtitleTracks: StateFlow<List<TrackNode>> =
     PlaybackSession.propNode["track-list"]
       .map { node ->
-        node?.toObject<List<TrackNode>>(json)?.filter { it.isSubtitle }?.toImmutableList()
-          ?: persistentListOf()
-      }.stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
+        parseTracks(node).filter { it.isSubtitle }.toImmutableList()
+      }.stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
 
   val audioTracks: StateFlow<List<TrackNode>> =
     PlaybackSession.propNode["track-list"]
       .map { node ->
-        node?.toObject<List<TrackNode>>(json)?.filter { it.isAudio }?.toImmutableList()
-          ?: persistentListOf()
-      }.stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
+        parseTracks(node).filter { it.isAudio }.toImmutableList()
+      }.stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
 
   val isAudioOnly: StateFlow<Boolean> =
     combine(
@@ -541,7 +589,7 @@ class PlayerViewModel : ViewModel(),
             .filterNotNull()
             .any { candidate -> candidate.fileExtension() in FileTypeUtils.VIDEO_EXTENSIONS }
 
-      val tracks = node?.toObject<List<TrackNode>>(json).orEmpty()
+      val tracks = parseTracks(node)
       val hasRealVideo = tracks.any { it.isVideo && !it.isAlbumArtwork }
       val detectedAudio =
         when {
@@ -560,16 +608,16 @@ class PlayerViewModel : ViewModel(),
   val hasAlbumArt: StateFlow<Boolean> =
     PlaybackSession.propNode["track-list"]
       .map { node ->
-        val tracks = node?.toObject<List<TrackNode>>(json).orEmpty()
+        val tracks = parseTracks(node)
         tracks.any { it.isAlbumArtwork }
       }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
   val chapters: StateFlow<List<dev.vivvvek.seeker.Segment>> =
     PlaybackSession.propNode["chapter-list"]
       .map { node ->
-        node?.toObject<List<ChapterNode>>(json)?.map { it.toSegment() }?.toImmutableList()
+        runCatching { node?.toObject<List<ChapterNode>>(json) }.getOrNull()?.map { it.toSegment() }?.toImmutableList()
           ?: persistentListOf()
-      }.stateIn(viewModelScope, SharingStarted.Lazily, persistentListOf())
+      }.stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
 
   // Audio player UI state
   val albumArtBounds = MutableStateFlow<android.graphics.Rect?>(null)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -2715,12 +2715,27 @@ class PlayerViewModel : ViewModel(),
   }
 
   private fun maybeAutoSkipIntro(positionSeconds: Double) {
+    val totalDur = currentDurationSeconds()
+    val hasNextItem = PlaybackSession.hasNext()
     val activeSegment =
       skipSegmentsSnapshot.firstOrNull { segment ->
         positionSeconds in segment.startSeconds..segment.endSeconds && (segment.endSeconds - positionSeconds) >= 1.0
+      } ?: if (hasNextItem && totalDur > 45.0 && (totalDur - positionSeconds) in 1.0..30.0) {
+        SkipSegment(
+          type = SkipSegmentType.NEXT_EPISODE,
+          startSeconds = totalDur - 30.0,
+          endSeconds = totalDur,
+          source = "auto_outro",
+        )
+      } else {
+        null
       }
+
     val showChip =
-      activeSegment != null && (positionSeconds - activeSegment.startSeconds) < AUTO_SHOW_SKIP_CHIP_DURATION
+      activeSegment != null && (
+        activeSegment.type == SkipSegmentType.NEXT_EPISODE ||
+          (positionSeconds - activeSegment.startSeconds) < AUTO_SHOW_SKIP_CHIP_DURATION
+      )
     if (_currentSkippableSegment.value != activeSegment) {
       _currentSkippableSegment.value = activeSegment
     }
@@ -2737,29 +2752,38 @@ class PlayerViewModel : ViewModel(),
         SkipSegmentType.OUTRO -> playerPreferences.autoSkipOutro.get()
         SkipSegmentType.CREDITS -> playerPreferences.autoSkipOutro.get()
         SkipSegmentType.PREVIEW -> playerPreferences.autoSkipOutro.get()
+        SkipSegmentType.NEXT_EPISODE -> false
       }
     if (!autoSkipEnabled) return
 
     skippedSegmentTypes += activeSegment.type
-    PlaybackSession.setPropertyDouble("time-pos", activeSegment.endSeconds)
-    syncplayManager.updatePlayerState(
-      activeSegment.endSeconds,
-      PlaybackSession.getPropertyBoolean("pause") ?: false,
-      doSeek = true,
-    )
-    showToast("${activeSegment.label} (auto)")
+    if ((activeSegment.type == SkipSegmentType.OUTRO || activeSegment.type == SkipSegmentType.CREDITS) && hasNext()) {
+      playNext()
+    } else {
+      PlaybackSession.setPropertyDouble("time-pos", activeSegment.endSeconds)
+      syncplayManager.updatePlayerState(
+        activeSegment.endSeconds,
+        PlaybackSession.getPropertyBoolean("pause") ?: false,
+        doSeek = true,
+      )
+      showToast("${activeSegment.label} (auto)")
+    }
   }
 
   fun skipActiveSegment() {
     val segment = _currentSkippableSegment.value ?: return
     skippedSegmentTypes += segment.type
-    PlaybackSession.setPropertyDouble("time-pos", segment.endSeconds)
-    syncplayManager.updatePlayerState(
-      segment.endSeconds,
-      PlaybackSession.getPropertyBoolean("pause") ?: false,
-      doSeek = true,
-    )
-    showToast("${segment.label}")
+    if ((segment.type == SkipSegmentType.OUTRO || segment.type == SkipSegmentType.CREDITS || segment.type == SkipSegmentType.NEXT_EPISODE) && hasNext()) {
+      playNext()
+    } else {
+      PlaybackSession.setPropertyDouble("time-pos", segment.endSeconds)
+      syncplayManager.updatePlayerState(
+        segment.endSeconds,
+        PlaybackSession.getPropertyBoolean("pause") ?: false,
+        doSeek = true,
+      )
+      showToast("${segment.label}")
+    }
   }
 
   private fun mergeSkipSegments() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -552,25 +552,28 @@ class PlayerViewModel : ViewModel(),
   }
 
   // These MPV-backed state flows must be initialized before any init block collects them.
-  val subtitleTracks: StateFlow<List<TrackNode>> =
+  private val allTracks: StateFlow<List<TrackNode>> =
     PlaybackSession.propNode["track-list"]
-      .map { node ->
-        parseTracks(node).filter { it.isSubtitle }.toImmutableList()
-      }.stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
+      .map { node -> parseTracks(node).toImmutableList() }
+      .stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
+
+  val subtitleTracks: StateFlow<List<TrackNode>> =
+    allTracks
+      .map { tracks -> tracks.filter { it.isSubtitle }.toImmutableList() }
+      .stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
 
   val audioTracks: StateFlow<List<TrackNode>> =
-    PlaybackSession.propNode["track-list"]
-      .map { node ->
-        parseTracks(node).filter { it.isAudio }.toImmutableList()
-      }.stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
+    allTracks
+      .map { tracks -> tracks.filter { it.isAudio }.toImmutableList() }
+      .stateIn(viewModelScope, SharingStarted.Eagerly, persistentListOf())
 
   val isAudioOnly: StateFlow<Boolean> =
     combine(
-      PlaybackSession.propNode["track-list"],
+      allTracks,
       PlaybackSession.propString["path"],
       PlaybackSession.propString["stream-open-filename"],
       PlaybackSession.state,
-    ) { node, path, streamPath, session ->
+    ) { tracks, path, streamPath, session ->
       val currentPath = path?.takeIf { it.isNotBlank() } ?: streamPath
       val queuedItem = session.currentItem
       val itemDeclaresAudio =
@@ -589,7 +592,6 @@ class PlayerViewModel : ViewModel(),
             .filterNotNull()
             .any { candidate -> candidate.fileExtension() in FileTypeUtils.VIDEO_EXTENSIONS }
 
-      val tracks = parseTracks(node)
       val hasRealVideo = tracks.any { it.isVideo && !it.isAlbumArtwork }
       val detectedAudio =
         when {
@@ -606,11 +608,9 @@ class PlayerViewModel : ViewModel(),
       .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
   val hasAlbumArt: StateFlow<Boolean> =
-    PlaybackSession.propNode["track-list"]
-      .map { node ->
-        val tracks = parseTracks(node)
-        tracks.any { it.isAlbumArtwork }
-      }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+    allTracks
+      .map { tracks -> tracks.any { it.isAlbumArtwork } }
+      .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
   val chapters: StateFlow<List<dev.vivvvek.seeker.Segment>> =
     PlaybackSession.propNode["chapter-list"]

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/SkipSegment.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/SkipSegment.kt
@@ -17,6 +17,7 @@ enum class SkipSegmentType {
   OUTRO,
   CREDITS,
   PREVIEW,
+  NEXT_EPISODE,
   ;
 
   val label: String
@@ -27,6 +28,7 @@ enum class SkipSegmentType {
         OUTRO -> "Skip outro"
         CREDITS -> "Skip credits"
         PREVIEW -> "Skip preview"
+        NEXT_EPISODE -> "Next episode"
       }
 
   val accentColor: Color
@@ -37,6 +39,7 @@ enum class SkipSegmentType {
         OUTRO -> Color(0xFFE05666)
         CREDITS -> Color(0xFFA64DFF)
         PREVIEW -> Color(0xFF00D4C7)
+        NEXT_EPISODE -> Color(0xFF4CAF50)
       }
 }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/TrackSheetRows.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/TrackSheetRows.kt
@@ -69,8 +69,10 @@ fun AddTrackRow(
 
 @Composable
 fun getTrackTitle(track: TrackNode): String {
-  val hasTitle = !track.title.isNullOrBlank()
-  val hasLang = !track.lang.isNullOrBlank()
+  val title = track.effectiveTitle
+  val lang = track.effectiveLang
+  val hasTitle = !title.isNullOrBlank()
+  val hasLang = !lang.isNullOrBlank()
 
   if (track.isSubtitle && track.external == true && !hasTitle && !hasLang && track.externalFilename != null) {
     val decoded = Uri.decode(track.externalFilename)
@@ -83,11 +85,12 @@ fun getTrackTitle(track: TrackNode): String {
       stringResource(
         R.string.player_sheets_track_title_w_lang,
         track.id,
-        track.title,
-        track.lang,
+        title,
+        lang,
       )
-    hasTitle -> stringResource(R.string.player_sheets_track_title_wo_lang, track.id, track.title)
-    hasLang -> stringResource(R.string.player_sheets_track_lang_wo_title, track.id, track.lang)
+    hasTitle -> stringResource(R.string.player_sheets_track_title_wo_lang, track.id, title)
+    hasLang -> stringResource(R.string.player_sheets_track_lang_wo_title, track.id, lang)
+    !track.codecDesc.isNullOrBlank() -> stringResource(R.string.player_sheets_track_title_wo_lang, track.id, track.codecDesc)
     track.isSubtitle -> stringResource(R.string.player_sheets_chapter_title_substitute_subtitle, track.id)
     track.isAudio -> stringResource(R.string.player_sheets_chapter_title_substitute_audio, track.id)
     else -> ""

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AppearancePreferencesScreen.kt
@@ -739,6 +739,7 @@ object AppearancePreferencesScreen : Screen {
               val showRecentsTab by preferences.showRecentsTab.collectAsState()
               val showPlaylistsTab by preferences.showPlaylistsTab.collectAsState()
               val showNetworkTab by preferences.showNetworkTab.collectAsState()
+              val showJellyfinTab by preferences.showJellyfinTab.collectAsState()
 
               SwitchPreference(
                 value = showHomeTab,
@@ -803,6 +804,20 @@ object AppearancePreferencesScreen : Screen {
                 summary = {
                   Text(
                     text = stringResource(id = R.string.pref_nav_network_summary),
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+              )
+
+              PreferenceDivider()
+
+              SwitchPreference(
+                value = showJellyfinTab,
+                onValueChange = preferences.showJellyfinTab::set,
+                title = { Text(text = stringResource(id = R.string.pref_nav_jellyfin_title)) },
+                summary = {
+                  Text(
+                    text = stringResource(id = R.string.pref_nav_jellyfin_summary),
                     color = MaterialTheme.colorScheme.outline,
                   )
                 },

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
@@ -82,6 +82,9 @@ object MediaUtils {
     mediaDescription: String? = null,
     posterUrl: String? = null,
     backdropUrl: String? = null,
+    playlist: List<Uri> = emptyList(),
+    playlistIndex: Int = 0,
+    playlistTitles: List<String> = emptyList(),
   ) {
     val uri =
       when (source) {
@@ -138,6 +141,9 @@ object MediaUtils {
             mediaDescription = mediaDescription,
             posterUrl = posterUrl,
             backdropUrl = backdropUrl,
+            playlist = playlist,
+            playlistIndex = playlistIndex,
+            playlistTitles = playlistTitles,
           )
           context.startActivity(intent)
           return
@@ -218,6 +224,9 @@ object MediaUtils {
       mediaDescription = mediaDescription,
       posterUrl = posterUrl,
       backdropUrl = backdropUrl,
+      playlist = playlist,
+      playlistIndex = playlistIndex,
+      playlistTitles = playlistTitles,
     )
     context.startActivity(intent)
   }
@@ -273,7 +282,19 @@ object MediaUtils {
     mediaDescription: String?,
     posterUrl: String?,
     backdropUrl: String?,
+    playlist: List<Uri> = emptyList(),
+    playlistIndex: Int = 0,
+    playlistTitles: List<String> = emptyList(),
   ) {
+    if (playlist.isNotEmpty()) {
+      val playlistArrayList = if (playlist is ArrayList) playlist else ArrayList(playlist)
+      intent.putParcelableArrayListExtra("playlist", playlistArrayList)
+      intent.putExtra("playlistIndex", playlistIndex)
+      if (playlistTitles.isNotEmpty()) {
+        val titlesArrayList = if (playlistTitles is ArrayList) playlistTitles else ArrayList(playlistTitles)
+        intent.putStringArrayListExtra("playlist_titles", titlesArrayList)
+      }
+    }
     launchSource?.let { intent.putExtra("launch_source", it) }
     title?.let {
       intent.putExtra("title", it)

--- a/app/src/main/res/drawable/ic_jellyfin.xml
+++ b/app/src/main/res/drawable/ic_jellyfin.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group
+      android:pivotX="12"
+      android:pivotY="12"
+      android:scaleX="0.82"
+      android:scaleY="0.82">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,0.002C8.826,0.002 -1.398,18.537 0.16,21.666c1.56,3.129 22.14,3.094 23.682,0S15.177,0 12,0zm7.76,18.949c-1.008,2.028 -14.493,2.05 -15.514,0C3.224,16.9 9.92,4.755 12.003,4.755c2.081,0 8.77,12.166 7.759,14.196zM12,9.198c-1.054,0 -4.446,6.15 -3.93,7.189c0.518,1.04 7.348,1.027 7.86,0c0.511,-1.027 -2.874,-7.19 -3.93,-7.19z"/>
+  </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,8 @@
   <string name="pref_nav_playlists_summary">Show or hide Playlists in the bottom navigation bar</string>
   <string name="pref_nav_network_title">Show Network tab</string>
   <string name="pref_nav_network_summary">Show or hide Network in the bottom navigation bar</string>
+  <string name="pref_nav_jellyfin_title">Show Jellyfin tab</string>
+  <string name="pref_nav_jellyfin_summary">Show or hide Jellyfin in the bottom navigation bar</string>
   <string name="pref_quick_play_fab_title">Quick Play FAB</string>
   <string name="pref_quick_play_fab_summary">Show the quick play floating action button in browser screens</string>
   <string name="pref_quick_play_fab_direct_title">Direct Quick Play</string>
@@ -1238,6 +1240,7 @@
   <string name="ui_videos">Videos</string>
   <string name="ui_add_connection">Add Connection</string>
   <string name="ui_local_network">Local Network</string>
+  <string name="ui_jellyfin">Jellyfin</string>
   <string name="ui_no_network_connections">No network connections</string>
   <string name="ui_no_recent_links">No recent stream links or torrents yet. Paste a stream URL above to get started.</string>
   <string name="ui_add_smb_ftp_or_webdav_connections_to_browse_network_files">Add SMB, FTP, or WebDAV connections to browse network files</string>


### PR DESCRIPTION
Adds native Jellyfin support as a dedicated browser tab with zero transcoding — direct stream via libmpv hardware acceleration.

## Features

- **Client & auth**: server management, token/password login, multi-server support
- **Browsing**: libraries, folders, movies, TV shows/seasons/episodes with poster + list layouts
- **Search**: prioritized results (shows/movies first, episodes below)
- **Streaming**: direct stream URLs, external subtitle injection, auth header passthrough
- **Playback**: next-episode overlay with auto-play, progress tracking, watched/unwatched state sync
- **Continue Watching**: resume carousel on home view
- **History**: Jellyfin items appear in recently played with correct thumbnails
- **Selection**: long-press multi-select with icon-only action pill (Play, Watched, Unwatched, Info)
- **Item info**: metadata bottom sheet (type, episode, year, rating, duration, container, overview)

closes #377 