### PR TITLE
Make waveform seekbar the default

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
@@ -50,7 +50,7 @@ class AppearancePreferences(
   val showUnplayedOldVideoLabel = preferenceStore.getBoolean("show_unplayed_old_video_label", true)
   val unplayedOldVideoDays = preferenceStore.getInt("unplayed_old_video_days", 7)
   val showNetworkThumbnails = preferenceStore.getBoolean("show_network_thumbnails", false)
-  val seekbarStyle = preferenceStore.getEnum("seekbar_style", SeekbarStyle.Thick)
+  val seekbarStyle = preferenceStore.getEnum("seekbar_style", SeekbarStyle.Wavy)
   val portraitPlaybackControlsPosition =
     preferenceStore.getEnum("portrait_playback_controls_position", PortraitPlaybackControlsPosition.Center)
   val showHomeTab = preferenceStore.getBoolean("show_home_tab", true)


### PR DESCRIPTION
## Summary
- default the player seekbar style to `Wavy` so the waveform-style timeline is enabled out of the box
- applies through the shared seekbar style preference used by player seekbars
- users can disable it by selecting any of the existing non-waveform seekbar styles
- does not change seek interaction/commit behavior or add thumbnail-preview behavior

## Scope
This is intentionally a small UI-default change; existing seekbar rendering and seeking logic remain untouched.