### PR TITLE
feat(jellyfin): enhance playback sync, session reporting, and server configuration UI

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -44,12 +44,22 @@ class JellyfinClient(
     private const val VERSION = "2.1.0"
     private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
 
-    fun normalizeUrl(rawUrl: String): String {
-      var url = rawUrl.trim()
-      if (!url.startsWith("http://", ignoreCase = true) && !url.startsWith("https://", ignoreCase = true)) {
-        url = "http://$url"
+    fun normalizeUrlCandidates(rawUrl: String): List<String> {
+      val trimmed = rawUrl.trim().removeSuffix("/")
+      if (trimmed.startsWith("http://", ignoreCase = true) || trimmed.startsWith("https://", ignoreCase = true)) {
+        return listOf(trimmed)
       }
-      return url.removeSuffix("/")
+      val clean = trimmed.removePrefix("//")
+      val port = clean.substringAfterLast(":", "").substringBefore("/").toIntOrNull()
+      return if (port == 80 || port == 8096) {
+        listOf("http://$clean", "https://$clean")
+      } else {
+        listOf("https://$clean", "http://$clean")
+      }
+    }
+
+    fun normalizeUrl(rawUrl: String): String {
+      return normalizeUrlCandidates(rawUrl).first()
     }
 
     fun authHeader(token: String? = null): String {
@@ -102,51 +112,61 @@ class JellyfinClient(
     password: String,
   ): Result<JellyfinAuthResult> =
     withContext(Dispatchers.IO) {
-      runCatching {
-        val base = normalizeUrl(serverUrl)
-        val endpoint = "$base/Users/AuthenticateByName"
-        val payload =
-          JsonObject(
-            mapOf(
-              "Username" to kotlinx.serialization.json.JsonPrimitive(username),
-              "Pw" to kotlinx.serialization.json.JsonPrimitive(password),
-            ),
-          ).toString()
+      val candidates = normalizeUrlCandidates(serverUrl)
+      var lastError: Throwable = IOException("No valid URL candidate for $serverUrl")
 
-        val request =
-          Request
-            .Builder()
-            .url(endpoint)
-            .addHeader("X-Emby-Authorization", authHeader())
-            .addHeader("Content-Type", "application/json")
-            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
-            .build()
+      for (candidate in candidates) {
+        try {
+          val endpoint = "$candidate/Users/AuthenticateByName"
+          val payload =
+            JsonObject(
+              mapOf(
+                "Username" to kotlinx.serialization.json.JsonPrimitive(username),
+                "Pw" to kotlinx.serialization.json.JsonPrimitive(password),
+              ),
+            ).toString()
 
-        httpClient.newCall(request).execute().use { response ->
-          if (!response.isSuccessful) {
-            throw IOException("Authentication failed: HTTP ${response.code} ${response.message}")
-          }
-          val bodyStr = response.body.string()
-          val root = json.parseToJsonElement(bodyStr).jsonObject
-          val accessToken = root["AccessToken"]?.jsonPrimitive?.content ?: throw IOException("Missing AccessToken in response")
-          val userObj = root["User"]?.jsonObject ?: throw IOException("Missing User object in response")
-          val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id in response")
-          val uname = userObj["Name"]?.jsonPrimitive?.content ?: username
-          val serverId = root["ServerId"]?.jsonPrimitive?.content
-          val configObj = userObj["Configuration"]?.jsonObject
-          val audioLang = configObj?.get("AudioLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-          val subLang = configObj?.get("SubtitleLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+          val request =
+            Request
+              .Builder()
+              .url(endpoint)
+              .addHeader("X-Emby-Authorization", authHeader())
+              .addHeader("Content-Type", "application/json")
+              .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+              .build()
 
-          JellyfinAuthResult(
-            accessToken = accessToken,
-            userId = userId,
-            username = uname,
-            serverId = serverId,
-            audioLanguage = audioLang,
-            subtitleLanguage = subLang,
-          )
+          val result =
+            httpClient.newCall(request).execute().use { response ->
+              if (!response.isSuccessful) {
+                throw IOException("Authentication failed: HTTP ${response.code} ${response.message}")
+              }
+              val bodyStr = response.body.string()
+              val root = json.parseToJsonElement(bodyStr).jsonObject
+              val accessToken = root["AccessToken"]?.jsonPrimitive?.content ?: throw IOException("Missing AccessToken in response")
+              val userObj = root["User"]?.jsonObject ?: throw IOException("Missing User object in response")
+              val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id in response")
+              val uname = userObj["Name"]?.jsonPrimitive?.content ?: username
+              val serverId = root["ServerId"]?.jsonPrimitive?.content
+              val configObj = userObj["Configuration"]?.jsonObject
+              val audioLang = configObj?.get("AudioLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+              val subLang = configObj?.get("SubtitleLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+
+              JellyfinAuthResult(
+                accessToken = accessToken,
+                userId = userId,
+                username = uname,
+                serverId = serverId,
+                audioLanguage = audioLang,
+                subtitleLanguage = subLang,
+                normalizedServerUrl = candidate,
+              )
+            }
+          return@withContext Result.success(result)
+        } catch (e: Throwable) {
+          lastError = e
         }
       }
+      Result.failure(lastError)
     }
 
   suspend fun validateToken(
@@ -154,41 +174,51 @@ class JellyfinClient(
     token: String,
   ): Result<JellyfinUser> =
     withContext(Dispatchers.IO) {
-      runCatching {
-        val base = normalizeUrl(serverUrl)
-        val endpoint = "$base/Users/Me"
-        val request =
-          Request
-            .Builder()
-            .url(endpoint)
-            .addHeader("X-Emby-Authorization", authHeader(token))
-            .addHeader("X-Emby-Token", token)
-            .get()
-            .build()
+      val candidates = normalizeUrlCandidates(serverUrl)
+      var lastError: Throwable = IOException("No valid URL candidate for $serverUrl")
 
-        httpClient.newCall(request).execute().use { response ->
-          if (!response.isSuccessful) {
-            throw IOException("Token validation failed: HTTP ${response.code} ${response.message}")
-          }
-          val bodyStr = response.body.string()
-          val userObj = json.parseToJsonElement(bodyStr).jsonObject
-          val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id")
-          val uname = userObj["Name"]?.jsonPrimitive?.content ?: "User"
-          val serverId = userObj["ServerId"]?.jsonPrimitive?.content
+      for (candidate in candidates) {
+        try {
+          val endpoint = "$candidate/Users/Me"
+          val request =
+            Request
+              .Builder()
+              .url(endpoint)
+              .addHeader("X-Emby-Authorization", authHeader(token))
+              .addHeader("X-Emby-Token", token)
+              .get()
+              .build()
 
-          val configObj = userObj["Configuration"]?.jsonObject
-          val audioLang = configObj?.get("AudioLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-          val subLang = configObj?.get("SubtitleLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+          val result =
+            httpClient.newCall(request).execute().use { response ->
+              if (!response.isSuccessful) {
+                throw IOException("Token validation failed: HTTP ${response.code} ${response.message}")
+              }
+              val bodyStr = response.body.string()
+              val userObj = json.parseToJsonElement(bodyStr).jsonObject
+              val userId = userObj["Id"]?.jsonPrimitive?.content ?: throw IOException("Missing User.Id")
+              val uname = userObj["Name"]?.jsonPrimitive?.content ?: "User"
+              val serverId = userObj["ServerId"]?.jsonPrimitive?.content
 
-          JellyfinUser(
-            id = userId,
-            name = uname,
-            serverId = serverId,
-            audioLanguage = audioLang,
-            subtitleLanguage = subLang,
-          )
+              val configObj = userObj["Configuration"]?.jsonObject
+              val audioLang = configObj?.get("AudioLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+              val subLang = configObj?.get("SubtitleLanguagePreference")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+
+              JellyfinUser(
+                id = userId,
+                name = uname,
+                serverId = serverId,
+                audioLanguage = audioLang,
+                subtitleLanguage = subLang,
+                normalizedServerUrl = candidate,
+              )
+            }
+          return@withContext Result.success(result)
+        } catch (e: Throwable) {
+          lastError = e
         }
       }
+      Result.failure(lastError)
     }
 
   suspend fun getUserLibraries(

--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -283,6 +283,36 @@ class JellyfinClient(
       }
     }
 
+  suspend fun getItem(
+    serverUrl: String,
+    userId: String,
+    itemId: String,
+    token: String,
+  ): Result<JellyfinItem> =
+    withContext(Dispatchers.IO) {
+      runCatching {
+        val base = normalizeUrl(serverUrl)
+        val endpoint = "$base/Users/$userId/Items/$itemId"
+        val request =
+          Request
+            .Builder()
+            .url(endpoint)
+            .addHeader("X-Emby-Authorization", authHeader(token))
+            .addHeader("X-Emby-Token", token)
+            .get()
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+          if (!response.isSuccessful) {
+            throw IOException("Failed to load item: HTTP ${response.code}")
+          }
+          val bodyStr = response.body.string()
+          val root = json.parseToJsonElement(bodyStr).jsonObject
+          parseItem(root)
+        }
+      }
+    }
+
   suspend fun getItems(
     serverUrl: String,
     userId: String,

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/jellyfin/JellyfinModels.kt
@@ -119,6 +119,7 @@ data class JellyfinAuthResult(
   val serverId: String? = null,
   val audioLanguage: String? = null,
   val subtitleLanguage: String? = null,
+  val normalizedServerUrl: String = "",
 )
 
 @Serializable
@@ -128,4 +129,5 @@ data class JellyfinUser(
   val serverId: String? = null,
   val audioLanguage: String? = null,
   val subtitleLanguage: String? = null,
+  val normalizedServerUrl: String = "",
 )

--- a/app/src/main/java/app/gyrolet/mpvrx/repository/JellyfinRepository.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/repository/JellyfinRepository.kt
@@ -61,6 +61,12 @@ class JellyfinRepository(
   ): Result<List<JellyfinItem>> =
     client.getResumeItems(server.serverUrl, server.userId, server.accessToken, limit)
 
+  suspend fun getItem(
+    server: JellyfinServer,
+    itemId: String,
+  ): Result<JellyfinItem> =
+    client.getItem(server.serverUrl, server.userId, itemId, server.accessToken)
+
   suspend fun getItems(
     server: JellyfinServer,
     parentId: String? = null,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/AddJellyfinServerDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/AddJellyfinServerDialog.kt
@@ -96,7 +96,7 @@ fun AddJellyfinServerDialog(
           value = serverUrl,
           onValueChange = { serverUrl = it },
           label = { Text("Server URL") },
-          placeholder = { Text("http://192.168.1.100:8096") },
+          placeholder = { Text("jellyfin.example.com or 192.168.1.100:8096") },
           singleLine = true,
           modifier = Modifier.fillMaxWidth(),
           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/AddJellyfinServerDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/AddJellyfinServerDialog.kt
@@ -9,30 +9,48 @@
 
 package app.gyrolet.mpvrx.ui.browser.jellyfin
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,8 +60,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.gyrolet.mpvrx.domain.jellyfin.JellyfinAuthMode
@@ -51,6 +71,7 @@ import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddJellyfinServerDialog(
   isOpen: Boolean,
@@ -61,11 +82,14 @@ fun AddJellyfinServerDialog(
 ) {
   if (!isOpen) return
 
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
   var serverUrl by remember { mutableStateOf("") }
   var serverName by remember { mutableStateOf("") }
   var authMode by remember { mutableStateOf(JellyfinAuthMode.CREDENTIALS) }
   var username by remember { mutableStateOf("") }
   var password by remember { mutableStateOf("") }
+  var isPasswordVisible by remember { mutableStateOf(false) }
   var token by remember { mutableStateOf("") }
 
   val canConnect =
@@ -75,131 +99,315 @@ fun AddJellyfinServerDialog(
         JellyfinAuthMode.TOKEN -> token.isNotBlank()
       }
 
-  AlertDialog(
+  val submitAction = {
+    if (canConnect && !isLoading) {
+      onConnect(serverUrl, serverName, authMode, username, password, token)
+    }
+  }
+
+  ModalBottomSheet(
     onDismissRequest = { if (!isLoading) onDismiss() },
-    title = {
-      Text(
-        text = "Add Jellyfin Server",
-        style = MaterialTheme.typography.headlineSmall,
-        fontWeight = FontWeight.Bold,
+    sheetState = sheetState,
+    shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    dragHandle = { BottomSheetDefaults.DragHandle() },
+  ) {
+    Column(
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .verticalScroll(rememberScrollState())
+          .padding(horizontal = 24.dp)
+          .navigationBarsPadding(),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      // Header
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = "Add Jellyfin Server",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+          )
+          Text(
+            text = "Enter your server address and account details",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        IconButton(
+          onClick = { if (!isLoading) onDismiss() },
+          enabled = !isLoading,
+        ) {
+          Icon(
+            imageVector = Icons.RoundedFilled.Close,
+            contentDescription = "Close",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+
+      // Server URL Input
+      OutlinedTextField(
+        value = serverUrl,
+        onValueChange = { serverUrl = it },
+        label = { Text("Server Address") },
+        placeholder = { Text("jellyfin.example.com or 192.168.1.100:8096") },
+        leadingIcon = {
+          Icon(
+            imageVector = Icons.RoundedFilled.BringYourOwnIp,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+          )
+        },
+        trailingIcon = {
+          if (serverUrl.isNotEmpty()) {
+            IconButton(onClick = { serverUrl = "" }) {
+              Icon(
+                imageVector = Icons.RoundedFilled.Close,
+                contentDescription = "Clear",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+          }
+        },
+        supportingText = { Text("HTTPS will be tried first automatically") },
+        singleLine = true,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier.fillMaxWidth(),
+        keyboardOptions =
+          KeyboardOptions(
+            keyboardType = KeyboardType.Uri,
+            imeAction = ImeAction.Next,
+          ),
       )
-    },
-    text = {
-      Column(
+
+      // Display Name Input
+      OutlinedTextField(
+        value = serverName,
+        onValueChange = { serverName = it },
+        label = { Text("Display Name (Optional)") },
+        placeholder = { Text("Home Jellyfin") },
+        leadingIcon = {
+          Icon(
+            imageVector = Icons.RoundedFilled.Edit,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        },
+        singleLine = true,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier.fillMaxWidth(),
+        keyboardOptions =
+          KeyboardOptions(
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Next,
+          ),
+      )
+
+      // Authentication Method Selector (M3 SingleChoiceSegmentedButtonRow)
+      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+          text = "Authentication Method",
+          style = MaterialTheme.typography.labelLarge,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SingleChoiceSegmentedButtonRow(
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          SegmentedButton(
+            selected = authMode == JellyfinAuthMode.CREDENTIALS,
+            onClick = { authMode = JellyfinAuthMode.CREDENTIALS },
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+            icon = {
+              Icon(
+                imageVector = Icons.RoundedFilled.Person,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+              )
+            },
+          ) {
+            Text("Credentials")
+          }
+          SegmentedButton(
+            selected = authMode == JellyfinAuthMode.TOKEN,
+            onClick = { authMode = JellyfinAuthMode.TOKEN },
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+            icon = {
+              Icon(
+                imageVector = Icons.RoundedFilled.Security,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+              )
+            },
+          ) {
+            Text("API Token")
+          }
+        }
+      }
+
+      // Conditional Auth Fields
+      if (authMode == JellyfinAuthMode.CREDENTIALS) {
+        OutlinedTextField(
+          value = username,
+          onValueChange = { username = it },
+          label = { Text("Username") },
+          leadingIcon = {
+            Icon(
+              imageVector = Icons.RoundedFilled.Person,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          },
+          singleLine = true,
+          shape = RoundedCornerShape(16.dp),
+          modifier = Modifier.fillMaxWidth(),
+          keyboardOptions =
+            KeyboardOptions(
+              keyboardType = KeyboardType.Text,
+              imeAction = ImeAction.Next,
+            ),
+        )
+
+        OutlinedTextField(
+          value = password,
+          onValueChange = { password = it },
+          label = { Text("Password") },
+          leadingIcon = {
+            Icon(
+              imageVector = Icons.RoundedFilled.Lock,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          },
+          singleLine = true,
+          shape = RoundedCornerShape(16.dp),
+          visualTransformation = if (isPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+          keyboardOptions =
+            KeyboardOptions(
+              keyboardType = if (isPasswordVisible) KeyboardType.Text else KeyboardType.Password,
+              imeAction = ImeAction.Done,
+            ),
+          keyboardActions = KeyboardActions(onDone = { submitAction() }),
+          trailingIcon = {
+            IconButton(onClick = { isPasswordVisible = !isPasswordVisible }) {
+              Icon(
+                imageVector = if (isPasswordVisible) Icons.RoundedFilled.VisibilityOff else Icons.RoundedFilled.Visibility,
+                contentDescription = if (isPasswordVisible) "Hide password" else "Show password",
+              )
+            }
+          },
+          modifier = Modifier.fillMaxWidth(),
+        )
+      } else {
+        OutlinedTextField(
+          value = token,
+          onValueChange = { token = it },
+          label = { Text("Access Token / API Key") },
+          placeholder = { Text("Paste token generated in Jellyfin Dashboard") },
+          leadingIcon = {
+            Icon(
+              imageVector = Icons.RoundedFilled.Security,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          },
+          supportingText = { Text("Dashboard -> API Keys") },
+          singleLine = true,
+          shape = RoundedCornerShape(16.dp),
+          modifier = Modifier.fillMaxWidth(),
+          keyboardOptions =
+            KeyboardOptions(
+              keyboardType = KeyboardType.Password,
+              imeAction = ImeAction.Done,
+            ),
+          keyboardActions = KeyboardActions(onDone = { submitAction() }),
+        )
+      }
+
+      // Animated Error Card
+      AnimatedVisibility(
+        visible = !errorMessage.isNullOrBlank(),
+        enter = fadeIn() + expandVertically(),
+        exit = fadeOut() + shrinkVertically(),
+      ) {
+        Card(
+          shape = RoundedCornerShape(14.dp),
+          colors =
+            CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.errorContainer,
+            ),
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+          ) {
+            Icon(
+              imageVector = Icons.RoundedFilled.Warning,
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onErrorContainer,
+              modifier = Modifier.size(22.dp),
+            )
+            Text(
+              text = errorMessage ?: "",
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onErrorContainer,
+              modifier = Modifier.weight(1f),
+            )
+          }
+        }
+      }
+
+      // Action Buttons
+      Button(
+        onClick = submitAction,
+        enabled = canConnect && !isLoading,
+        shape = RoundedCornerShape(16.dp),
         modifier =
           Modifier
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-      ) {
-        OutlinedTextField(
-          value = serverUrl,
-          onValueChange = { serverUrl = it },
-          label = { Text("Server URL") },
-          placeholder = { Text("jellyfin.example.com or 192.168.1.100:8096") },
-          singleLine = true,
-          modifier = Modifier.fillMaxWidth(),
-          keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-        )
-
-        OutlinedTextField(
-          value = serverName,
-          onValueChange = { serverName = it },
-          label = { Text("Display Name (Optional)") },
-          placeholder = { Text("Home Jellyfin") },
-          singleLine = true,
-          modifier = Modifier.fillMaxWidth(),
-        )
-
-        Text(
-          text = "Authentication Method",
-          style = MaterialTheme.typography.bodyMedium,
-          fontWeight = FontWeight.SemiBold,
-        )
-
-        Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-          FilterChip(
-            selected = authMode == JellyfinAuthMode.CREDENTIALS,
-            onClick = { authMode = JellyfinAuthMode.CREDENTIALS },
-            label = { Text("Username & Password") },
-          )
-          FilterChip(
-            selected = authMode == JellyfinAuthMode.TOKEN,
-            onClick = { authMode = JellyfinAuthMode.TOKEN },
-            label = { Text("API Token") },
-          )
-        }
-
-        if (authMode == JellyfinAuthMode.CREDENTIALS) {
-          OutlinedTextField(
-            value = username,
-            onValueChange = { username = it },
-            label = { Text("Username") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-          )
-
-          OutlinedTextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Password") },
-            singleLine = true,
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            modifier = Modifier.fillMaxWidth(),
-          )
-        } else {
-          OutlinedTextField(
-            value = token,
-            onValueChange = { token = it },
-            label = { Text("Access Token / API Key") },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
-
-        if (!errorMessage.isNullOrBlank()) {
-          Spacer(modifier = Modifier.height(4.dp))
-          Text(
-            text = errorMessage,
-            color = MaterialTheme.colorScheme.error,
-            style = MaterialTheme.typography.bodySmall,
-          )
-        }
-      }
-    },
-    confirmButton = {
-      Button(
-        onClick = {
-          onConnect(serverUrl, serverName, authMode, username, password, token)
-        },
-        enabled = canConnect && !isLoading,
+            .height(52.dp),
       ) {
         if (isLoading) {
           CircularProgressIndicator(
-            modifier = Modifier.size(16.dp),
-            strokeWidth = 2.dp,
+            modifier = Modifier.size(20.dp),
+            strokeWidth = 2.5.dp,
             color = MaterialTheme.colorScheme.onPrimary,
           )
+          Spacer(modifier = Modifier.width(10.dp))
+          Text(
+            text = "Connecting...",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+          )
+        } else {
+          Icon(
+            imageVector = Icons.RoundedFilled.Link,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+          )
           Spacer(modifier = Modifier.width(8.dp))
+          Text(
+            text = "Connect Server",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+          )
         }
-        Text("Connect")
       }
-    },
-    dismissButton = {
-      TextButton(
-        onClick = onDismiss,
-        enabled = !isLoading,
-      ) {
-        Text("Cancel")
-      }
-    },
-  )
+
+      Spacer(modifier = Modifier.height(12.dp))
+    }
+  }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ManageJellyfinServersDialog(
   isOpen: Boolean,
@@ -212,34 +420,88 @@ fun ManageJellyfinServersDialog(
 ) {
   if (!isOpen) return
 
-  AlertDialog(
+  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+  ModalBottomSheet(
     onDismissRequest = onDismiss,
-    title = {
-      Text(
-        text = "Jellyfin Servers",
-        style = MaterialTheme.typography.headlineSmall,
-        fontWeight = FontWeight.Bold,
-      )
-    },
-    text = {
-      Column(
-        modifier =
-          Modifier
-            .fillMaxWidth()
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+    sheetState = sheetState,
+    shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    dragHandle = { BottomSheetDefaults.DragHandle() },
+  ) {
+    Column(
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .verticalScroll(rememberScrollState())
+          .padding(horizontal = 24.dp)
+          .navigationBarsPadding(),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      // Header
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
       ) {
-        if (servers.isEmpty()) {
+        Column(modifier = Modifier.weight(1f)) {
           Text(
-            text = "No servers connected yet.",
+            text = "Jellyfin Servers",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+          )
+          Text(
+            text = "${servers.size} configured server${if (servers.size == 1) "" else "s"}",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
           )
-        } else {
+        }
+        TextButton(onClick = onDismiss) {
+          Text("Done")
+        }
+      }
+
+      if (servers.isEmpty()) {
+        Card(
+          shape = RoundedCornerShape(16.dp),
+          colors =
+            CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ),
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          Box(
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+            contentAlignment = Alignment.Center,
+          ) {
+            Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              Icon(
+                imageVector = Icons.RoundedFilled.BringYourOwnIp,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(40.dp),
+              )
+              Text(
+                text = "No servers connected yet",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+          }
+        }
+      } else {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
           servers.forEach { server ->
             val isSelected = server.id == activeServer?.id
             Surface(
-              shape = RoundedCornerShape(12.dp),
+              shape = RoundedCornerShape(16.dp),
               color =
                 if (isSelected) {
                   MaterialTheme.colorScheme.primaryContainer
@@ -249,42 +511,78 @@ fun ManageJellyfinServersDialog(
               modifier =
                 Modifier
                   .fillMaxWidth()
-                  .clip(RoundedCornerShape(12.dp))
+                  .clip(RoundedCornerShape(16.dp))
                   .clickable {
                     onSelectServer(server)
                     onDismiss()
                   },
             ) {
               Row(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
               ) {
-                Icon(
-                  imageVector = Icons.RoundedFilled.BringYourOwnIp,
-                  contentDescription = null,
-                  tint =
+                Surface(
+                  shape = CircleShape,
+                  color =
                     if (isSelected) {
                       MaterialTheme.colorScheme.primary
                     } else {
-                      MaterialTheme.colorScheme.onSurfaceVariant
+                      MaterialTheme.colorScheme.surfaceContainerHighest
                     },
-                  modifier = Modifier.size(24.dp),
-                )
+                  modifier = Modifier.size(40.dp),
+                ) {
+                  Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                  ) {
+                    Icon(
+                      imageVector = if (isSelected) Icons.RoundedFilled.Check else Icons.RoundedFilled.BringYourOwnIp,
+                      contentDescription = null,
+                      tint =
+                        if (isSelected) {
+                          MaterialTheme.colorScheme.onPrimary
+                        } else {
+                          MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                      modifier = Modifier.size(20.dp),
+                    )
+                  }
+                }
+
                 Column(modifier = Modifier.weight(1f)) {
-                  Text(
-                    text = server.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
-                    color =
-                      if (isSelected) {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                      } else {
-                        MaterialTheme.colorScheme.onSurface
-                      },
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                  )
+                  Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                  ) {
+                    Text(
+                      text = server.name,
+                      style = MaterialTheme.typography.titleMedium,
+                      fontWeight = if (isSelected) FontWeight.Bold else FontWeight.SemiBold,
+                      color =
+                        if (isSelected) {
+                          MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                          MaterialTheme.colorScheme.onSurface
+                        },
+                      maxLines = 1,
+                      overflow = TextOverflow.Ellipsis,
+                    )
+                    if (isSelected) {
+                      Surface(
+                        shape = RoundedCornerShape(6.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(2.dp),
+                      ) {
+                        Text(
+                          text = "Active",
+                          style = MaterialTheme.typography.labelSmall,
+                          color = MaterialTheme.colorScheme.onPrimary,
+                          modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        )
+                      }
+                    }
+                  }
                   Text(
                     text = server.serverUrl,
                     style = MaterialTheme.typography.bodySmall,
@@ -298,46 +596,48 @@ fun ManageJellyfinServersDialog(
                     overflow = TextOverflow.Ellipsis,
                   )
                 }
+
                 IconButton(
                   onClick = { onDeleteServer(server) },
-                  modifier = Modifier.size(32.dp),
+                  modifier = Modifier.size(36.dp),
                 ) {
                   Icon(
                     imageVector = Icons.RoundedFilled.Delete,
                     contentDescription = "Remove Server",
                     tint = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.size(18.dp),
+                    modifier = Modifier.size(20.dp),
                   )
                 }
               }
             }
           }
         }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Button(
-          onClick = {
-            onDismiss()
-            onAddServerClick()
-          },
-          modifier = Modifier.fillMaxWidth(),
-        ) {
-          Icon(
-            imageVector = Icons.RoundedFilled.Add,
-            contentDescription = null,
-            modifier = Modifier.size(18.dp),
-          )
-          Spacer(modifier = Modifier.width(8.dp))
-          Text("Add New Server")
-        }
       }
-    },
-    confirmButton = {
-      TextButton(onClick = onDismiss) {
-        Text("Done")
+
+      FilledTonalButton(
+        onClick = {
+          onDismiss()
+          onAddServerClick()
+        },
+        shape = RoundedCornerShape(16.dp),
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+      ) {
+        Icon(
+          imageVector = Icons.RoundedFilled.Add,
+          contentDescription = null,
+          modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+          text = "Add Another Server",
+          style = MaterialTheme.typography.labelLarge,
+        )
       }
-    },
-  )
+
+      Spacer(modifier = Modifier.height(12.dp))
+    }
+  }
 }
-

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -142,13 +143,15 @@ fun JellyfinPosterCard(
   isSelected: Boolean = false,
 ) {
   val imageUrl =
-    JellyfinClient.getImageUrl(
-      serverUrl = server.serverUrl,
-      itemId = item.id,
-      imageTag = item.primaryImageTag,
-      maxWidth = 400,
-      token = server.accessToken,
-    )
+    remember(server.serverUrl, item.id, item.primaryImageTag, server.accessToken) {
+      JellyfinClient.getImageUrl(
+        serverUrl = server.serverUrl,
+        itemId = item.id,
+        imageTag = item.primaryImageTag,
+        maxWidth = 400,
+        token = server.accessToken,
+      )
+    }
 
   val containerColor =
     if (isSelected) {
@@ -292,13 +295,15 @@ fun JellyfinEpisodeCard(
   isSelected: Boolean = false,
 ) {
   val imageUrl =
-    JellyfinClient.getImageUrl(
-      serverUrl = server.serverUrl,
-      itemId = item.id,
-      imageTag = item.primaryImageTag,
-      maxWidth = 300,
-      token = server.accessToken,
-    )
+    remember(server.serverUrl, item.id, item.primaryImageTag, server.accessToken) {
+      JellyfinClient.getImageUrl(
+        serverUrl = server.serverUrl,
+        itemId = item.id,
+        imageTag = item.primaryImageTag,
+        maxWidth = 300,
+        token = server.accessToken,
+      )
+    }
 
   val containerColor =
     if (isSelected) {
@@ -454,13 +459,15 @@ fun JellyfinListItemCard(
   isSelected: Boolean = false,
 ) {
   val imageUrl =
-    JellyfinClient.getImageUrl(
-      serverUrl = server.serverUrl,
-      itemId = item.id,
-      imageTag = item.primaryImageTag,
-      maxWidth = 200,
-      token = server.accessToken,
-    )
+    remember(server.serverUrl, item.id, item.primaryImageTag, server.accessToken) {
+      JellyfinClient.getImageUrl(
+        serverUrl = server.serverUrl,
+        itemId = item.id,
+        imageTag = item.primaryImageTag,
+        maxWidth = 200,
+        token = server.accessToken,
+      )
+    }
 
   val containerColor =
     if (isSelected) {
@@ -636,22 +643,24 @@ fun JellyfinResumeCard(
   isInSelectionMode: Boolean = false,
 ) {
   val imageUrl =
-    if (!item.backdropImageTag.isNullOrBlank()) {
-      JellyfinClient.getBackdropUrl(
-        serverUrl = server.serverUrl,
-        itemId = item.id,
-        imageTag = item.backdropImageTag,
-        maxWidth = 500,
-        token = server.accessToken,
-      )
-    } else {
-      JellyfinClient.getImageUrl(
-        serverUrl = server.serverUrl,
-        itemId = item.id,
-        imageTag = item.primaryImageTag,
-        maxWidth = 400,
-        token = server.accessToken,
-      )
+    remember(server.serverUrl, item.id, item.backdropImageTag, item.primaryImageTag, server.accessToken) {
+      if (!item.backdropImageTag.isNullOrBlank()) {
+        JellyfinClient.getBackdropUrl(
+          serverUrl = server.serverUrl,
+          itemId = item.id,
+          imageTag = item.backdropImageTag,
+          maxWidth = 500,
+          token = server.accessToken,
+        )
+      } else {
+        JellyfinClient.getImageUrl(
+          serverUrl = server.serverUrl,
+          itemId = item.id,
+          imageTag = item.primaryImageTag,
+          maxWidth = 400,
+          token = server.accessToken,
+        )
+      }
     }
 
   val containerColor =

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
@@ -196,9 +196,8 @@ fun JellyfinContent(
               query = uiState.searchQuery,
               onQueryChange = {
                 viewModel.onSearchQueryChanged(it)
-                viewModel.performSearch(it)
               },
-              onSearch = { viewModel.performSearch(uiState.searchQuery) },
+              onSearch = { viewModel.performSearch(uiState.searchQuery, debounceMs = 0L) },
               expanded = false,
               onExpandedChange = { },
               placeholder = { Text(stringResource(R.string.settings_search_title)) },
@@ -327,7 +326,7 @@ fun JellyfinContent(
     ) {
       PullRefreshBox(
         isRefreshing = isRefreshing,
-        onRefresh = { viewModel.refresh() },
+        onRefresh = { viewModel.refreshSuspend() },
         modifier = Modifier.fillMaxSize(),
       ) {
         Box(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -448,13 +448,12 @@ class JellyfinViewModel(
   ) {
     viewModelScope.launch {
       _uiState.update { it.copy(isAuthenticating = true, authError = null) }
-      val cleanUrl = JellyfinClient.normalizeUrl(serverUrl)
 
       try {
         val serverToSave =
           if (authMode == JellyfinAuthMode.CREDENTIALS) {
             val authResult =
-              jellyfinRepository.authenticate(cleanUrl, username, password).getOrThrow()
+              jellyfinRepository.authenticate(serverUrl, username, password).getOrThrow()
 
             if (subtitlesPreferences.preferredLanguages.get().isBlank() && !authResult.subtitleLanguage.isNullOrBlank()) {
               subtitlesPreferences.preferredLanguages.set(authResult.subtitleLanguage)
@@ -463,16 +462,18 @@ class JellyfinViewModel(
               audioPreferences.preferredLanguages.set(authResult.audioLanguage)
             }
 
+            val effectiveUrl = authResult.normalizedServerUrl.ifBlank { JellyfinClient.normalizeUrl(serverUrl) }
+
             JellyfinServer(
               name = serverName.ifBlank { "Jellyfin (${authResult.username})" },
-              serverUrl = cleanUrl,
+              serverUrl = effectiveUrl,
               userId = authResult.userId,
               username = authResult.username,
               accessToken = authResult.accessToken,
               lastConnected = System.currentTimeMillis(),
             )
           } else {
-            val user = jellyfinRepository.validateToken(cleanUrl, token).getOrThrow()
+            val user = jellyfinRepository.validateToken(serverUrl, token).getOrThrow()
 
             if (subtitlesPreferences.preferredLanguages.get().isBlank() && !user.subtitleLanguage.isNullOrBlank()) {
               subtitlesPreferences.preferredLanguages.set(user.subtitleLanguage)
@@ -481,9 +482,11 @@ class JellyfinViewModel(
               audioPreferences.preferredLanguages.set(user.audioLanguage)
             }
 
+            val effectiveUrl = user.normalizedServerUrl.ifBlank { JellyfinClient.normalizeUrl(serverUrl) }
+
             JellyfinServer(
               name = serverName.ifBlank { "Jellyfin (${user.name})" },
-              serverUrl = cleanUrl,
+              serverUrl = effectiveUrl,
               userId = user.id,
               username = user.name,
               accessToken = token.trim(),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -42,6 +42,8 @@ import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+import app.gyrolet.mpvrx.ui.player.PlaybackIdentity
+
 data class JellyfinBreadcrumb(
   val id: String,
   val title: String,
@@ -502,6 +504,7 @@ class JellyfinViewModel(
   ) {
     val server = _uiState.value.activeServer ?: return
     val streamUrl = jellyfinRepository.getStreamUrl(server, item)
+    val mediaIdentifier = PlaybackIdentity.forUri(streamUrl)
     val posterUrl = jellyfinRepository.getImageUrl(server, item)
     val backdropUrl = jellyfinRepository.getBackdropUrl(server, item)
 
@@ -513,7 +516,10 @@ class JellyfinViewModel(
 
     viewModelScope.launch(Dispatchers.IO) {
       if (startFromBeginning) {
-        runCatching { playbackStateRepository.deleteByTitle(streamUrl) }
+        runCatching {
+          playbackStateRepository.deleteByTitle(mediaIdentifier)
+          playbackStateRepository.deleteByTitle(streamUrl)
+        }
       }
 
       // Concurrently run DB seed and external subtitle fetching
@@ -522,9 +528,13 @@ class JellyfinViewModel(
           if (!startFromBeginning && item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
             val positionSeconds = (item.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
             runCatching {
-              playbackStateRepository.upsert(
-                PlaybackStateEntity(
-                  mediaTitle = streamUrl,
+              val existing = playbackStateRepository.getVideoDataByTitle(mediaIdentifier)
+              val stateToSave =
+                existing?.copy(
+                  lastPosition = positionSeconds,
+                  timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+                ) ?: PlaybackStateEntity(
+                  mediaTitle = mediaIdentifier,
                   lastPosition = positionSeconds,
                   playbackSpeed = 1.0,
                   videoZoom = 0f,
@@ -535,8 +545,8 @@ class JellyfinViewModel(
                   aid = -1,
                   audioDelay = 0,
                   timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
-                ),
-              )
+                )
+              playbackStateRepository.upsert(stateToSave)
             }
           }
         }
@@ -622,6 +632,7 @@ class JellyfinViewModel(
     if (playable.isEmpty()) return
     val firstItem = playable.first()
     val streamUrl = jellyfinRepository.getStreamUrl(server, firstItem)
+    val mediaIdentifier = PlaybackIdentity.forUri(streamUrl)
     val posterUrl = jellyfinRepository.getImageUrl(server, firstItem)
     val backdropUrl = jellyfinRepository.getBackdropUrl(server, firstItem)
 
@@ -651,19 +662,57 @@ class JellyfinViewModel(
         "X-Emby-Authorization" to JellyfinClient.authHeader(server.accessToken),
       )
 
-    MediaUtils.playFile(
-      source = streamUrl,
-      context = context,
-      launchSource = "jellyfin_stream",
-      title = itemTitle,
-      headers = headers,
-      mediaDescription = firstItem.overview,
-      posterUrl = posterUrl,
-      backdropUrl = backdropUrl,
-      playlist = playlistUris,
-      playlistIndex = 0,
-      playlistTitles = playlistTitles,
-    )
+    viewModelScope.launch(Dispatchers.IO) {
+      if (firstItem.playbackPositionTicks != null && firstItem.playbackPositionTicks > 0) {
+        val positionSeconds = (firstItem.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
+        runCatching {
+          val existing = playbackStateRepository.getVideoDataByTitle(mediaIdentifier)
+          val stateToSave =
+            existing?.copy(
+              lastPosition = positionSeconds,
+              timeRemaining = (firstItem.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+            ) ?: PlaybackStateEntity(
+              mediaTitle = mediaIdentifier,
+              lastPosition = positionSeconds,
+              playbackSpeed = 1.0,
+              videoZoom = 0f,
+              sid = -1,
+              secondarySid = -1,
+              subDelay = 0,
+              subSpeed = 1.0,
+              aid = -1,
+              audioDelay = 0,
+              timeRemaining = (firstItem.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+            )
+          playbackStateRepository.upsert(stateToSave)
+        }
+      }
+
+      launch {
+        jellyfinRepository.reportPlaybackStart(
+          serverUrl = server.serverUrl,
+          token = server.accessToken,
+          itemId = firstItem.id,
+          positionTicks = firstItem.playbackPositionTicks ?: 0L,
+        )
+      }
+
+      withContext(Dispatchers.Main) {
+        MediaUtils.playFile(
+          source = streamUrl,
+          context = context,
+          launchSource = "jellyfin_stream",
+          title = itemTitle,
+          headers = headers,
+          mediaDescription = firstItem.overview,
+          posterUrl = posterUrl,
+          backdropUrl = backdropUrl,
+          playlist = playlistUris,
+          playlistIndex = 0,
+          playlistTitles = playlistTitles,
+        )
+      }
+    }
   }
 
   fun togglePlayed(item: JellyfinItem) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -31,7 +31,9 @@ import app.gyrolet.mpvrx.repository.JellyfinRepository
 import app.gyrolet.mpvrx.utils.media.MediaUtils
 import app.gyrolet.mpvrx.utils.media.PlaybackSubtitleTrack
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -79,6 +81,10 @@ class JellyfinViewModel(
   private val playbackStateRepository: PlaybackStateRepository by inject()
   private val subtitlesPreferences: SubtitlesPreferences by inject()
   private val audioPreferences: AudioPreferences by inject()
+
+  private var loadLibrariesJob: Job? = null
+  private var loadItemsJob: Job? = null
+  private var searchJob: Job? = null
 
   private val _uiState = MutableStateFlow(JellyfinUiState())
   val uiState: StateFlow<JellyfinUiState> = _uiState.asStateFlow()
@@ -129,18 +135,33 @@ class JellyfinViewModel(
     }
   }
 
-  fun loadLibraries(server: JellyfinServer) {
-    viewModelScope.launch {
-      _uiState.update { it.copy(isLoading = true, error = null) }
-      loadResumeItems(server)
-      val result = jellyfinRepository.getLibraries(server)
-      result
-        .onSuccess { libs ->
-          _uiState.update { it.copy(libraries = libs, isLoading = false, error = null) }
-        }.onFailure { err ->
-          _uiState.update { it.copy(isLoading = false, error = err.message ?: "Failed to load libraries") }
-        }
+  suspend fun refreshSuspend() {
+    val active = _uiState.value.activeServer ?: return
+    val currentCrumb = _uiState.value.breadcrumbs.lastOrNull()
+    if (currentCrumb == null) {
+      loadLibraries(active)
+      loadLibrariesJob?.join()
+    } else {
+      loadItems(active, currentCrumb.id, currentCrumb.type, resetPagination = true)
+      loadItemsJob?.join()
     }
+  }
+
+  fun loadLibraries(server: JellyfinServer) {
+    loadLibrariesJob?.cancel()
+    loadItemsJob?.cancel()
+    loadLibrariesJob =
+      viewModelScope.launch {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        loadResumeItems(server)
+        val result = jellyfinRepository.getLibraries(server)
+        result
+          .onSuccess { libs ->
+            _uiState.update { it.copy(libraries = libs, isLoading = false, error = null) }
+          }.onFailure { err ->
+            _uiState.update { it.copy(isLoading = false, error = err.message ?: "Failed to load libraries") }
+          }
+      }
   }
 
   fun loadResumeItems(server: JellyfinServer) {
@@ -242,115 +263,120 @@ class JellyfinViewModel(
     val startIndex = if (resetPagination) 0 else _uiState.value.startIndex
     val currentList = if (resetPagination) emptyList() else _uiState.value.currentItems
 
-    viewModelScope.launch {
-      if (resetPagination) {
-        _uiState.update {
-          it.copy(
-            isLoading = true,
-            currentItems = emptyList(),
-            startIndex = 0,
-            hasMore = false,
-            error = null,
-          )
-        }
-      } else {
-        _uiState.update { it.copy(isLoadingMore = true) }
-      }
-
-      val currentState = _uiState.value
-
-      when (parentType) {
-        "Series" -> {
-          val result = jellyfinRepository.getSeasons(server, parentId)
-          result
-            .onSuccess { items ->
-              _uiState.update {
-                it.copy(
-                  currentItems = items,
-                  totalRecordCount = items.size,
-                  hasMore = false,
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = null,
-                )
-              }
-            }.onFailure { err ->
-              _uiState.update {
-                it.copy(
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = err.message ?: "Failed to load seasons",
-                )
-              }
-            }
-        }
-
-        "Season" -> {
-          val seriesId = _uiState.value.breadcrumbs.dropLast(1).lastOrNull { it.type == "Series" }?.id ?: parentId
-          val result = jellyfinRepository.getEpisodes(server, seriesId, parentId)
-          result
-            .onSuccess { items ->
-              _uiState.update {
-                it.copy(
-                  currentItems = items,
-                  totalRecordCount = items.size,
-                  hasMore = false,
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = null,
-                )
-              }
-            }.onFailure { err ->
-              _uiState.update {
-                it.copy(
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = err.message ?: "Failed to load episodes",
-                )
-              }
-            }
-        }
-
-        else -> {
-          val result =
-            jellyfinRepository.getItems(
-              server = server,
-              parentId = parentId,
-              searchTerm = currentState.searchQuery.takeIf { it.isNotBlank() },
-              sortBy = currentState.sortBy,
-              sortOrder = currentState.sortOrder,
-              isPlayed = if (currentState.isUnplayedOnly) false else null,
-              startIndex = startIndex,
-              limit = 100,
-            )
-
-          result
-            .onSuccess { queryResult ->
-              val combined = currentList + queryResult.items
-              val hasMore = combined.size < queryResult.totalRecordCount
-              _uiState.update {
-                it.copy(
-                  currentItems = combined,
-                  totalRecordCount = queryResult.totalRecordCount,
-                  startIndex = combined.size,
-                  hasMore = hasMore,
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = null,
-                )
-              }
-            }.onFailure { err ->
-              _uiState.update {
-                it.copy(
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = err.message ?: "Failed to load items",
-                )
-              }
-            }
-        }
-      }
+    if (resetPagination) {
+      loadItemsJob?.cancel()
     }
+
+    loadItemsJob =
+      viewModelScope.launch {
+        if (resetPagination) {
+          _uiState.update {
+            it.copy(
+              isLoading = true,
+              currentItems = emptyList(),
+              startIndex = 0,
+              hasMore = false,
+              error = null,
+            )
+          }
+        } else {
+          _uiState.update { it.copy(isLoadingMore = true) }
+        }
+
+        val currentState = _uiState.value
+
+        when (parentType) {
+          "Series" -> {
+            val result = jellyfinRepository.getSeasons(server, parentId)
+            result
+              .onSuccess { items ->
+                _uiState.update {
+                  it.copy(
+                    currentItems = items.distinctBy { it.id },
+                    totalRecordCount = items.size,
+                    hasMore = false,
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = null,
+                  )
+                }
+              }.onFailure { err ->
+                _uiState.update {
+                  it.copy(
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = err.message ?: "Failed to load seasons",
+                  )
+                }
+              }
+          }
+
+          "Season" -> {
+            val seriesId = _uiState.value.breadcrumbs.dropLast(1).lastOrNull { it.type == "Series" }?.id ?: parentId
+            val result = jellyfinRepository.getEpisodes(server, seriesId, parentId)
+            result
+              .onSuccess { items ->
+                _uiState.update {
+                  it.copy(
+                    currentItems = items.distinctBy { it.id },
+                    totalRecordCount = items.size,
+                    hasMore = false,
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = null,
+                  )
+                }
+              }.onFailure { err ->
+                _uiState.update {
+                  it.copy(
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = err.message ?: "Failed to load episodes",
+                  )
+                }
+              }
+          }
+
+          else -> {
+            val result =
+              jellyfinRepository.getItems(
+                server = server,
+                parentId = parentId,
+                searchTerm = currentState.searchQuery.takeIf { it.isNotBlank() },
+                sortBy = currentState.sortBy,
+                sortOrder = currentState.sortOrder,
+                isPlayed = if (currentState.isUnplayedOnly) false else null,
+                startIndex = startIndex,
+                limit = 100,
+              )
+
+            result
+              .onSuccess { queryResult ->
+                val combined = (currentList + queryResult.items).distinctBy { it.id }
+                val hasMore = combined.size < queryResult.totalRecordCount
+                _uiState.update {
+                  it.copy(
+                    currentItems = combined,
+                    totalRecordCount = queryResult.totalRecordCount,
+                    startIndex = combined.size,
+                    hasMore = hasMore,
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = null,
+                  )
+                }
+              }.onFailure { err ->
+                _uiState.update {
+                  it.copy(
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = err.message ?: "Failed to load items",
+                  )
+                }
+              }
+          }
+        }
+      }
   }
 
   fun loadMoreItems() {
@@ -363,42 +389,52 @@ class JellyfinViewModel(
 
   fun onSearchQueryChanged(query: String) {
     _uiState.update { it.copy(searchQuery = query) }
+    performSearch(query, debounceMs = 300L)
   }
 
-  fun performSearch(query: String) {
+  fun performSearch(
+    query: String,
+    debounceMs: Long = 0L,
+  ) {
     val active = _uiState.value.activeServer ?: return
+    searchJob?.cancel()
     if (query.isBlank()) {
       refresh()
       return
     }
-    viewModelScope.launch {
-      _uiState.update { it.copy(isLoading = true, currentItems = emptyList(), startIndex = 0, error = null) }
-      val currentCrumb = _uiState.value.breadcrumbs.lastOrNull()
-      val result =
-        jellyfinRepository.getItems(
-          server = active,
-          parentId = currentCrumb?.id,
-          searchTerm = query,
-          sortBy = _uiState.value.sortBy,
-          sortOrder = _uiState.value.sortOrder,
-          startIndex = 0,
-          limit = 100,
-        )
-      result
-        .onSuccess { queryResult ->
-          _uiState.update {
-            it.copy(
-              currentItems = queryResult.items,
-              totalRecordCount = queryResult.totalRecordCount,
-              startIndex = queryResult.items.size,
-              hasMore = queryResult.items.size < queryResult.totalRecordCount,
-              isLoading = false,
-            )
-          }
-        }.onFailure { err ->
-          _uiState.update { it.copy(isLoading = false, error = err.message) }
+    searchJob =
+      viewModelScope.launch {
+        if (debounceMs > 0) {
+          delay(debounceMs)
         }
-    }
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        val currentCrumb = _uiState.value.breadcrumbs.lastOrNull()
+        val result =
+          jellyfinRepository.getItems(
+            server = active,
+            parentId = currentCrumb?.id,
+            searchTerm = query,
+            sortBy = _uiState.value.sortBy,
+            sortOrder = _uiState.value.sortOrder,
+            startIndex = 0,
+            limit = 100,
+          )
+        result
+          .onSuccess { queryResult ->
+            _uiState.update {
+              it.copy(
+                currentItems = queryResult.items.distinctBy { item -> item.id },
+                totalRecordCount = queryResult.totalRecordCount,
+                startIndex = queryResult.items.size,
+                hasMore = queryResult.items.size < queryResult.totalRecordCount,
+                isLoading = false,
+                error = null,
+              )
+            }
+          }.onFailure { err ->
+            _uiState.update { it.copy(isLoading = false, error = err.message) }
+          }
+      }
   }
 
   fun addServer(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -561,32 +561,12 @@ class JellyfinViewModel(
         }
       }
 
-      // Concurrently run DB seed and external subtitle fetching
-      val dbJob =
+      val freshItemDeferred =
         async {
-          if (!startFromBeginning && item.playbackPositionTicks != null && item.playbackPositionTicks > 0) {
-            val positionSeconds = (item.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
-            runCatching {
-              val existing = playbackStateRepository.getVideoDataByTitle(mediaIdentifier)
-              val stateToSave =
-                existing?.copy(
-                  lastPosition = positionSeconds,
-                  timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
-                ) ?: PlaybackStateEntity(
-                  mediaTitle = mediaIdentifier,
-                  lastPosition = positionSeconds,
-                  playbackSpeed = 1.0,
-                  videoZoom = 0f,
-                  sid = -1,
-                  secondarySid = -1,
-                  subDelay = 0,
-                  subSpeed = 1.0,
-                  aid = -1,
-                  audioDelay = 0,
-                  timeRemaining = (item.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
-                )
-              playbackStateRepository.upsert(stateToSave)
-            }
+          if (!startFromBeginning) {
+            jellyfinRepository.getItem(server, item.id).getOrNull()
+          } else {
+            null
           }
         }
 
@@ -597,17 +577,50 @@ class JellyfinViewModel(
             .getOrDefault(emptyList())
         }
 
+      val freshItem = freshItemDeferred.await() ?: item
+      val effectivePositionTicks =
+        if (!startFromBeginning) {
+          freshItem.playbackPositionTicks ?: item.playbackPositionTicks ?: 0L
+        } else {
+          0L
+        }
+      val positionSeconds = (effectivePositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
+
+      if (positionSeconds > 0) {
+        val durationSec = (freshItem.runTimeTicks ?: item.runTimeTicks ?: 0L) / JellyfinClient.TICKS_PER_SECOND
+        runCatching {
+          val existing = playbackStateRepository.getVideoDataByTitle(mediaIdentifier)
+          val stateToSave =
+            existing?.copy(
+              lastPosition = positionSeconds,
+              timeRemaining = (durationSec - positionSeconds).toInt().coerceAtLeast(0),
+            ) ?: PlaybackStateEntity(
+              mediaTitle = mediaIdentifier,
+              lastPosition = positionSeconds,
+              playbackSpeed = 1.0,
+              videoZoom = 0f,
+              sid = -1,
+              secondarySid = -1,
+              subDelay = 0,
+              subSpeed = 1.0,
+              aid = -1,
+              audioDelay = 0,
+              timeRemaining = (durationSec - positionSeconds).toInt().coerceAtLeast(0),
+            )
+          playbackStateRepository.upsert(stateToSave)
+        }
+      }
+
       // Fire scrobble start non-blocking in background
       launch {
         jellyfinRepository.reportPlaybackStart(
           serverUrl = server.serverUrl,
           token = server.accessToken,
           itemId = item.id,
-          positionTicks = if (startFromBeginning) 0L else (item.playbackPositionTicks ?: 0L),
+          positionTicks = effectivePositionTicks,
         )
       }
 
-      dbJob.await()
       val externalSubs = subsDeferred.await()
 
       // If playing an episode, extract surrounding episode playlist from current view
@@ -702,14 +715,18 @@ class JellyfinViewModel(
       )
 
     viewModelScope.launch(Dispatchers.IO) {
-      if (firstItem.playbackPositionTicks != null && firstItem.playbackPositionTicks > 0) {
-        val positionSeconds = (firstItem.playbackPositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
+      val freshItem = jellyfinRepository.getItem(server, firstItem.id).getOrNull() ?: firstItem
+      val effectivePositionTicks = freshItem.playbackPositionTicks ?: firstItem.playbackPositionTicks ?: 0L
+      val positionSeconds = (effectivePositionTicks / JellyfinClient.TICKS_PER_SECOND).toInt()
+
+      if (positionSeconds > 0) {
+        val durationSec = (freshItem.runTimeTicks ?: firstItem.runTimeTicks ?: 0L) / JellyfinClient.TICKS_PER_SECOND
         runCatching {
           val existing = playbackStateRepository.getVideoDataByTitle(mediaIdentifier)
           val stateToSave =
             existing?.copy(
               lastPosition = positionSeconds,
-              timeRemaining = (firstItem.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+              timeRemaining = (durationSec - positionSeconds).toInt().coerceAtLeast(0),
             ) ?: PlaybackStateEntity(
               mediaTitle = mediaIdentifier,
               lastPosition = positionSeconds,
@@ -721,7 +738,7 @@ class JellyfinViewModel(
               subSpeed = 1.0,
               aid = -1,
               audioDelay = 0,
-              timeRemaining = (firstItem.durationSeconds - positionSeconds).toInt().coerceAtLeast(0),
+              timeRemaining = (durationSec - positionSeconds).toInt().coerceAtLeast(0),
             )
           playbackStateRepository.upsert(stateToSave)
         }
@@ -732,7 +749,7 @@ class JellyfinViewModel(
           serverUrl = server.serverUrl,
           token = server.accessToken,
           itemId = firstItem.id,
-          positionTicks = firstItem.playbackPositionTicks ?: 0L,
+          positionTicks = effectivePositionTicks,
         )
       }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -3564,7 +3564,7 @@ class PlayerActivity :
 
     reportJellyfinStop()
     currentUri?.toString()?.let { url ->
-      jellyfinSessionReporter = JellyfinSessionReporter.create(url, lifecycleScope)
+      jellyfinSessionReporter = JellyfinSessionReporter.create(url, lifecycleScope, networkHttpClient)
       jellyfinSessionReporter?.reportPlaybackStart((viewModel.pos ?: 0).toLong() * 1000L)
       startJellyfinProgressLoop()
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -4014,6 +4014,15 @@ class PlayerActivity :
     jellyfinProgressJob?.cancel()
     jellyfinProgressJob =
       lifecycleScope.launch {
+        // Immediately report pause/resume state changes to Jellyfin dashboard
+        launch {
+          PlaybackSession.propBoolean["pause"]
+            .collect { pausedValue ->
+              val reporter = jellyfinSessionReporter ?: return@collect
+              val currentPosMs = (viewModel.pos ?: 0).toLong() * 1000L
+              reporter.reportPlaybackProgress(currentPosMs, pausedValue ?: false)
+            }
+        }
         while (isActive) {
           delay(10000) // Report progress every 10 seconds
           val reporter = jellyfinSessionReporter ?: continue

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/JellyfinSessionReporter.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/JellyfinSessionReporter.kt
@@ -42,18 +42,22 @@ class JellyfinSessionReporter(
       try {
         val uri = Uri.parse(url)
         val pathSegments = uri.pathSegments
-        val videosIndex = pathSegments.indexOf("Videos")
-        if (videosIndex == -1 || videosIndex + 1 >= pathSegments.size) {
+        val mediaIndex = pathSegments.indexOfFirst {
+          it.equals("Videos", ignoreCase = true) ||
+            it.equals("Audio", ignoreCase = true) ||
+            it.equals("Items", ignoreCase = true)
+        }
+        if (mediaIndex == -1 || mediaIndex + 1 >= pathSegments.size) {
           return null
         }
-        val itemId = pathSegments[videosIndex + 1]
+        val itemId = pathSegments[mediaIndex + 1]
         val apiKey = uri.getQueryParameter("api_key") ?: uri.getQueryParameter("ApiKey") ?: return null
         val playSessionId = uri.getQueryParameter("playSessionId") ?: uri.getQueryParameter("PlaySessionId")
         val mediaSourceId = uri.getQueryParameter("mediaSourceId") ?: uri.getQueryParameter("MediaSourceId")
 
         val scheme = uri.scheme ?: "http"
         val authority = uri.encodedAuthority ?: return null
-        val subPathSegments = pathSegments.subList(0, videosIndex)
+        val subPathSegments = pathSegments.subList(0, mediaIndex)
         val baseUrl =
           if (subPathSegments.isEmpty()) {
             "$scheme://$authority"

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/JellyfinSessionReporter.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/JellyfinSessionReporter.kt
@@ -17,9 +17,11 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.io.OutputStreamWriter
-import java.net.HttpURLConnection
-import java.net.URL
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
 
 class JellyfinSessionReporter(
   private val baseUrl: String,
@@ -28,16 +30,26 @@ class JellyfinSessionReporter(
   private val playSessionId: String?,
   private val mediaSourceId: String?,
   private val coroutineScope: CoroutineScope,
+  private val httpClient: OkHttpClient = defaultHttpClient,
 ) {
   companion object {
     private const val TAG = "JellyfinSessionReporter"
 
     // Ticks per millisecond in Jellyfin (1 tick = 100 nanoseconds = 10,000 ticks per millisecond)
     private const val TICKS_PER_MILLISECOND = 10000L
+    private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
+    private val defaultHttpClient by lazy {
+      OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.SECONDS)
+        .build()
+    }
 
     fun create(
       url: String,
       coroutineScope: CoroutineScope,
+      httpClient: OkHttpClient? = null,
     ): JellyfinSessionReporter? {
       try {
         val uri = Uri.parse(url)
@@ -69,7 +81,15 @@ class JellyfinSessionReporter(
           TAG,
           "Created JellyfinSessionReporter: baseUrl=$baseUrl, itemId=$itemId, playSessionId=$playSessionId, mediaSourceId=$mediaSourceId",
         )
-        return JellyfinSessionReporter(baseUrl, itemId, apiKey, playSessionId, mediaSourceId, coroutineScope)
+        return JellyfinSessionReporter(
+          baseUrl = baseUrl,
+          itemId = itemId,
+          apiKey = apiKey,
+          playSessionId = playSessionId,
+          mediaSourceId = mediaSourceId,
+          coroutineScope = coroutineScope,
+          httpClient = httpClient ?: defaultHttpClient,
+        )
       } catch (e: Exception) {
         Log.e(TAG, "Failed to parse Jellyfin URL: ${e.message}")
         return null
@@ -160,33 +180,25 @@ class JellyfinSessionReporter(
     urlString: String,
     jsonBody: String,
   ) {
-    var connection: HttpURLConnection? = null
     try {
-      val url = URL(urlString)
-      connection = url.openConnection() as HttpURLConnection
-      connection.requestMethod = "POST"
-      connection.connectTimeout = 5000
-      connection.readTimeout = 5000
-      connection.doOutput = true
-      connection.setRequestProperty("Content-Type", "application/json")
-      connection.setRequestProperty("X-Emby-Token", apiKey)
-      connection.setRequestProperty("User-Agent", "mpvRx/1.0")
+      val request =
+        Request.Builder()
+          .url(urlString)
+          .header("Content-Type", "application/json")
+          .header("X-Emby-Token", apiKey)
+          .header("User-Agent", "mpvRx/1.0")
+          .post(jsonBody.toRequestBody(JSON_MEDIA_TYPE))
+          .build()
 
-      OutputStreamWriter(connection.outputStream, "UTF-8").use { writer ->
-        writer.write(jsonBody)
-        writer.flush()
-      }
-
-      val responseCode = connection.responseCode
-      if (responseCode in 200..299) {
-        Log.d(TAG, "Successfully reported status to Jellyfin: $urlString")
-      } else {
-        Log.e(TAG, "Failed to report status to Jellyfin: $urlString, response code: $responseCode")
+      httpClient.newCall(request).execute().use { response ->
+        if (response.isSuccessful) {
+          Log.d(TAG, "Successfully reported status to Jellyfin: $urlString")
+        } else {
+          Log.e(TAG, "Failed to report status to Jellyfin: $urlString, response code: ${response.code}")
+        }
       }
     } catch (e: Exception) {
       Log.e(TAG, "Error sending playback report to Jellyfin: ${e.message}", e)
-    } finally {
-      connection?.disconnect()
     }
   }
 }


### PR DESCRIPTION
## Summary
Enhances Jellyfin integration with cross-device playback progress synchronization, modern Material 3 Expressive server management sheets, migrated OkHttp session reporting, and performance improvements.

## Key Changes
- **Cross-Device Progress Sync**: Added single-item endpoint retrieval (`/Users/{userId}/Items/{itemId}`) to fetch fresh `PlaybackPositionTicks` and seed `PlaybackStateEntity` immediately before playback starts.
- **Session Reporting & Identity Tracking**: Keyed stream state using `PlaybackIdentity` and migrated `JellyfinSessionReporter` from legacy `HttpURLConnection` to injected `OkHttp`. Also, Immediately report pause/resume state changes to Jellyfin dashboard.
- **Material 3 Expressive Server Management**: Redesigned server add/edit dialogs into modern `ModalBottomSheet` components featuring `SingleChoiceSegmentedButtonRow` (Credentials vs API Token), password visibility toggle, active server indicators, and validation cards.
- **Networking & URL Robustness**: Hardened URL normalization (automatic port/scheme fallback, path trimming) and authority parsing.
- **UI Performance**: Debounced search query jobs and optimized Compose recompositions.

## Verification
- Verified real-time cross-device resume position loading.
- Validated server addition via Credentials and API Token.
- Checked `./gradlew compileStandardDebugKotlin` and `./gradlew ktlintCheck` (0 errors).
