### PR TITLE
Select subtitle tracks using ordered title keywords

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -297,6 +297,8 @@ dependencies {
   implementation(libs.reorderable)
   implementation(libs.androidx.biometric)
 
+  testImplementation("junit:junit:4.13.2")
+
   // libtorrent4j's Java API plus the native library for every enabled APK ABI.
   implementation(libs.libtorrent4j)
   implementation(libs.libtorrent4j.android.arm64)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/SubtitleTitleMatcher.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/SubtitleTitleMatcher.kt
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player
+
+/** Selects a subtitle title by applying comma-separated preferences from left to right. */
+internal object SubtitleTitleMatcher {
+  fun findBestMatchIndex(
+    titles: List<String>,
+    orderedKeywords: List<String>,
+  ): Int? {
+    var candidates = titles.indices.toList()
+    var matchedAnyKeyword = false
+
+    for (keyword in orderedKeywords.map(String::trim).filter(String::isNotEmpty)) {
+      val matches = candidates.filter { index -> matchesKeyword(titles[index], keyword) }
+      if (matches.isNotEmpty()) {
+        candidates = matches
+        matchedAnyKeyword = true
+      }
+    }
+
+    return candidates.firstOrNull().takeIf { matchedAnyKeyword }
+  }
+
+  private fun matchesKeyword(
+    title: String,
+    keyword: String,
+  ): Boolean {
+    val isShortAsciiCode = keyword.length <= 3 && keyword.all { it.isAsciiLetterOrDigit() }
+    if (!isShortAsciiCode) return title.contains(keyword, ignoreCase = true)
+
+    // Treat short values such as eng, ch and zh as codes. Boundaries prevent
+    // "ch" from accidentally matching unrelated words such as "French".
+    val codePattern = Regex("(?i)(?<![a-z0-9])${Regex.escape(keyword)}(?![a-z0-9])")
+    return codePattern.containsMatchIn(title)
+  }
+
+  private fun Char.isAsciiLetterOrDigit(): Boolean =
+    this in 'a'..'z' || this in 'A'..'Z' || this in '0'..'9'
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/TrackSelector.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/TrackSelector.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.withContext
  * **Subtitle Selection Strategy (Highest to Lowest Priority):**
  * Subtitle selection is highly dependent on the auto-detected media context (Anime vs. Live-Action).
  * - **Pass 00 (External Override):** Automatically prioritizes manually loaded external subtitle files.
+ * - **Pass 0 (Preferred Title):** Applies the user's ordered keywords to subtitle track titles.
  * - **Pass A0 (Anime Only - Native Default):** If exactly *one* subtitle track is flagged
  * as default and it is Japanese, it is selected. This protects against muxing errors
  * where multiple tracks are incorrectly flagged as default by the encoder.
@@ -293,7 +294,20 @@ class TrackSelector(
       // PASS 00: EXTERNAL TRACK OVERRIDE (Protects manually loaded subtitle files & respects language preference)
       val externalTracks = subTracks.filter { it.external }
       if (externalTracks.isNotEmpty()) {
-        // 1. Try to find an external track matching preferred languages in order
+        // 1. Apply ordered title keywords to external tracks.
+        val titleMatchIndex =
+          SubtitleTitleMatcher.findBestMatchIndex(
+            titles = externalTracks.map(Track::title),
+            orderedKeywords = preferredLangs,
+          )
+        if (titleMatchIndex != null) {
+          val track = externalTracks[titleMatchIndex]
+          if (currentSid != track.id) setTrackSelectionId("sid", track.id)
+          Log.d(TAG, "Smart Sub: Preferred external title matched (id=${track.id})")
+          return
+        }
+
+        // 2. Try to find an external track matching preferred languages in order
         for (prefLang in preferredLangs) {
           for (track in externalTracks) {
             if (track.lang == prefLang || track.lang.startsWith(prefLang)) {
@@ -314,7 +328,7 @@ class TrackSelector(
           }
         }
 
-        // 2. Try to find manually loaded subtitle files (usually have empty or "und" lang)
+        // 3. Try to find manually loaded subtitle files (usually have empty or "und" lang)
         val unknownLangCodes = setOf("", "und", "zxx")
         for (track in externalTracks) {
           if (track.lang in unknownLangCodes) {
@@ -331,7 +345,7 @@ class TrackSelector(
           }
         }
 
-        // 3. Fallback: select the first available external track
+        // 4. Fallback: select the first available external track
         val fallbackTrack = externalTracks.first()
         if (currentSid == fallbackTrack.id) {
           Log.d(
@@ -342,6 +356,21 @@ class TrackSelector(
           Log.d(TAG, "Smart Sub: Fallback External Subtitle Detected (id=${fallbackTrack.id}) [Applied]")
           setTrackSelectionId("sid", fallbackTrack.id)
         }
+        return
+      }
+
+      // PASS 0: ORDERED SUBTITLE TITLE PREFERENCES
+      // A matching keyword narrows the current candidates. Later keywords act as tie-breakers
+      // without overriding an earlier, higher-priority match.
+      val titleMatchIndex =
+        SubtitleTitleMatcher.findBestMatchIndex(
+          titles = subTracks.map(Track::title),
+          orderedKeywords = preferredLangs,
+        )
+      if (titleMatchIndex != null) {
+        val track = subTracks[titleMatchIndex]
+        if (currentSid != track.id) setTrackSelectionId("sid", track.id)
+        Log.d(TAG, "Smart Sub: Preferred title matched (id=${track.id})")
         return
       }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SubtitlesPreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SubtitlesPreferencesScreen.kt
@@ -262,12 +262,12 @@ object SubtitlesPreferencesScreen : Screen {
                 },
                 textField = { value, onValueChange, _ ->
                   Column {
-                    Text(stringResource(R.string.enter_language_codes))
+                    Text(stringResource(R.string.enter_subtitle_title_preferences))
                     TextField(
                       value,
                       onValueChange,
                       modifier = Modifier.fillMaxWidth(),
-                      placeholder = { Text(stringResource(R.string.language_codes_placeholder)) },
+                      placeholder = { Text(stringResource(R.string.subtitle_title_preferences_placeholder)) },
                     )
                   }
                 },

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -497,6 +497,8 @@
   <string name="not_set_video_default">未设置（将使用视频默认值）</string>
   <string name="enter_language_codes">输入以逗号分隔的语言代码（例如 eng,jpn,spa）</string>
   <string name="language_codes_placeholder">eng,jpn,spa</string>
+  <string name="enter_subtitle_title_preferences">按优先级输入字幕轨标题关键词或语言代码，用逗号分隔；越靠前优先级越高，并列时继续匹配后续关键词。</string>
+  <string name="subtitle_title_preferences_placeholder">特效,简体,chs,zh</string>
   <string name="pref_audio_channels_auto_safe_desc">默认、安全的自动选择</string>
   <string name="pref_audio_channels_auto_desc">自动选择</string>
   <string name="pref_audio_channels_mono_desc">混音为单声道</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,6 +516,8 @@
   <string name="not_set_video_default">Not set (will use video default)</string>
   <string name="enter_language_codes">Enter language codes separated by commas (e.g., eng,jpn,spa)</string>
   <string name="language_codes_placeholder">eng,jpn,spa</string>
+  <string name="enter_subtitle_title_preferences">Enter subtitle-title keywords or language codes in priority order, separated by commas. Earlier matches take precedence.</string>
+  <string name="subtitle_title_preferences_placeholder">Full,Dialogue,eng,en</string>
   <string name="pref_audio_channels_auto_safe_desc">Default, safe auto selection</string>
   <string name="pref_audio_channels_auto_desc">Auto selection</string>
   <string name="pref_audio_channels_mono_desc">Downmix to mono</string>

--- a/app/src/test/java/app/gyrolet/mpvrx/ui/player/SubtitleTitleMatcherTest.kt
+++ b/app/src/test/java/app/gyrolet/mpvrx/ui/player/SubtitleTitleMatcherTest.kt
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SubtitleTitleMatcherTest {
+  @Test
+  fun `uses later keywords to break ties among earlier matches`() {
+    val titles =
+      listOf(
+        "Official Simplified Chinese",
+        "Effects Simplified Chinese",
+        "Effects Traditional Chinese",
+      )
+
+    val result = SubtitleTitleMatcher.findBestMatchIndex(titles, listOf("effects", "simplified", "chs"))
+
+    assertEquals(1, result)
+  }
+
+  @Test
+  fun `earlier keyword cannot be outweighed by later keywords`() {
+    val titles = listOf("Effects subtitles", "Simplified chs Chinese")
+
+    val result = SubtitleTitleMatcher.findBestMatchIndex(titles, listOf("effects", "simplified", "chs"))
+
+    assertEquals(0, result)
+  }
+
+  @Test
+  fun `short language code requires an ascii token boundary`() {
+    val titles = listOf("French", "Chinese [CH]")
+
+    val result = SubtitleTitleMatcher.findBestMatchIndex(titles, listOf("ch"))
+
+    assertEquals(1, result)
+  }
+
+  @Test
+  fun `returns null when no title keyword matches`() {
+    val result = SubtitleTitleMatcher.findBestMatchIndex(listOf("English", "日本語"), listOf("简", "繁"))
+
+    assertNull(result)
+  }
+}


### PR DESCRIPTION
## Summary
- allow the existing preferred subtitle language list to also contain track-title keywords
- narrow matching subtitle candidates from left to right, so earlier keywords have higher priority and later keywords break ties
- match short language codes only at ASCII token boundaries to avoid false positives such as ch in French
- apply title matching to external and embedded subtitle tracks before the existing smart-selection fallbacks
- clarify the subtitle preference prompt and add English/Chinese examples

Adapted from the subtitle-title preference behavior in [yaodao0yaodao/mpvEx-CN](https://github.com/yaodao0yaodao/mpvEx-CN), without its project-specific defaults or unrelated customizations.

## Verification
- .\\gradlew.bat :app:testStandardDebugUnitTest --no-daemon --max-workers=2
- .\\gradlew.bat :app:assembleStandardDebug --no-daemon --max-workers=2
- 4 unit tests cover ordered tie-breaking, priority preservation, short-code boundaries, and no-match fallback