### PR TITLE
fix(player): restore original ThumbFast startup behavior

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -51,13 +51,11 @@ class App :
   private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
   private val networkAutoConnectStarted = AtomicBoolean(false)
   private val metadataMaintenanceStarted = AtomicBoolean(false)
-  private val fastThumbnailsStarted = AtomicBoolean(false)
   private var startedActivityCount = 0
 
   companion object {
     private const val TAG = "App"
     private const val POST_START_MAINTENANCE_DELAY_MS = 10_000L
-    private const val THUMBNAIL_WARMUP_DELAY_MS = 1_500L
     private const val IDLE_MPV_CORE_GRACE_MS = 3L * 60L * 1000L
   }
 
@@ -84,6 +82,12 @@ class App :
     }
     registerActivityLifecycleCallbacks(this)
     Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(applicationContext, CrashActivity::class.java))
+
+    // Keep the native thumbnail engine ready before any player/browser UI can request a frame.
+    // This restores the original ThumbFast initialization behavior and removes the foreground
+    // warm-up race where an early scrub could arrive before FastThumbnails was initialized.
+    FastThumbnails.initialize(this)
+
     startIdleMpvCoreReaper()
 
     applicationScope.launch {
@@ -108,8 +112,7 @@ class App :
     }
 
     // TextMate grammar/theme assets for the script editor are initialized lazily on first use.
-    // Metadata cache maintenance and native thumbnail startup are intentionally kept out of the
-    // Application cold-start path so they cannot compete with first composition / first frame.
+    // Metadata cache maintenance remains off the Application cold-start path.
 
     // MediaStore is Android's source of truth for the normal library. Do not trigger a recursive
     // scan of the entire external-storage root from process startup: on large libraries that can
@@ -120,7 +123,6 @@ class App :
   override fun onActivityStarted(activity: Activity) {
     if (startedActivityCount++ == 0) {
       getKoin().get<app.gyrolet.mpvrx.domain.syncplay.SyncplayManager>().onAppForegrounded()
-      scheduleFastThumbnailWarmupOnce()
       scheduleMetadataMaintenanceOnce()
     }
   }
@@ -193,22 +195,6 @@ class App :
           Log.d(TAG, "Destroying libmpv after idle grace period")
           PlaybackSession.destroy()
         }
-      }
-    }
-  }
-
-  private fun scheduleFastThumbnailWarmupOnce() {
-    if (!fastThumbnailsStarted.compareAndSet(false, true)) return
-    applicationScope.launch(Dispatchers.Default) {
-      try {
-        delay(THUMBNAIL_WARMUP_DELAY_MS)
-        FastThumbnails.initialize(this@App)
-      } catch (cancellation: CancellationException) {
-        fastThumbnailsStarted.set(false)
-        throw cancellation
-      } catch (error: Exception) {
-        fastThumbnailsStarted.set(false)
-        Log.w(TAG, "Deferred FastThumbnails initialization failed", error)
       }
     }
   }


### PR DESCRIPTION
## Summary

This replaces the now-empty/closed #414 with a real revert PR focused on the remaining ThumbFast regression that differs from the older working implementation.

## What changed

- restore `FastThumbnails.initialize(this)` during `Application.onCreate()`
- remove the later 1.5-second deferred foreground warm-up
- remove the `fastThumbnailsStarted` guard and delayed initialization coroutine
- leave the current seek/ThumbFast routing code untouched because it already matches the pre-`a25c23f` known-good implementation on `master`

## Why

PR #348 moved native FastThumbnails initialization out of app startup and delayed it until 1.5 seconds after the first Activity entered the foreground.

That creates a real race: the player can be opened and scrubbed before the native thumbnail engine is ready. Early ThumbFast requests can therefore fail or sit in loading/failure handling even though the original implementation initialized the native engine before any UI could request a thumbnail.

The older working App implementation initialized FastThumbnails synchronously during process startup. This PR restores that behavior without reverting unrelated resource-audit improvements such as deferred metadata maintenance, the idle mpv core reaper, MediaStore handling, or other player fixes.

## Scope

- 1 commit
- 1 production file
- `App.kt`: 7 additions / 21 deletions
- no seekbar visual changes
- no new decoder architecture
- no main playback-core seeking during ThumbFast
- no changes to Jellyfin, PiP, lifecycle, renderer, HDR, subtitles, playlist, or network playback

## Historical check

The seek/ThumbFast implementation in `PlayerViewModel`, `PlayerControls`, and `GestureHandler` on current `master` already matches the older pre-`fix precise network seek previews` behavior. The large `a25c23f` seek rewrite was already reverted historically, so duplicating those old files here would create no diff.

The remaining concrete behavior difference is the deferred native ThumbFast initialization introduced later by the resource-audit work; this PR reverts only that regression.

## Device checks

- cold-start app -> immediately open a video -> scrub with ThumbFast enabled
- scrub immediately after player appears; preview should not wait for a 1.5 s warm-up
- rapid repeated ThumbFast scrubbing
- toggle ThumbFast off and verify legacy live-video seeking is unchanged
- local MP4/MKV and network stream checks
