### PR TITLE
fix: improve FAB menu behavior and scroll integration

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/fab/FabScrollHelper.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/fab/FabScrollHelper.kt
@@ -9,6 +9,20 @@
 
 package app.gyrolet.mpvrx.ui.browser.fab
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
@@ -16,6 +30,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import app.gyrolet.mpvrx.ui.theme.AppMotion
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -25,6 +44,41 @@ import kotlinx.coroutines.flow.filter
  * Common helper functions for FAB visibility based on scroll state
  */
 object FabScrollHelper {
+  /**
+   * Fullscreen scrim overlay that absorbs all pointer gestures and auto-dismisses the expanded FAB.
+   * Intercepts gestures during PointerEventPass.Initial so background content (LazyColumn, HorizontalPager)
+   * cannot scroll or swipe while the FAB menu is open.
+   */
+  @Composable
+  fun FabScrim(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+  ) {
+    AnimatedVisibility(
+      visible = visible,
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
+      Box(
+        modifier =
+          modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.32f))
+            .pointerInput(Unit) {
+              awaitEachGesture {
+                val down = awaitFirstDown(pass = PointerEventPass.Initial)
+                down.consume()
+                onDismiss()
+                do {
+                  val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                  event.changes.forEach { it.consume() }
+                } while (event.changes.any { it.pressed })
+              }
+            },
+      )
+    }
+  }
   /**
    * Sets up scroll tracking for both list and grid views to control FAB visibility
    */

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/filesystem/FileSystemBrowserScreen.kt
@@ -17,8 +17,13 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -72,7 +77,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -635,6 +642,13 @@ fun FileSystemBrowserScreen(path: String? = null) {
         val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
         val miniPlayerClearance = app.gyrolet.mpvrx.ui.browser.NavigationBarState.miniPlayerClearance
         if (isAtRoot) {
+          val isFabShouldBeVisible =
+            showQuickPlayFab &&
+              !isInSelectionMode &&
+              isFabVisible.value &&
+              !app.gyrolet.mpvrx.ui.browser.MainScreen
+                .getPermissionDeniedState()
+
           FloatingActionButtonMenu(
             modifier =
               Modifier.padding(
@@ -665,12 +679,7 @@ fun FileSystemBrowserScreen(path: String? = null) {
                   modifier =
                     Modifier
                       .animateFloatingActionButton(
-                        visible =
-                          showQuickPlayFab &&
-                            !isInSelectionMode &&
-                            isFabVisible.value &&
-                            !app.gyrolet.mpvrx.ui.browser.MainScreen
-                              .getPermissionDeniedState(),
+                        visible = isFabShouldBeVisible,
                         alignment = Alignment.BottomEnd,
                       ),
                   checked = isFabExpanded.value && !quickPlayFabDirect,
@@ -768,8 +777,8 @@ fun FileSystemBrowserScreen(path: String? = null) {
             }
           }
         }
-      },
-    ) { padding ->
+      }
+  ) { padding ->
       Box(modifier = Modifier.padding(padding)) {
         if (isPermissionSetupCompleted && permissionState.status == PermissionStatus.Granted) {
             if (isSearching) {
@@ -882,6 +891,11 @@ fun FileSystemBrowserScreen(path: String? = null) {
             modifier = Modifier,
           )
         }
+
+        FabScrollHelper.FabScrim(
+          visible = isFabExpanded.value && !quickPlayFabDirect,
+          onDismiss = { isFabExpanded.value = false },
+        )
       }
     }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/folderlist/FolderListScreen.kt
@@ -15,7 +15,12 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -75,7 +80,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -690,6 +697,14 @@ object FolderListScreen : Screen {
           }
         },
         floatingActionButton = {
+          val isFabShouldBeVisible =
+            showQuickPlayFab &&
+              !selectionManager.isInSelectionMode &&
+              isFabVisible.value &&
+              !app.gyrolet.mpvrx.ui.browser.MainScreen
+                .getPermissionDeniedState() &&
+              !(isDualPaneActive && selectedFolderBucketId != null)
+
           FloatingActionButtonMenu(
             modifier = Modifier.padding(bottom = (navigationBarHeight - 16.dp).coerceAtLeast(0.dp)),
             expanded = isFabExpanded.value && !quickPlayFabDirect,
@@ -716,13 +731,7 @@ object FolderListScreen : Screen {
                 ToggleFloatingActionButton(
                   modifier =
                     Modifier.animateFloatingActionButton(
-                      visible =
-                        showQuickPlayFab &&
-                          !selectionManager.isInSelectionMode &&
-                          isFabVisible.value &&
-                          !app.gyrolet.mpvrx.ui.browser.MainScreen
-                            .getPermissionDeniedState() &&
-                          !(isDualPaneActive && selectedFolderBucketId != null),
+                      visible = isFabShouldBeVisible,
                       alignment = Alignment.BottomEnd,
                     ),
                   checked = isFabExpanded.value && !quickPlayFabDirect,
@@ -956,6 +965,11 @@ object FolderListScreen : Screen {
               Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 0.dp),
+          )
+
+          FabScrollHelper.FabScrim(
+            visible = isFabExpanded.value && !quickPlayFabDirect,
+            onDismiss = { isFabExpanded.value = false },
           )
         }
       }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -84,6 +85,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -95,6 +97,7 @@ import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.domain.jellyfin.JellyfinItem
 import app.gyrolet.mpvrx.domain.jellyfin.JellyfinSearchCategory
 import app.gyrolet.mpvrx.domain.jellyfin.JellyfinServer
+import app.gyrolet.mpvrx.preferences.AppearancePreferences
 import app.gyrolet.mpvrx.preferences.BrowserPreferences
 import app.gyrolet.mpvrx.preferences.MediaLayoutMode
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
@@ -105,6 +108,7 @@ import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.browser.components.ExpressiveScrollBar
 import app.gyrolet.mpvrx.ui.browser.components.fastScrollGlyph
 import app.gyrolet.mpvrx.ui.browser.dialogs.JellyfinSortDialog
+import app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper
 import app.gyrolet.mpvrx.ui.browser.selection.rememberSelectionManager
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
@@ -121,13 +125,40 @@ fun JellyfinContent(
   val context = LocalContext.current
   val backstack = LocalBackStack.current
   val browserPreferences = koinInject<BrowserPreferences>()
+  val appearancePreferences = koinInject<AppearancePreferences>()
   val layoutMode by browserPreferences.jellyfinLayoutMode.collectAsState()
+  val showQuickPlayFab by appearancePreferences.showQuickPlayFab.collectAsState()
+  val quickPlayFabDirect by appearancePreferences.quickPlayFabDirect.collectAsState()
 
   var isAddDialogOpen by remember { mutableStateOf(false) }
   var isManageServersOpen by rememberSaveable { mutableStateOf(false) }
   var isSearching by rememberSaveable { mutableStateOf(false) }
   var isSortDialogOpen by rememberSaveable { mutableStateOf(false) }
+  var isFabExpanded by remember { mutableStateOf(false) }
+  val isFabVisible = remember { mutableStateOf(true) }
   val searchFocusRequester = remember { FocusRequester() }
+
+  val homeListState = rememberLazyListState()
+  val libraryListState = remember(uiState.openLibrary, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) { LazyListState() }
+  val libraryGridState = remember(uiState.openLibrary, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) { LazyGridState() }
+
+  if (uiState.openLibrary == null) {
+    FabScrollHelper.trackScrollForFabVisibility(
+      listState = homeListState,
+      gridState = null,
+      isFabVisible = isFabVisible,
+      expanded = isFabExpanded,
+      onExpandedChange = { isFabExpanded = it },
+    )
+  } else {
+    FabScrollHelper.trackScrollForFabVisibility(
+      listState = libraryListState,
+      gridState = if (layoutMode == MediaLayoutMode.GRID) libraryGridState else null,
+      isFabVisible = isFabVisible,
+      expanded = isFabExpanded,
+      onExpandedChange = { isFabExpanded = it },
+    )
+  }
 
   val selectionManager =
     rememberSelectionManager(
@@ -150,9 +181,12 @@ fun JellyfinContent(
   BackHandler(
     enabled =
       isSearching || selectionManager.isInSelectionMode ||
-        uiState.detailItem != null || uiState.openLibrary != null,
+        uiState.detailItem != null || uiState.openLibrary != null || (isFabExpanded && !quickPlayFabDirect),
   ) {
     when {
+      isFabExpanded && !quickPlayFabDirect -> {
+        isFabExpanded = false
+      }
       uiState.detailItem != null -> {
         viewModel.closeDetail()
       }
@@ -401,13 +435,12 @@ fun JellyfinContent(
 
             // Root / Discovery Home View (Expressive UI)
             uiState.openLibrary == null && uiState.searchQuery.isBlank() -> {
-              val listState = rememberLazyListState()
               val server = uiState.activeServer
 
               if (server != null) {
                 Box(modifier = Modifier.fillMaxSize()) {
                   LazyColumn(
-                    state = listState,
+                    state = homeListState,
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = navigationBarHeight + 84.dp),
                     verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -624,10 +657,7 @@ fun JellyfinContent(
                   )
                 }
               } else if (isListMode) {
-                val listState =
-                  remember(uiState.openLibrary, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
-                    LazyListState()
-                  }
+                val listState = libraryListState
                 val hasEnoughItems = items.size > 6
                 val scrollbarAlpha by animateFloatAsState(
                   targetValue = if (hasEnoughItems) 1f else 0f,
@@ -722,10 +752,7 @@ fun JellyfinContent(
                   }
                 }
               } else {
-                val gridState =
-                  remember(uiState.openLibrary, uiState.sortBy, uiState.sortOrder, uiState.isUnplayedOnly) {
-                    LazyGridState()
-                  }
+                val gridState = libraryGridState
                 val hasEnoughItems = items.size > 6
                 val scrollbarAlpha by animateFloatAsState(
                   targetValue = if (hasEnoughItems) 1f else 0f,
@@ -920,77 +947,94 @@ fun JellyfinContent(
         }
       }
 
-      if (!selectionManager.isInSelectionMode && uiState.activeServer != null && (uiState.currentItems.isNotEmpty() || uiState.resumeItems.isNotEmpty() || uiState.heroItems.isNotEmpty())) {
-        // Expressive Floating Action Button Menu
-        var isFabExpanded by remember { mutableStateOf(false) }
+      FabScrollHelper.FabScrim(
+        visible = isFabExpanded && !quickPlayFabDirect,
+        onDismiss = { isFabExpanded = false },
+      )
 
-        FloatingActionButtonMenu(
-          modifier =
-            Modifier
-              .align(Alignment.BottomEnd)
-              .padding(end = 16.dp, bottom = navigationBarHeight + 16.dp),
-          expanded = isFabExpanded,
-          button = {
-            ToggleFloatingActionButton(
-              modifier =
-                Modifier.animateFloatingActionButton(
-                  visible = !isSearching,
-                  alignment = Alignment.BottomEnd,
-                ),
-              checked = isFabExpanded,
-              onCheckedChange = { isFabExpanded = !isFabExpanded },
+      val isFabShouldBeVisible =
+        showQuickPlayFab &&
+          !selectionManager.isInSelectionMode &&
+          !isSearching &&
+          isFabVisible.value &&
+          uiState.activeServer != null &&
+          (uiState.currentItems.isNotEmpty() || uiState.resumeItems.isNotEmpty() || uiState.heroItems.isNotEmpty())
+
+      // Expressive Floating Action Button Menu
+      FloatingActionButtonMenu(
+        modifier =
+          Modifier
+            .align(Alignment.BottomEnd)
+            .padding(end = 16.dp, bottom = navigationBarHeight + 16.dp),
+        expanded = isFabExpanded && !quickPlayFabDirect,
+        button = {
+          ToggleFloatingActionButton(
+            modifier =
+              Modifier.animateFloatingActionButton(
+                visible = isFabShouldBeVisible,
+                alignment = Alignment.BottomEnd,
+              ),
+            checked = isFabExpanded && !quickPlayFabDirect,
+              onCheckedChange = {
+                if (quickPlayFabDirect) {
+                  viewModel.resumeLastPlayed(context)
+                } else {
+                  isFabExpanded = !isFabExpanded
+                }
+              },
             ) {
-              val checkedProgress = if (isFabExpanded) 1f else 0f
+              val checkedProgress = if (isFabExpanded && !quickPlayFabDirect) 1f else 0f
               val imageVector by remember {
                 derivedStateOf {
-                  if (isFabExpanded) Icons.RoundedFilled.Close else Icons.RoundedFilled.PlayArrow
+                  if (checkedProgress > 0.5f && !quickPlayFabDirect) Icons.RoundedFilled.Close else Icons.RoundedFilled.PlayArrow
                 }
               }
               Icon(
                 imageVector = imageVector,
-                contentDescription = "Quick Menu",
-                modifier = Modifier.animateIcon({ checkedProgress }),
+                contentDescription = stringResource(R.string.ui_quick_play),
+                modifier = Modifier.animateIcon({ if (quickPlayFabDirect) 0f else checkedProgress }),
               )
             }
           },
         ) {
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded = false
-              viewModel.playRandom(context)
-            },
-            icon = { Icon(Icons.RoundedFilled.Shuffle, contentDescription = null) },
-            text = { Text("Play Random") },
-          )
+          if (!quickPlayFabDirect) {
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded = false
+                isSearching = true
+              },
+              icon = { Icon(Icons.RoundedFilled.Search, contentDescription = null) },
+              text = { Text("Search") },
+            )
 
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded = false
-              isManageServersOpen = true
-            },
-            icon = { Icon(Icons.RoundedFilled.BringYourOwnIp, contentDescription = null) },
-            text = { Text("Switch Server") },
-          )
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded = false
+                viewModel.playRandom(context)
+              },
+              icon = { Icon(Icons.RoundedFilled.Shuffle, contentDescription = null) },
+              text = { Text("Play Random") },
+            )
 
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded = false
-              isSearching = true
-            },
-            icon = { Icon(Icons.RoundedFilled.Search, contentDescription = null) },
-            text = { Text("Search") },
-          )
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded = false
+                isManageServersOpen = true
+              },
+              icon = { Icon(Icons.RoundedFilled.BringYourOwnIp, contentDescription = null) },
+              text = { Text("Switch Server") },
+            )
 
-          FloatingActionButtonMenuItem(
-            onClick = {
-              isFabExpanded = false
-              viewModel.resumeLastPlayed(context)
-            },
-            icon = { Icon(Icons.RoundedFilled.PlayArrow, contentDescription = null) },
-            text = { Text("Resume") },
-          )
+            FloatingActionButtonMenuItem(
+              onClick = {
+                isFabExpanded = false
+                viewModel.resumeLastPlayed(context)
+              },
+              icon = { Icon(Icons.RoundedFilled.History, contentDescription = null) },
+              text = { Text(stringResource(R.string.pref_advanced_enable_recently_played_title)) },
+            )
+          }
         }
-      }
     }
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -17,8 +17,13 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -65,6 +70,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
@@ -354,8 +361,9 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
     context.startActivity(intent)
   }
 
-  BackHandler(enabled = selectionManager.isInSelectionMode || isSearching) {
+  BackHandler(enabled = selectionManager.isInSelectionMode || isSearching || (isFabExpanded.value && !quickPlayFabDirect)) {
     when {
+      isFabExpanded.value && !quickPlayFabDirect -> isFabExpanded.value = false
       selectionManager.isInSelectionMode -> selectionManager.clear()
       isSearching -> {
         isSearching = false
@@ -494,40 +502,42 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
       }
     },
     floatingActionButton = {
-      if (filteredVideosWithInfo.isNotEmpty()) {
-        FloatingActionButtonMenu(
-          modifier = Modifier.padding(bottom = (navigationBarHeight - 16.dp).coerceAtLeast(0.dp)),
-          expanded = isFabExpanded.value && !quickPlayFabDirect,
-          button = {
-            TooltipBox(
-              positionProvider =
-                TooltipDefaults.rememberTooltipPositionProvider(
-                  if (isFabExpanded.value && !quickPlayFabDirect) {
-                    TooltipAnchorPosition.Start
-                  } else {
-                    TooltipAnchorPosition.Above
-                  },
+      val isFabShouldBeVisible =
+        filteredVideosWithInfo.isNotEmpty() &&
+          showQuickPlayFab &&
+          !selectionManager.isInSelectionMode &&
+          isFabVisible.value &&
+          !MainScreen.getPermissionDeniedState()
+
+      FloatingActionButtonMenu(
+        modifier = Modifier.padding(bottom = (navigationBarHeight - 16.dp).coerceAtLeast(0.dp)),
+        expanded = isFabExpanded.value && !quickPlayFabDirect,
+        button = {
+          TooltipBox(
+            positionProvider =
+              TooltipDefaults.rememberTooltipPositionProvider(
+                if (isFabExpanded.value && !quickPlayFabDirect) {
+                  TooltipAnchorPosition.Start
+                } else {
+                  TooltipAnchorPosition.Above
+                },
+              ),
+            tooltip = {
+              PlainTooltip {
+                Text(
+                  androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.ui_toggle_menu),
+                )
+              }
+            },
+            state = rememberTooltipState(),
+          ) {
+            ToggleFloatingActionButton(
+              modifier =
+                Modifier.animateFloatingActionButton(
+                  visible = isFabShouldBeVisible,
+                  alignment = Alignment.BottomEnd,
                 ),
-              tooltip = {
-                PlainTooltip {
-                  Text(
-                    androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.ui_toggle_menu),
-                  )
-                }
-              },
-              state = rememberTooltipState(),
-            ) {
-              ToggleFloatingActionButton(
-                modifier =
-                  Modifier.animateFloatingActionButton(
-                    visible =
-                      showQuickPlayFab &&
-                        !selectionManager.isInSelectionMode &&
-                        isFabVisible.value &&
-                        !MainScreen.getPermissionDeniedState(),
-                    alignment = Alignment.BottomEnd,
-                  ),
-                checked = isFabExpanded.value && !quickPlayFabDirect,
+              checked = isFabExpanded.value && !quickPlayFabDirect,
                 onCheckedChange = {
                   if (quickPlayFabDirect) {
                     coroutineScope.launch {
@@ -606,9 +616,8 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
             )
           }
         }
-      }
-    },
-  ) { padding ->
+      },
+    ) { padding ->
     val autoScrollToLastPlayed by browserPreferences.autoScrollToLastPlayed.collectAsState()
     val videosWereDeletedOrMoved = false
 
@@ -695,10 +704,17 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
               modifier = Modifier.fillMaxSize(),
               showFloatingBottomBar = showFloatingBottomBar,
               mediaLayoutMode = mediaLayoutMode,
+              isFabExpanded = isFabExpanded.value,
+              onFabExpandedChange = { isFabExpanded.value = it },
             )
           }
         }
       }
+
+      FabScrollHelper.FabScrim(
+        visible = isFabExpanded.value && !quickPlayFabDirect,
+        onDismiss = { isFabExpanded.value = false },
+      )
 
       AnimatedVisibility(
         visible = showFloatingBottomBar,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryContent.kt
@@ -8,11 +8,15 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.text.format.DateUtils
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -29,10 +33,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -84,12 +92,14 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
@@ -101,6 +111,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.floor
 import kotlin.math.sqrt
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import app.gyrolet.mpvrx.R
@@ -120,6 +132,7 @@ import app.gyrolet.mpvrx.ui.browser.cards.PlaylistCard
 import app.gyrolet.mpvrx.ui.browser.components.BrowserBottomBar
 import app.gyrolet.mpvrx.ui.browser.components.BrowserTopBar
 import app.gyrolet.mpvrx.ui.browser.dialogs.AddToPlaylistDialog
+import app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper
 import app.gyrolet.mpvrx.ui.browser.dialogs.DeleteConfirmationDialog
 import app.gyrolet.mpvrx.ui.browser.dialogs.FolderSortDialog
 import app.gyrolet.mpvrx.ui.browser.dialogs.MusicSortDialog
@@ -290,6 +303,50 @@ fun MusicLibraryContent(
     playlistSelectionManager.clear()
   }
 
+  val songsListState = rememberLazyListState()
+  val songsGridState = rememberLazyGridState()
+  val albumsListState = rememberLazyListState()
+  val albumsGridState = rememberLazyGridState()
+  val artistsListState = rememberLazyListState()
+  val artistsGridState = rememberLazyGridState()
+  val playlistsListState = rememberLazyListState()
+  val playlistsGridState = rememberLazyGridState()
+
+  val activeTab = visibleTabs.getOrNull(pagerState.currentPage) ?: MusicTab.SONGS
+  val activeListState = when (activeTab) {
+    MusicTab.SONGS -> songsListState
+    MusicTab.ALBUMS -> albumsListState
+    MusicTab.ARTISTS -> artistsListState
+    MusicTab.PLAYLISTS -> playlistsListState
+    MusicTab.FOLDERS -> null
+  }
+  val activeGridState = when (activeTab) {
+    MusicTab.SONGS -> songsGridState
+    MusicTab.ALBUMS -> albumsGridState
+    MusicTab.ARTISTS -> artistsGridState
+    MusicTab.PLAYLISTS -> playlistsGridState
+    MusicTab.FOLDERS -> null
+  }
+
+  if (activeListState != null) {
+    FabScrollHelper.trackScrollForFabVisibility(
+      listState = activeListState,
+      gridState = if (viewMode == MusicViewMode.GRID) activeGridState else null,
+      isFabVisible = isFabVisible,
+      expanded = isFabExpanded.value,
+      onExpandedChange = { isFabExpanded.value = it },
+    )
+  }
+
+  LaunchedEffect(pagerState) {
+    snapshotFlow { pagerState.isScrollInProgress }
+      .distinctUntilChanged()
+      .filter { it }
+      .collect {
+        if (isFabExpanded.value) isFabExpanded.value = false
+      }
+  }
+
   val navBarState = NavigationBarState
   SideEffect {
     navBarState.updateSelectionState(
@@ -304,12 +361,14 @@ fun MusicLibraryContent(
     }
   }
 
-  BackHandler(enabled = isSearchActive || activeSelectionManager.isInSelectionMode) {
-    if (isSearchActive) {
-      isSearchActive = false
-      musicViewModel.setSearchQuery("")
-    } else if (activeSelectionManager.isInSelectionMode) {
-      activeSelectionManager.clear()
+  BackHandler(enabled = isSearchActive || activeSelectionManager.isInSelectionMode || (isFabExpanded.value && !quickPlayFabDirect)) {
+    when {
+      isFabExpanded.value && !quickPlayFabDirect -> isFabExpanded.value = false
+      isSearchActive -> {
+        isSearchActive = false
+        musicViewModel.setSearchQuery("")
+      }
+      activeSelectionManager.isInSelectionMode -> activeSelectionManager.clear()
     }
   }
 
@@ -503,6 +562,9 @@ fun MusicLibraryContent(
     floatingActionButton = {
       val isPlaylistsTab = visibleTabs.getOrNull(pagerState.currentPage) == MusicTab.PLAYLISTS
       val isFoldersTab = visibleTabs.getOrNull(pagerState.currentPage) == MusicTab.FOLDERS
+      val isFabShouldBeVisible =
+        showQuickPlayFab && !activeSelectionManager.isInSelectionMode && isFabVisible.value && !MainScreen.getPermissionDeniedState()
+
       if (isFoldersTab) {
         // FolderListScreen.MediaStoreFolderListContent renders its own FAB, skip ours.
       } else if (isPlaylistsTab) {
@@ -511,19 +573,20 @@ fun MusicLibraryContent(
           expanded = false,
           button = {
             ToggleFloatingActionButton(
-              modifier = Modifier.animateFloatingActionButton(
-                visible = showQuickPlayFab && !activeSelectionManager.isInSelectionMode && isFabVisible.value && !MainScreen.getPermissionDeniedState(),
-                alignment = Alignment.BottomEnd,
-              ),
+              modifier =
+                Modifier.animateFloatingActionButton(
+                  visible = isFabShouldBeVisible,
+                  alignment = Alignment.BottomEnd,
+                ),
               checked = false,
-              onCheckedChange = { showCreatePlaylistDialog = true }
+              onCheckedChange = { showCreatePlaylistDialog = true },
             ) {
               Icon(
                 imageVector = Icons.RoundedFilled.Add,
-                contentDescription = "New Playlist"
+                contentDescription = "New Playlist",
               )
             }
-          }
+          },
         ) { }
       } else if (songs.isNotEmpty()) {
         FloatingActionButtonMenu(
@@ -531,17 +594,19 @@ fun MusicLibraryContent(
           expanded = isFabExpanded.value && !quickPlayFabDirect,
           button = {
             TooltipBox(
-              positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                if (isFabExpanded.value && !quickPlayFabDirect) TooltipAnchorPosition.Start else TooltipAnchorPosition.Above
-              ),
+              positionProvider =
+                TooltipDefaults.rememberTooltipPositionProvider(
+                  if (isFabExpanded.value && !quickPlayFabDirect) TooltipAnchorPosition.Start else TooltipAnchorPosition.Above,
+                ),
               tooltip = { PlainTooltip { Text(stringResource(R.string.ui_toggle_menu)) } },
               state = rememberTooltipState(),
             ) {
               ToggleFloatingActionButton(
-                modifier = Modifier.animateFloatingActionButton(
-                  visible = showQuickPlayFab && !activeSelectionManager.isInSelectionMode && isFabVisible.value && !MainScreen.getPermissionDeniedState(),
-                  alignment = Alignment.BottomEnd,
-                ),
+                modifier =
+                  Modifier.animateFloatingActionButton(
+                    visible = isFabShouldBeVisible,
+                    alignment = Alignment.BottomEnd,
+                  ),
                 checked = isFabExpanded.value && !quickPlayFabDirect,
                 onCheckedChange = {
                   if (quickPlayFabDirect) {
@@ -585,7 +650,7 @@ fun MusicLibraryContent(
           }
         }
       }
-    }
+    },
   ) { innerPadding ->
     Box(
       modifier = Modifier
@@ -628,7 +693,9 @@ fun MusicLibraryContent(
                 onSongLongClick = { song ->
                   songSelectionManager.toggle(song)
                 },
-                selectionManager = songSelectionManager
+                selectionManager = songSelectionManager,
+                listState = songsListState,
+                gridState = songsGridState,
               )
 
               MusicTab.ALBUMS -> AlbumsTabContent(
@@ -645,7 +712,9 @@ fun MusicLibraryContent(
                 onAlbumLongClick = { album ->
                   albumSelectionManager.toggle(album)
                 },
-                selectionManager = albumSelectionManager
+                selectionManager = albumSelectionManager,
+                listState = albumsListState,
+                gridState = albumsGridState,
               )
 
               MusicTab.ARTISTS -> ArtistsTabContent(
@@ -662,7 +731,9 @@ fun MusicLibraryContent(
                 onArtistLongClick = { artist ->
                   artistSelectionManager.toggle(artist)
                 },
-                selectionManager = artistSelectionManager
+                selectionManager = artistSelectionManager,
+                listState = artistsListState,
+                gridState = artistsGridState,
               )
 
               MusicTab.PLAYLISTS -> PlaylistsTabContent(
@@ -681,6 +752,8 @@ fun MusicLibraryContent(
                   playlistSelectionManager.toggle(playlist)
                 },
                 selectionManager = playlistSelectionManager,
+                listState = playlistsListState,
+                gridState = playlistsGridState,
               )
 
               // Reuse the exact same folder-browsing screen Home uses for videos,
@@ -1093,6 +1166,11 @@ fun MusicLibraryContent(
           showAddToPlaylist = selectedTab != MusicTab.PLAYLISTS && selectedTab != MusicTab.FOLDERS,
           modifier = Modifier.align(Alignment.BottomCenter)
         )
+
+        FabScrollHelper.FabScrim(
+          visible = isFabExpanded.value && !quickPlayFabDirect,
+          onDismiss = { isFabExpanded.value = false },
+        )
     }
   }
 }
@@ -1193,7 +1271,9 @@ private fun SongsTabContent(
   coverArtSizeDp: Int = 48,
   onSongClick: (MusicSong) -> Unit,
   onSongLongClick: (MusicSong) -> Unit,
-  selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<MusicSong, Long>
+  selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<MusicSong, Long>,
+  listState: LazyListState = rememberLazyListState(),
+  gridState: LazyGridState = rememberLazyGridState(),
 ) {
   if (songs.isEmpty()) {
     EmptyMusicState(text = "No songs found")
@@ -1216,6 +1296,7 @@ private fun SongsTabContent(
   Column(modifier = Modifier.fillMaxSize()) {
     if (viewMode == MusicViewMode.GRID) {
       LazyVerticalGrid(
+        state = gridState,
         columns = GridCells.Adaptive(minSize = 145.dp),
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = navBarHeight + 16.dp),
@@ -1234,6 +1315,7 @@ private fun SongsTabContent(
       }
     } else {
       LazyColumn(
+        state = listState,
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = navBarHeight + 16.dp)
       ) {
@@ -1391,7 +1473,9 @@ private fun AlbumsTabContent(
   coverArtSizeDp: Int = 48,
   onAlbumClick: (MusicAlbum) -> Unit,
   onAlbumLongClick: (MusicAlbum) -> Unit,
-  selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<MusicAlbum, Long>
+  selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<MusicAlbum, Long>,
+  listState: LazyListState = rememberLazyListState(),
+  gridState: LazyGridState = rememberLazyGridState(),
 ) {
   if (albums.isEmpty()) {
     EmptyMusicState(text = "No albums found")
@@ -1401,6 +1485,7 @@ private fun AlbumsTabContent(
   val navBarHeight = LocalNavigationBarHeight.current.takeIf { it > 0.dp } ?: 88.dp
   if (viewMode == MusicViewMode.GRID) {
     LazyVerticalGrid(
+      state = gridState,
       columns = GridCells.Adaptive(minSize = 145.dp),
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = navBarHeight + 16.dp),
@@ -1418,6 +1503,7 @@ private fun AlbumsTabContent(
     }
   } else {
     LazyColumn(
+      state = listState,
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = navBarHeight + 16.dp)
     ) {
@@ -1610,7 +1696,9 @@ private fun ArtistsTabContent(
   coverArtSizeDp: Int = 48,
   onArtistClick: (MusicArtist) -> Unit,
   onArtistLongClick: (MusicArtist) -> Unit,
-  selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<MusicArtist, Long>
+  selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<MusicArtist, Long>,
+  listState: LazyListState = rememberLazyListState(),
+  gridState: LazyGridState = rememberLazyGridState(),
 ) {
   if (artists.isEmpty()) {
     EmptyMusicState(text = "No artists found")
@@ -1620,6 +1708,7 @@ private fun ArtistsTabContent(
   val navBarHeight = LocalNavigationBarHeight.current.takeIf { it > 0.dp } ?: 88.dp
   if (viewMode == MusicViewMode.GRID) {
     LazyVerticalGrid(
+      state = gridState,
       columns = GridCells.Adaptive(minSize = 160.dp),
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = navBarHeight + 16.dp),
@@ -1637,6 +1726,7 @@ private fun ArtistsTabContent(
     }
   } else {
     LazyColumn(
+      state = listState,
       modifier = Modifier.fillMaxSize(),
       contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = navBarHeight + 16.dp)
     ) {
@@ -2103,6 +2193,8 @@ private fun PlaylistsTabContent(
   onPlaylistClick: (PlaylistEntity) -> Unit,
   onPlaylistLongClick: (PlaylistEntity) -> Unit,
   selectionManager: app.gyrolet.mpvrx.ui.browser.selection.SelectionManager<PlaylistEntity, Long>,
+  listState: LazyListState = rememberLazyListState(),
+  gridState: LazyGridState = rememberLazyGridState(),
 ) {
   val playlistRepository: PlaylistRepository = koinInject()
 
@@ -2110,9 +2202,9 @@ private fun PlaylistsTabContent(
     value = withContext(Dispatchers.IO) {
       playlists.associate { playlist ->
         val items = playlistRepository.getPlaylistItems(playlist.id)
-        val artUris = items.mapNotNull { item ->
-          songs.find { s -> s.path == item.filePath }?.albumArtUri
-        }.distinct().take(4)
+        val artUris = items.take(4).mapNotNull { item ->
+          songs.firstOrNull { it.path == item.filePath }?.albumArtUri
+        }
         playlist.id to Pair(items.size, artUris)
       }
     }
@@ -2139,6 +2231,7 @@ private fun PlaylistsTabContent(
       val navBarHeight = LocalNavigationBarHeight.current.takeIf { it > 0.dp } ?: 88.dp
       if (viewMode == MusicViewMode.GRID) {
         LazyVerticalGrid(
+          state = gridState,
           columns = GridCells.Adaptive(minSize = 145.dp),
           modifier = Modifier.fillMaxSize(),
           contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = navBarHeight + 16.dp),
@@ -2162,6 +2255,7 @@ private fun PlaylistsTabContent(
         }
       } else {
         LazyColumn(
+          state = listState,
           modifier = Modifier.fillMaxSize(),
           contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = navBarHeight + 16.dp)
         ) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/recentlyplayed/RecentlyPlayedScreen.kt
@@ -14,6 +14,12 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import app.gyrolet.mpvrx.ui.browser.fab.FabScrollHelper
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -56,7 +62,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -223,6 +231,9 @@ object RecentlyPlayedScreen : Screen {
         )
       },
       floatingActionButton = {
+        val isFabShouldBeVisible =
+          showQuickPlayFab && !selectionManager.isInSelectionMode && isFabVisible.value && recentItems.isNotEmpty()
+
         FloatingActionButtonMenu(
           modifier =
             Modifier
@@ -252,7 +263,7 @@ object RecentlyPlayedScreen : Screen {
                 modifier =
                   Modifier
                     .animateFloatingActionButton(
-                      visible = showQuickPlayFab && !selectionManager.isInSelectionMode && isFabVisible.value,
+                      visible = isFabShouldBeVisible,
                       alignment = Alignment.BottomEnd,
                     ),
                 checked = isFabExpanded.value && !quickPlayFabDirect,
@@ -356,15 +367,18 @@ object RecentlyPlayedScreen : Screen {
         }
       },
     ) { padding ->
-      when {
-        !enableRecentlyPlayed -> {
-          Box(
-            modifier =
-              Modifier
-                .fillMaxSize()
-                .padding(padding),
-            contentAlignment = Alignment.Center,
-          ) {
+      Box(
+        modifier =
+          Modifier
+            .fillMaxSize()
+            .padding(padding),
+      ) {
+        when {
+          !enableRecentlyPlayed -> {
+            Box(
+              modifier = Modifier.fillMaxSize(),
+              contentAlignment = Alignment.Center,
+            ) {
             EmptyState(
               icon = Icons.RoundedFilled.History,
               title = stringResource(R.string.ui_recently_played_disabled),
@@ -375,10 +389,7 @@ object RecentlyPlayedScreen : Screen {
 
         isLoading && recentItems.isEmpty() -> {
           Box(
-            modifier =
-              Modifier
-                .fillMaxSize()
-                .padding(padding),
+            modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
           ) {
             CircularProgressIndicator(
@@ -390,10 +401,7 @@ object RecentlyPlayedScreen : Screen {
 
         recentItems.isEmpty() && !isLoading -> {
           Box(
-            modifier =
-              Modifier
-                .fillMaxSize()
-                .padding(padding),
+            modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
           ) {
             EmptyState(
@@ -428,7 +436,7 @@ object RecentlyPlayedScreen : Screen {
               // Navigate to playlist detail screen
               backStack.add(PlaylistDetailScreen(playlistItem.playlist.id))
             },
-            modifier = Modifier.padding(padding),
+            modifier = Modifier,
             isInSelectionMode = selectionManager.isInSelectionMode,
             listState = listState,
             gridState = gridState,
@@ -503,8 +511,14 @@ object RecentlyPlayedScreen : Screen {
         onDismiss = { showLinkDialog.value = false },
         onPlayLink = { url -> MediaUtils.playFile(url, context, "play_link") },
       )
+
+      FabScrollHelper.FabScrim(
+        visible = isFabExpanded.value && !quickPlayFabDirect,
+        onDismiss = { isFabExpanded.value = false },
+      )
     }
   }
+}
 }
 
 @Composable

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/videolist/VideoListScreen.kt
@@ -14,6 +14,7 @@ import android.os.Environment
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -387,6 +388,9 @@ data class VideoListScreen(
         val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
         val miniPlayerClearance = app.gyrolet.mpvrx.ui.browser.NavigationBarState.miniPlayerClearance
         if (sortedVideosWithInfo.isNotEmpty()) {
+          val isFabShouldBeVisible =
+            showQuickPlayFab && !selectionManager.isInSelectionMode && isFabVisible.value
+
           TooltipBox(
             positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
             tooltip = {
@@ -406,7 +410,7 @@ data class VideoListScreen(
                   .windowInsetsPadding(WindowInsets.systemBars)
                   .padding(bottom = navigationBarHeight + miniPlayerClearance)
                   .animateFloatingActionButton(
-                    visible = showQuickPlayFab && !selectionManager.isInSelectionMode && isFabVisible.value,
+                    visible = isFabShouldBeVisible,
                     alignment = Alignment.BottomEnd,
                   ),
               onClick = {
@@ -816,6 +820,8 @@ internal fun VideoListContent(
   mediaLayoutMode: app.gyrolet.mpvrx.preferences.MediaLayoutMode,
   isAudio: Boolean = false,
   musicCoverArtSize: Int = 48,
+  isFabExpanded: Boolean = false,
+  onFabExpandedChange: (Boolean) -> Unit = {},
 ) {
   val thumbnailRepository = koinInject<ThumbnailRepository>()
   val gesturePreferences = koinInject<GesturePreferences>()
@@ -1062,8 +1068,8 @@ internal fun VideoListContent(
           listState = listState,
           gridState = if (mediaLayoutMode == MediaLayoutMode.GRID) gridState else null,
           isFabVisible = isFabVisible,
-          expanded = false,
-          onExpandedChange = {},
+          expanded = isFabExpanded,
+          onExpandedChange = onFabExpandedChange,
         )
 
         val coroutineScope = rememberCoroutineScope()


### PR DESCRIPTION
- Add quick play preference support and resume action to Jellyfin FAB
- Reorder Jellyfin FAB menu items to Search, Play Random, Switch Server, Recently Played
- Introduce FabScrim overlay to absorb pointer gestures and auto-collapse FAB on outside press
- Prevent horizontal tab switching and list scrolling while FAB menu is open
- Wire scroll-based auto-hide and reveal to list/grid states across all browser tabs
- Fix double padding layout issue on RecentlyPlayedScreen

closes #454 