### PR TITLE
Fix per-item progress persistence when switching playlist episodes

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserViewModel.kt
@@ -560,6 +560,7 @@ class FileSystemBrowserViewModel(
       val video = videoFile.video
       val playbackIdentifiers =
         linkedSetOf(
+          PlaybackIdentity.forLocalPath(video.path),
           PlaybackIdentity.forUri(video.uri.toString()),
           PlaybackIdentity.forUri(video.path),
           PlaybackIdentity.forUri("file://${video.path}"),
@@ -600,6 +601,7 @@ class FileSystemBrowserViewModel(
       val durationSeconds = (video.duration / 1000L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
       val identifiers =
         linkedSetOf(
+          PlaybackIdentity.forLocalPath(video.path),
           PlaybackIdentity.forUri(video.uri.toString()),
           PlaybackIdentity.forUri(video.path),
           PlaybackIdentity.forUri("file://${video.path}"),
@@ -609,7 +611,7 @@ class FileSystemBrowserViewModel(
       }
       playbackStateRepository.upsert(
         (existing ?: app.gyrolet.mpvrx.database.entities.PlaybackStateEntity(
-          mediaTitle = PlaybackIdentity.forUri(video.uri.toString()),
+          mediaTitle = PlaybackIdentity.forLocalPath(video.path),
           lastPosition = 0,
           playbackSpeed = 1.0,
           sid = -1,
@@ -621,13 +623,13 @@ class FileSystemBrowserViewModel(
           timeRemaining = durationSeconds,
           hasBeenWatched = false,
         )).copy(
-          mediaTitle = PlaybackIdentity.forUri(video.uri.toString()),
+          mediaTitle = PlaybackIdentity.forLocalPath(video.path),
           lastPosition = 0,
           timeRemaining = if (watched) 0 else durationSeconds,
           hasBeenWatched = watched,
         ),
       )
-      PlaybackStateEvents.notifyChanged(PlaybackIdentity.forUri(video.uri.toString()))
+      PlaybackStateEvents.notifyChanged(PlaybackIdentity.forLocalPath(video.path))
     }
   }
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListViewModel.kt
@@ -276,7 +276,8 @@ class FolderListViewModel(
 
                     // A video counts as "unplayed" until it has been watched to the
                     // configured threshold. Threshold 0 ("Infinitely") keeps it unplayed.
-                    val playbackState = playbackStateRepository.getVideoDataByTitle(PlaybackIdentity.forUri(video.uri.toString()))
+                    val playbackState = playbackStateRepository.getVideoDataByTitle(PlaybackIdentity.forLocalPath(video.path))
+                      ?: playbackStateRepository.getVideoDataByTitle(PlaybackIdentity.forUri(video.uri.toString()))
                       ?: playbackStateRepository.getVideoDataByTitle(PlaybackIdentity.forUri(video.path))
                       ?: playbackStateRepository.getVideoDataByTitle(PlaybackIdentity.forUri("file://${video.path}"))
                     val isUnplayed =

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -100,6 +100,7 @@ import app.gyrolet.mpvrx.ui.browser.videolist.VideoListContent
 import app.gyrolet.mpvrx.ui.browser.videolist.VideoWithPlaybackInfo
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.player.PlaybackIdentity
 import app.gyrolet.mpvrx.ui.player.PlaybackItem
 import app.gyrolet.mpvrx.ui.player.PlaybackSession
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
@@ -325,6 +326,7 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
     val queueItems = playlistVideos.map { item ->
       PlaybackItem.fromUri(
         uri = item.uri.toString(),
+        stableId = PlaybackIdentity.forLocalPath(item.path),
         title = item.displayName,
         mimeType = item.mimeType,
       )
@@ -347,6 +349,7 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
         putExtra("media_library_audio", mediaType == MediaLibraryType.Audio)
         putExtra("is_audio", video.isAudio)
         putExtra("title", video.displayName)
+        putExtra("local_media_path", video.path)
       }
     context.startActivity(intent)
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryViewModel.kt
@@ -106,6 +106,7 @@ class MediaLibraryViewModel(
 
     fun findPlaybackState(video: Video) =
       linkedSetOf(
+        PlaybackIdentity.forLocalPath(video.path),
         PlaybackIdentity.forUri(video.uri.toString()),
         PlaybackIdentity.forUri(video.path),
         PlaybackIdentity.forUri("file://${video.path}"),
@@ -160,6 +161,7 @@ class MediaLibraryViewModel(
       val durationSeconds = (video.duration / 1000L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
       val identifiers =
         linkedSetOf(
+          PlaybackIdentity.forLocalPath(video.path),
           PlaybackIdentity.forUri(video.uri.toString()),
           PlaybackIdentity.forUri(video.path),
           PlaybackIdentity.forUri("file://${video.path}"),
@@ -169,7 +171,7 @@ class MediaLibraryViewModel(
       }
       playbackStateRepository.upsert(
         (existing ?: PlaybackStateEntity(
-          mediaTitle = PlaybackIdentity.forUri(video.uri.toString()),
+          mediaTitle = PlaybackIdentity.forLocalPath(video.path),
           lastPosition = 0,
           playbackSpeed = 1.0,
           sid = -1,
@@ -181,13 +183,13 @@ class MediaLibraryViewModel(
           timeRemaining = durationSeconds,
           hasBeenWatched = false,
         )).copy(
-          mediaTitle = PlaybackIdentity.forUri(video.uri.toString()),
+          mediaTitle = PlaybackIdentity.forLocalPath(video.path),
           lastPosition = 0,
           timeRemaining = if (watched) 0 else durationSeconds,
           hasBeenWatched = watched,
         ),
       )
-      PlaybackStateEvents.notifyChanged(PlaybackIdentity.forUri(video.uri.toString()))
+      PlaybackStateEvents.notifyChanged(PlaybackIdentity.forLocalPath(video.path))
     }
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListViewModel.kt
@@ -247,6 +247,7 @@ class VideoListViewModel(
   private suspend fun findPlaybackState(video: Video): PlaybackStateEntity? {
     val identifiers =
       linkedSetOf(
+        PlaybackIdentity.forLocalPath(video.path),
         PlaybackIdentity.forUri(video.uri.toString()),
         PlaybackIdentity.forUri(video.path),
         PlaybackIdentity.forUri("file://${video.path}"),
@@ -258,7 +259,7 @@ class VideoListViewModel(
     return null
   }
 
-  private fun canonicalPlaybackIdentifier(video: Video): String = PlaybackIdentity.forUri(video.uri.toString())
+  private fun canonicalPlaybackIdentifier(video: Video): String = PlaybackIdentity.forLocalPath(video.path)
 
   private suspend fun loadPlaybackInfo(videos: List<Video>) {
     val watchedThreshold = browserPreferences.watchedThreshold.get()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackModels.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackModels.kt
@@ -54,6 +54,7 @@ data class PlaybackItem(
   companion object {
     fun fromUri(
       uri: String,
+      stableId: String? = null,
       playableUri: String = uri,
       title: String? = null,
       mimeType: String? = null,
@@ -64,7 +65,8 @@ data class PlaybackItem(
     ): PlaybackItem =
       PlaybackItem(
         stableId =
-          networkSource?.let { PlaybackIdentity.forNetwork(it.connectionId, it.relativePath) }
+          stableId
+            ?: networkSource?.let { PlaybackIdentity.forNetwork(it.connectionId, it.relativePath) }
             ?: PlaybackIdentity.forUri(uri),
         originalUri = uri,
         playableUri = playableUri,
@@ -276,6 +278,9 @@ object PlaybackIdentity {
 
   fun forUri(uri: String): String = digest("uri\u0000${canonicalizeUri(uri)}")
 
+  /** Gives every URI representation of the same local file one playback-state key. */
+  fun forLocalPath(path: String): String = digest("local\u0000${normalizeLocalPath(path)}")
+
   fun forTorrent(
     infoHash: String,
     fileIndex: Int,
@@ -300,6 +305,11 @@ object PlaybackIdentity {
     }
     return normalized.joinToString("/")
   }
+
+  private fun normalizeLocalPath(path: String): String =
+    runCatching { URI(null, null, path.replace('\\', '/'), null).normalize().path }
+      .getOrDefault(path.replace('\\', '/'))
+      .trim()
 
   private fun canonicalizeUri(raw: String): String {
     val parsed = runCatching { URI(raw) }.getOrNull() ?: return raw.trim()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackStatePersistence.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackStatePersistence.kt
@@ -29,6 +29,7 @@ internal data class PlaybackStateSnapshot(
   val aid: Int,
   val audioDelayMs: Int,
   val externalSubtitles: String,
+  val isPositionRestorePending: Boolean = false,
 )
 
 internal object PlaybackStatePersistence {
@@ -44,9 +45,10 @@ internal object PlaybackStatePersistence {
         currentPosition = snapshot.currentPosition,
         duration = snapshot.duration,
         savePositionOnQuit = savePositionOnQuit,
+        isPositionRestorePending = snapshot.isPositionRestorePending,
       )
     val duration = snapshot.duration
-    val timeRemaining = if (duration > snapshot.currentPosition) duration - snapshot.currentPosition else 0
+    val timeRemaining = if (duration > lastPosition) duration - lastPosition else 0
 
     return PlaybackStateEntity(
       mediaTitle = snapshot.mediaIdentifier,
@@ -77,8 +79,15 @@ internal object PlaybackStatePersistence {
     currentPosition: Int,
     duration: Int,
     savePositionOnQuit: Boolean,
+    isPositionRestorePending: Boolean = false,
   ): Int {
     if (!savePositionOnQuit) {
+      return oldState?.lastPosition ?: 0
+    }
+    // FILE_LOADED makes the incoming item the active save target before its database lookup
+    // completes. Keep an existing resume point if a lifecycle save observes the initial 0 in
+    // that narrow window; a real seek/playback position remains authoritative.
+    if (isPositionRestorePending && currentPosition == 0) {
       return oldState?.lastPosition ?: 0
     }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -313,7 +313,11 @@ class PlayerActivity :
    * the incoming video inside [handleFileLoaded], so any save during the transition
    * lands on the correct (outgoing) record.
    */
+  @Volatile
   private var activeSaveMediaIdentifier: String = ""
+
+  @Volatile
+  private var pendingPositionRestoreGeneration: Long? = null
   private var pendingBackgroundPlaybackStart = false
 
   /**
@@ -3577,6 +3581,12 @@ class PlayerActivity :
     val loadedIntent = Intent(intent)
     val loadedPlaylistIndex = playlistIndex
     val loadedPlaylist = playlist.toList()
+    if (loadedMediaIdentifier.isNotBlank()) {
+      // MPV has confirmed that the incoming file is active, so subsequent lifecycle saves must
+      // target it even while its database-backed resume position is still being restored.
+      activeSaveMediaIdentifier = loadedMediaIdentifier
+      pendingPositionRestoreGeneration = loadGeneration
+    }
     currentUri?.let { viewModel.calculateVideoHash(it) }
 
     reportJellyfinStop()
@@ -3604,13 +3614,9 @@ class PlayerActivity :
         )
       if (!PlaybackSession.isCurrentGeneration(loadGeneration)) return@launch
 
-      // Only now re-point the persisted-state identifier at the incoming video. Its resume
-      // position has just been restored above, so any save that fires from here on lands on
-      // the correct (incoming) record with the resumed position. Until this point
-      // activeSaveMediaIdentifier still pointed at the outgoing video, so a save fired during
-      // the buffering transition could not stamp the incoming video's record with an un-resumed
-      // position (e.g. 0) and erase its saved progress.
-      if (loadedMediaIdentifier.isNotBlank()) activeSaveMediaIdentifier = loadedMediaIdentifier
+      if (pendingPositionRestoreGeneration == loadGeneration) {
+        pendingPositionRestoreGeneration = null
+      }
 
       // Apply track selection logic (defaults only apply when no saved state)
       trackSelector.onFileLoaded(hasState)
@@ -4080,6 +4086,8 @@ class PlayerActivity :
       mediaTitle = mediaTitle,
       currentPosition = readMpvIntSeconds("time-pos", viewModel.pos ?: 0),
       duration = readMpvIntSeconds("duration", viewModel.duration ?: 0),
+      isPositionRestorePending =
+        pendingPositionRestoreGeneration == PlaybackSession.state.value.activeGeneration,
       playbackSpeed = PlaybackSession.getPropertyDouble("speed") ?: DEFAULT_PLAYBACK_SPEED,
       videoZoom = PlaybackSession.getPropertyDouble("video-zoom")?.toFloat() ?: viewModel.videoZoom.value,
       sid = player.sid,
@@ -5785,7 +5793,8 @@ class PlayerActivity :
 
     // Save current video's playback state before switching
     if (saveCurrentPlaybackState && fileName.isNotBlank()) {
-      saveVideoPlaybackState(fileName)
+      // A later lifecycle save for the incoming item must not cancel this outgoing-item write.
+      saveVideoPlaybackState(fileName, immediate = true)
       reportJellyfinStop()
     }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -1336,7 +1336,7 @@ class PlayerActivity :
             networkPlaylistHeaders = queueItems.map(PlaybackItem::headers)
             networkPlaylistConnectionId = item.networkSource?.connectionId ?: -1L
             fileName = item.title?.takeIf { it.isNotBlank() } ?: getFileNameFromUri(Uri.parse(item.originalUri))
-            legacyMediaIdentifier = null
+            legacyMediaIdentifier = PlaybackIdentity.forUri(item.originalUri)
             mediaIdentifier = item.stableId
             currentPlayableUri = item.playableUri
             isReady = false
@@ -4131,7 +4131,8 @@ class PlayerActivity :
         // URI hash like "name_123456" for remote files). Bare filenames used by older
         // versions for local files are ambiguous — two files in different directories
         // share the same display name, so migrating would steal one file's state.
-        val isCollisionResistant = legacyKey != null && legacyKey.contains('_')
+        val isCollisionResistant =
+          legacyKey != null && (legacyKey.startsWith("media:v2:") || legacyKey.contains('_'))
         val legacyState = legacyKey
           ?.takeIf { isCollisionResistant }
           ?.let { playbackStateRepository.getVideoDataByTitle(it) }
@@ -5826,7 +5827,7 @@ class PlayerActivity :
       } else if (isRemotePlaybackUri(uri)) {
         "${fileName}_${uri.toString().hashCode()}"
       } else {
-        null
+        PlaybackIdentity.forUri(uri.toString())
       }
     mediaIdentifier =
       if (networkFilePath != null && resolvedNetworkConnectionId != null) {
@@ -6186,8 +6187,6 @@ class PlayerActivity :
     intent: Intent,
     fileName: String,
   ): String {
-    intent.getStringExtra("media_identifier")?.takeIf { it.isNotBlank() }?.let { return it }
-
     // Check if this is a network file played via proxy (SMB/WebDAV/FTP)
     // Use the stable network file path instead of the temporary proxy URL
     val networkFilePath = intent.getStringExtra("network_file_path")
@@ -6197,6 +6196,16 @@ class PlayerActivity :
       val identifier = buildNetworkMediaIdentifier(networkConnectionId, networkFilePath)
       return identifier
     }
+
+    val sourceUri = extractUriFromIntent(intent)
+    val localPath =
+      intent.getStringExtra("local_media_path")?.takeIf { it.isNotBlank() }
+        ?: sourceUri?.resolveLocalPath(this)
+    localPath?.let {
+      return PlaybackIdentity.forLocalPath(it)
+    }
+
+    intent.getStringExtra("media_identifier")?.takeIf { it.isNotBlank() }?.let { return it }
 
     val source = extractUriFromIntent(intent)?.toString() ?: parsePathFromIntent(intent) ?: fileName
     if (isTorrentSource(source, intent.type)) {
@@ -6218,13 +6227,17 @@ class PlayerActivity :
     intent: Intent,
     fileName: String,
   ): String? {
-    if (intent.getStringExtra("media_identifier")?.startsWith("media:v2:") == true) return null
+    val explicitIdentifier = intent.getStringExtra("media_identifier")?.takeIf { it.isNotBlank() }
+    val uri = extractUriFromIntent(intent)
+    val hasLocalPath =
+      intent.getStringExtra("local_media_path")?.isNotBlank() == true || uri?.resolveLocalPath(this) != null
+    if (hasLocalPath) return uri?.toString()?.let(PlaybackIdentity::forUri) ?: explicitIdentifier
+    if (explicitIdentifier?.startsWith("media:v2:") == true) return null
     val networkFilePath = intent.getStringExtra("network_file_path")
     val connectionId = intent.getLongExtra("network_connection_id", -1L)
     if (!networkFilePath.isNullOrBlank() && connectionId != -1L) {
       return "network_${connectionId}_${networkFilePath.hashCode()}"
     }
-    val uri = extractUriFromIntent(intent)
     if (uri != null && NetworkPlaybackUri.parse(uri.toString()) != null) return null
     // Local files must not use the bare filename as a legacy key — it is ambiguous when
     // multiple directories contain files with the same display name (issue #382).
@@ -6272,7 +6285,7 @@ class PlayerActivity :
 
   private fun Uri.matches(saved: SavedPlaylistSelection): Boolean {
     val uri = toString()
-    return saved.originalUri == uri || saved.stableId == PlaybackIdentity.forUri(uri)
+    return saved.originalUri == uri || saved.stableId == getMediaIdentifierFromUri(this, "")
   }
 
   private fun publishPlaylistToSession() {
@@ -6306,6 +6319,8 @@ class PlayerActivity :
 
         PlaybackItem.fromUri(
           uri = uri.toString(),
+          stableId =
+            if (networkSource == null) uri.resolveLocalPath(this)?.let(PlaybackIdentity::forLocalPath) else null,
           title = title,
           headers = headers,
           networkSource = networkSource,
@@ -6339,7 +6354,8 @@ class PlayerActivity :
     uri: Uri,
     @Suppress("UNUSED_PARAMETER") fileName: String,
   ): String =
-    NetworkPlaybackUri.parse(uri.toString())
+    uri.resolveLocalPath(this)?.let(PlaybackIdentity::forLocalPath)
+      ?: NetworkPlaybackUri.parse(uri.toString())
       ?.let { reference -> PlaybackIdentity.forNetwork(reference.connectionId, reference.path.value) }
       ?: PlaybackIdentity.forUri(uri.toString())
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerUtils.kt
@@ -71,6 +71,14 @@ internal fun Uri.openContentFd(context: Context): String? =
     ?: tryDocumentUriParsing(context)
     ?: tryFileDescriptorFallback(context)
 
+/** Resolves identity only; unlike [openContentFd], this never detaches a file descriptor. */
+internal fun Uri.resolveLocalPath(context: Context): String? =
+  when (scheme?.lowercase()) {
+    "file" -> path
+    "content" -> extractLocalPath() ?: tryMediaStoreQuery(context) ?: tryDocumentUriParsing(context)
+    else -> null
+  }
+
 /**
  * Method 1: Extract real filesystem path from file descriptor.
  * Works best for most content URIs on modern Android.


### PR DESCRIPTION
## Summary
- save playback state against the currently active playlist item before switching
- unify local media identities by normalized filesystem path so content and file URIs share progress
- migrate existing collision-resistant URI-based progress records to the canonical local identity
- use the canonical identity consistently across media-library and filesystem progress views

## Root cause
Direct episode launches used a content URI identity, while playlist navigation could use a file URI identity for the same physical file. This split one episode across different database keys and made switched-item progress appear to belong to the entry episode.

## Verification
- ./gradlew.bat :app:assembleStandardDebug --no-daemon --max-workers=2
- ./gradlew.bat :app:ktlintCheck --no-daemon --max-workers=2
- installed the arm64 debug APK over ADB with existing app data preserved
- manually reproduced the original episode-switch sequence; reporter confirmed the issue is resolved