### PR TITLE
feat: add native on-player video clipping

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/AppearancePreferences.kt
@@ -77,7 +77,7 @@ class AppearancePreferences(
   val bottomRightControls =
     preferenceStore.getString(
       "bottom_right_controls",
-      "FRAME_NAVIGATION,VIDEO_ZOOM,PICTURE_IN_PICTURE,ASPECT_RATIO",
+      "FRAME_NAVIGATION,CLIP,VIDEO_ZOOM,PICTURE_IN_PICTURE,ASPECT_RATIO",
     )
 
   val bottomLeftControls =
@@ -89,11 +89,13 @@ class AppearancePreferences(
   val portraitBottomControls =
     preferenceStore.getString(
       "portrait_bottom_controls",
-      "CAST,SCREEN_ROTATION,DECODER,AUDIO_TRACK,SUBTITLES,BOOKMARKS_CHAPTERS,PLAYBACK_SPEED,BACKGROUND_PLAYBACK,REPEAT_MODE,SHUFFLE,VIDEO_ZOOM,FRAME_NAVIGATION,ASPECT_RATIO,PICTURE_IN_PICTURE,LOCK_CONTROLS,MORE_OPTIONS",
+      "CAST,SCREEN_ROTATION,DECODER,AUDIO_TRACK,SUBTITLES,BOOKMARKS_CHAPTERS,PLAYBACK_SPEED,BACKGROUND_PLAYBACK,REPEAT_MODE,SHUFFLE,VIDEO_ZOOM,FRAME_NAVIGATION,CLIP,ASPECT_RATIO,PICTURE_IN_PICTURE,LOCK_CONTROLS,MORE_OPTIONS",
     )
 
   private val castButtonMigrationComplete =
     preferenceStore.getBoolean("cast_button_migration_complete", false)
+  private val clipButtonMigrationComplete =
+    preferenceStore.getBoolean("clip_button_migration_complete", false)
 
   init {
     if (!castButtonMigrationComplete.get()) {
@@ -113,6 +115,25 @@ class AppearancePreferences(
         portraitBottomControls.set("CAST,${portraitBottomControls.get()}")
       }
       castButtonMigrationComplete.set(true)
+    }
+
+    if (!clipButtonMigrationComplete.get()) {
+      val landscapeButtons =
+        listOf(
+          topLeftControls.get(),
+          topRightControls.get(),
+          bottomRightControls.get(),
+          bottomLeftControls.get(),
+        ).flatMap { it.split(',') }
+          .map { it.trim().uppercase() }
+      if ("CLIP" !in landscapeButtons) {
+        bottomRightControls.set("${bottomRightControls.get()},CLIP")
+      }
+      val portraitButtons = portraitBottomControls.get().split(',').map { it.trim().uppercase() }
+      if ("CLIP" !in portraitButtons) {
+        portraitBottomControls.set("${portraitBottomControls.get()},CLIP")
+      }
+      clipButtonMigrationComplete.set(true)
     }
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerButton.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerButton.kt
@@ -37,6 +37,7 @@ enum class PlayerButton(
   LOCK_CONTROLS(Icons.RoundedFilled.LockOpen),
   AUDIO_TRACK(Icons.RoundedFilled.Audiotrack),
   SUBTITLES(Icons.RoundedFilled.Subtitles),
+  CLIP(Icons.RoundedFilled.ContentCut),
   MORE_OPTIONS(Icons.RoundedFilled.MoreVert),
   CURRENT_CHAPTER(Icons.RoundedFilled.Bookmarks), // <-- CHANGED ICON
   REPEAT_MODE(Icons.RoundedFilled.Repeat),
@@ -84,6 +85,7 @@ fun getPlayerButtonLabel(button: PlayerButton): String =
     PlayerButton.LOCK_CONTROLS -> stringResource(R.string.btn_label_lock)
     PlayerButton.AUDIO_TRACK -> stringResource(R.string.btn_label_audio)
     PlayerButton.SUBTITLES -> stringResource(R.string.btn_label_subtitles)
+    PlayerButton.CLIP -> stringResource(R.string.clip_action)
     PlayerButton.MORE_OPTIONS -> stringResource(R.string.btn_label_more)
     PlayerButton.CURRENT_CHAPTER -> stringResource(R.string.btn_label_chapter)
     PlayerButton.REPEAT_MODE -> stringResource(R.string.btn_label_repeat_mode)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/MiniPlayer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/MiniPlayer.kt
@@ -126,14 +126,15 @@ fun MiniPlayer(modifier: Modifier = Modifier) {
 
   val ext = (currentItem?.originalUri ?: currentItem?.title ?: "").fileExtension()
   val mimeIsAudio = currentItem?.mimeType?.startsWith("audio/", ignoreCase = true) == true
+  val mimeIsVideo = currentItem?.mimeType?.startsWith("video/", ignoreCase = true) == true
   val extIsAudio = ext in FileTypeUtils.AUDIO_EXTENSIONS
   val extIsVideo = ext in FileTypeUtils.VIDEO_EXTENSIONS
 
   val isAudioOnlyItem =
-    if (hasRealVideo || extIsVideo) {
-      false
-    } else {
-      mimeIsAudio || extIsAudio || hasAlbumArt || tracks.any { it.isAudio }
+    when {
+      mimeIsAudio || extIsAudio -> true
+      mimeIsVideo || extIsVideo || hasRealVideo -> false
+      else -> hasAlbumArt || tracks.any { it.isAudio }
     }
 
   val isMiniPlayerAllowed = isAudioOnlyItem || enableVideoMiniPlayer

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.gyrolet.mpvrx.database.entities.PlaylistEntity
 import app.gyrolet.mpvrx.database.repository.PlaylistRepository
+import app.gyrolet.mpvrx.ui.player.MediaPlaybackService
 import app.gyrolet.mpvrx.ui.player.PlaybackItem
 import app.gyrolet.mpvrx.ui.player.PlaybackSession
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
@@ -300,6 +301,11 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
     if (songList.isEmpty()) return
     val index = songList.indexOfFirst { it.id == song.id }.coerceAtLeast(0)
 
+    // The detached video service still owns the shared PlaybackSession until PlayerActivity starts.
+    // Mark the handoff before replacing the queue so its asynchronous onDestroy cannot stop the
+    // newly selected music item after the Activity has already taken over playback.
+    MediaPlaybackService.prepareForActivityHandoff()
+
     val queueItems = songList.map { item ->
       PlaybackItem.fromUri(
         uri = item.uri.toString(),
@@ -333,6 +339,9 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
     if (songsToPlay.isEmpty()) return
     val list = if (shuffle) songsToPlay.shuffled() else songsToPlay
     val firstSong = list.first()
+
+    // See playSong(): prevent a detached video service teardown from racing this audio launch.
+    MediaPlaybackService.prepareForActivityHandoff()
 
     val queueItems = list.map { item ->
       PlaybackItem.fromUri(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
@@ -301,10 +301,9 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
     if (songList.isEmpty()) return
     val index = songList.indexOfFirst { it.id == song.id }.coerceAtLeast(0)
 
-    // The detached video service still owns the shared PlaybackSession until PlayerActivity starts.
-    // Mark the handoff before replacing the queue so its asynchronous onDestroy cannot stop the
-    // newly selected music item after the Activity has already taken over playback.
-    MediaPlaybackService.prepareForActivityHandoff()
+    // This selects different media, so quiesce the detached service and mini-player renderer
+    // before publishing the audio queue. Same-item Activity handoff must remain lossless instead.
+    MediaPlaybackService.prepareForFreshPlaybackLaunch()
 
     val queueItems = songList.map { item ->
       PlaybackItem.fromUri(
@@ -340,8 +339,7 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
     val list = if (shuffle) songsToPlay.shuffled() else songsToPlay
     val firstSong = list.first()
 
-    // See playSong(): prevent a detached video service teardown from racing this audio launch.
-    MediaPlaybackService.prepareForActivityHandoff()
+    MediaPlaybackService.prepareForFreshPlaybackLaunch()
 
     val queueItems = list.map { item ->
       PlaybackItem.fromUri(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/icons/Icons.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/icons/Icons.kt
@@ -64,6 +64,7 @@ object Icons {
     val Close by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Close) }
     val CloudDownload by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Cloud_download) }
     val Code by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Code) }
+    val ContentCut by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Content_cut) }
     val ContentCopy by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Content_copy) }
     val ContentPaste by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Content_paste) }
     val CreateNewFolder by lazy(LazyThreadSafetyMode.NONE) { AppIcon(MaterialSymbols.RoundedFilled.Create_new_folder) }
@@ -300,6 +301,7 @@ object Icons {
     val Close get() = Shared.Close
     val CloudDownload get() = Shared.CloudDownload
     val Code get() = Shared.Code
+    val ContentCut get() = Shared.ContentCut
     val ContentCopy get() = Shared.ContentCopy
     val ContentPaste get() = Shared.ContentPaste
     val CreateNewFolder get() = Shared.CreateNewFolder

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/MediaPlaybackService.kt
@@ -165,6 +165,22 @@ class MediaPlaybackService :
       }
     }
 
+    /** Stops the detached owner before a foreground Activity replaces the current media. */
+    internal fun prepareForFreshPlaybackLaunch() {
+      activeInstance?.let { service ->
+        service.handingBackToActivity = true
+        service.abandonAudioOwnership()
+        runCatching { service.releaseMpvAccessBeforeShutdown() }
+          .onFailure { error -> Log.e(TAG, "Error releasing service before fresh playback", error) }
+      }
+      if (PlaybackSession.state.value.phase !in
+        setOf(PlaybackPhase.UNINITIALIZED, PlaybackPhase.IDLE, PlaybackPhase.STOPPING)
+      ) {
+        PlaybackSession.stop(clearQueue = false)
+      }
+      PlaybackSession.detachSurfaceForMediaReplacement()
+    }
+
     internal fun isActivityHandoffInProgress(): Boolean = activeInstance?.handingBackToActivity == true
 
     /** Releases every service-owned MPV access before an Activity destroys the global core. */

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -302,6 +302,18 @@ object PlaybackSession : MPVLib.EventObserver {
     }
   }
 
+  /** Releases a stale Activity/mini-player renderer before a different media item is published. */
+  internal fun detachSurfaceForMediaReplacement() {
+    nativeLock.withLock {
+      if (initialized && nativeCoreReady && _state.value.surfaceAttached) {
+        detachRendererSurfaceLocked()
+      } else {
+        attachedSurfaceOwner = null
+        if (_state.value.surfaceAttached) updateState { it.copy(surfaceAttached = false) }
+      }
+    }
+  }
+
   /**
    * Detaches only Android's renderer resources. Surface transitions are not media lifecycle events:
    * they must not change video-track selection or disturb the live demuxer/cache.
@@ -417,6 +429,7 @@ object PlaybackSession : MPVLib.EventObserver {
     runCatching { MPVLib.setPropertyBoolean("pause", true) }
     runCatching { MPVLib.setPropertyString("vo", "null") }
     runCatching { MPVLib.detachSurface() }
+    attachedSurfaceOwner = null
     runCatching { MPVLib.removeObserver(this) }
     runCatching { MPVLib.destroy() }
       .onFailure { error -> Log.e(TAG, "Failed to destroy libmpv", error) }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -1877,6 +1877,7 @@ class PlayerActivity :
     }
 
     reusingPlaybackSessionOnLaunch = false
+    MediaPlaybackService.prepareForFreshPlaybackLaunch()
 
     if (MediaPlaybackService.isRunning()) {
       Log.d(TAG, "Stopping detached service before replacing its media")

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipEditorUiState.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipEditorUiState.kt
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.gyrolet.mpvrx.ui.player.clip
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class ClipEditorRangeState(
+  val startSeconds: Float,
+  val endSeconds: Float?,
+)
+
+/** Visible Clip selection shared with the player seekbar. */
+object ClipEditorUiState {
+  private val _state = MutableStateFlow<ClipEditorRangeState?>(null)
+  val state: StateFlow<ClipEditorRangeState?> = _state.asStateFlow()
+
+  internal fun publish(startSeconds: Double, endSeconds: Double?) {
+    _state.value =
+      ClipEditorRangeState(
+        startSeconds = startSeconds.toFloat().coerceAtLeast(0f),
+        endSeconds = endSeconds?.toFloat()?.coerceAtLeast(0f),
+      )
+  }
+
+  internal fun clear() {
+    _state.value = null
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipExportManager.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipExportManager.kt
@@ -1,0 +1,327 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player.clip
+
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.media3.common.util.UnstableApi
+import app.gyrolet.mpvrx.data.network.proxy.NetworkStreamingProxy
+import app.gyrolet.mpvrx.domain.network.NetworkPlaybackUri
+import app.gyrolet.mpvrx.ui.player.PlaybackItem
+import app.gyrolet.mpvrx.ui.player.PlaybackSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+/** Crop coordinates in the video orientation visible to the user. */
+data class ClipCrop(
+  val x: Int,
+  val y: Int,
+  val width: Int,
+  val height: Int,
+  val rotation: Int,
+)
+
+data class ClipRequest(
+  val item: PlaybackItem,
+  val startSeconds: Double,
+  val endSeconds: Double,
+  val crop: ClipCrop? = null,
+)
+
+sealed interface ClipExportState {
+  data object Idle : ClipExportState
+
+  data class Exporting(
+    val progress: Float,
+    val cancelling: Boolean = false,
+  ) : ClipExportState
+
+  data class Success(
+    val uri: Uri,
+    val displayName: String,
+  ) : ClipExportState
+
+  data class Error(
+    val message: String,
+  ) : ClipExportState
+}
+
+/**
+ * Process-scoped Clip export worker.
+ *
+ * Playback remains owned by libmpv. Export is intentionally handled by Media3 Transformer so a
+ * bundled libmpv build without encoding mode can never fail Clip save during mpv_initialize().
+ */
+@OptIn(UnstableApi::class)
+object ClipExportManager {
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private val exporting = AtomicBoolean(false)
+  private val streamSequence = AtomicLong(0L)
+  private val _state = MutableStateFlow<ClipExportState>(ClipExportState.Idle)
+
+  val state: StateFlow<ClipExportState> = _state.asStateFlow()
+
+  fun export(
+    context: Context,
+    request: ClipRequest,
+  ): Boolean {
+    if (request.endSeconds <= request.startSeconds + MIN_CLIP_SECONDS) return false
+    if (!exporting.compareAndSet(false, true)) return false
+
+    // Capture the displayed/oriented frame size while this request still refers to the actively
+    // playing item. CropSelectionView reports coordinates in this same orientation.
+    val cropFrameSize =
+      request.crop?.let { crop ->
+        val sourceWidth = PlaybackSession.getPropertyInt("video-params/w") ?: 0
+        val sourceHeight = PlaybackSession.getPropertyInt("video-params/h") ?: 0
+        val rotation = ((crop.rotation % 360) + 360) % 360
+        if (rotation == 90 || rotation == 270) {
+          sourceHeight to sourceWidth
+        } else {
+          sourceWidth to sourceHeight
+        }
+      }
+
+    val appContext = context.applicationContext
+    _state.value = ClipExportState.Exporting(0f)
+    scope.launch {
+      var resolvedSource: ResolvedSource? = null
+      var temporaryOutput: File? = null
+      try {
+        resolvedSource = resolveSource(appContext, request.item)
+        temporaryOutput = createTemporaryOutput(appContext)
+
+        val error =
+          Media3ClipExporter.export(
+            context = appContext,
+            source = resolvedSource.uri,
+            output = temporaryOutput.absolutePath,
+            startSeconds = request.startSeconds,
+            endSeconds = request.endSeconds,
+            crop = request.crop,
+            cropFrameWidth = cropFrameSize?.first ?: 0,
+            cropFrameHeight = cropFrameSize?.second ?: 0,
+            headers = request.item.headers,
+            onProgress = { progress ->
+              val current = _state.value as? ClipExportState.Exporting
+              _state.value =
+                ClipExportState.Exporting(
+                  progress = progress.toFloat().coerceIn(0f, 1f),
+                  cancelling = current?.cancelling == true,
+                )
+            },
+          )
+
+        if (error != null) {
+          if (error == Media3ClipExporter.CANCELLED) {
+            _state.value = ClipExportState.Idle
+          } else {
+            _state.value = ClipExportState.Error(error)
+          }
+          return@launch
+        }
+
+        if (!temporaryOutput.exists() || temporaryOutput.length() <= 0L) {
+          error("Clip export finished without producing an output video")
+        }
+
+        val displayName = buildDisplayName(request.item)
+        val savedUri = saveToVideoLibrary(appContext, temporaryOutput, displayName)
+        temporaryOutput = null
+        _state.value = ClipExportState.Success(savedUri, displayName)
+      } catch (error: Throwable) {
+        _state.value =
+          ClipExportState.Error(
+            error.message?.takeIf { it.isNotBlank() } ?: "Unable to save this clip",
+          )
+      } finally {
+        resolvedSource?.close?.invoke()
+        temporaryOutput?.delete()
+        exporting.set(false)
+      }
+    }
+    return true
+  }
+
+  fun cancel() {
+    val current = _state.value as? ClipExportState.Exporting ?: return
+    _state.value = current.copy(cancelling = true)
+    Media3ClipExporter.cancel()
+  }
+
+  fun consumeTerminalState() {
+    if (_state.value is ClipExportState.Success || _state.value is ClipExportState.Error) {
+      _state.value = ClipExportState.Idle
+    }
+  }
+
+  private fun createTemporaryOutput(context: Context): File {
+    val directory = File(context.cacheDir, "clips").apply { mkdirs() }
+    return File.createTempFile("mpvrx-clip-", ".mp4", directory).apply { delete() }
+  }
+
+  private fun resolveSource(
+    context: Context,
+    item: PlaybackItem,
+  ): ResolvedSource {
+    val contentUri =
+      when {
+        item.originalUri.startsWith("content://", ignoreCase = true) -> item.originalUri
+        item.playableUri.startsWith("content://", ignoreCase = true) -> item.playableUri
+        else -> null
+      }
+
+    // Media3 understands content:// directly. Do not detach the Android descriptor into fd://;
+    // fd:// was only required by the removed native libmpv exporter.
+    if (contentUri != null) {
+      return ResolvedSource(uri = contentUri)
+    }
+
+    val networkReference =
+      NetworkPlaybackUri.parse(item.playableUri)
+        ?: item.networkSource?.let { source ->
+          NetworkPlaybackUri.parse(NetworkPlaybackUri.create(source.connectionId, source.relativePath))
+        }
+    if (networkReference != null) {
+      val proxy = NetworkStreamingProxy.getInstance()
+      val streamId = "clip-${streamSequence.incrementAndGet()}"
+      val uri =
+        proxy.registerStream(
+          streamId = streamId,
+          connectionId = networkReference.connectionId,
+          filePath = networkReference.path.value,
+          mimeType = item.mimeType ?: "application/octet-stream",
+        )
+      return ResolvedSource(
+        uri = uri,
+        close = { runCatching { proxy.unregisterStream(streamId) } },
+      )
+    }
+
+    val source = item.playableUri.ifBlank { item.originalUri }
+    if (source.startsWith("fd://", ignoreCase = true)) {
+      error("This video source can no longer be reopened for clipping")
+    }
+    return ResolvedSource(uri = source)
+  }
+
+  private fun buildDisplayName(item: PlaybackItem): String {
+    val base =
+      item.title
+        ?.substringBeforeLast('.')
+        ?.sanitizeFileName()
+        ?.takeIf { it.isNotBlank() }
+        ?: "MPVRX"
+    val stamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+    return "${base}_clip_$stamp.mp4"
+  }
+
+  private fun saveToVideoLibrary(
+    context: Context,
+    source: File,
+    displayName: String,
+  ): Uri {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      val resolver = context.contentResolver
+      val values =
+        ContentValues().apply {
+          put(MediaStore.Video.Media.DISPLAY_NAME, displayName)
+          put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
+          put(MediaStore.Video.Media.RELATIVE_PATH, "${Environment.DIRECTORY_MOVIES}/mpvRx/Clips")
+          put(MediaStore.Video.Media.IS_PENDING, 1)
+        }
+      val uri =
+        resolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, values)
+          ?: error("Unable to create a MediaStore entry for the clip")
+      try {
+        resolver.openOutputStream(uri, "w")?.use { output ->
+          source.inputStream().use { input -> input.copyTo(output) }
+        } ?: error("Unable to open the saved clip")
+        resolver.update(
+          uri,
+          ContentValues().apply { put(MediaStore.Video.Media.IS_PENDING, 0) },
+          null,
+          null,
+        )
+        source.delete()
+        return uri
+      } catch (error: Throwable) {
+        resolver.delete(uri, null, null)
+        throw error
+      }
+    }
+
+    // Android 8/9 still use the legacy public Movies directory. If the platform denies public
+    // storage access, fall back to the app's external Movies directory rather than losing output.
+    val publicResult =
+      runCatching {
+        val directory = File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES), "mpvRx/Clips")
+        check(directory.exists() || directory.mkdirs()) { "Unable to create Movies/mpvRx/Clips" }
+        val target = uniqueFile(directory, displayName)
+        source.copyTo(target)
+        source.delete()
+        MediaScannerConnection.scanFile(context, arrayOf(target.absolutePath), arrayOf("video/mp4"), null)
+        Uri.fromFile(target)
+      }
+    publicResult.getOrNull()?.let { return it }
+
+    val fallbackDirectory =
+      File(context.getExternalFilesDir(Environment.DIRECTORY_MOVIES) ?: context.filesDir, "Clips")
+        .apply { mkdirs() }
+    val fallback = uniqueFile(fallbackDirectory, displayName)
+    source.copyTo(fallback)
+    source.delete()
+    return Uri.fromFile(fallback)
+  }
+
+  private fun uniqueFile(
+    directory: File,
+    requestedName: String,
+  ): File {
+    val first = File(directory, requestedName)
+    if (!first.exists()) return first
+    val stem = requestedName.substringBeforeLast('.')
+    val extension = requestedName.substringAfterLast('.', "mp4")
+    var index = 2
+    while (true) {
+      val candidate = File(directory, "${stem}_$index.$extension")
+      if (!candidate.exists()) return candidate
+      index++
+    }
+  }
+
+  private data class ResolvedSource(
+    val uri: String,
+    val close: () -> Unit = {},
+  )
+
+  private fun String.sanitizeFileName(): String =
+    replace(Regex("[\\/:*?\"<>|\\p{Cntrl}]"), "_")
+      .trim()
+      .take(80)
+
+  private const val MIN_CLIP_SECONDS = 0.05
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipExportManager.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipExportManager.kt
@@ -21,8 +21,11 @@ import app.gyrolet.mpvrx.data.network.proxy.NetworkStreamingProxy
 import app.gyrolet.mpvrx.domain.network.NetworkPlaybackUri
 import app.gyrolet.mpvrx.ui.player.PlaybackItem
 import app.gyrolet.mpvrx.ui.player.PlaybackSession
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -82,6 +85,9 @@ object ClipExportManager {
   private val streamSequence = AtomicLong(0L)
   private val _state = MutableStateFlow<ClipExportState>(ClipExportState.Idle)
 
+  @Volatile
+  private var activeJob: Job? = null
+
   val state: StateFlow<ClipExportState> = _state.asStateFlow()
 
   fun export(
@@ -106,8 +112,8 @@ object ClipExportManager {
       }
 
     val appContext = context.applicationContext
-    _state.value = ClipExportState.Exporting(0f)
-    scope.launch {
+    lateinit var job: Job
+    job = scope.launch(start = CoroutineStart.LAZY) {
       var resolvedSource: ResolvedSource? = null
       var temporaryOutput: File? = null
       try {
@@ -136,11 +142,7 @@ object ClipExportManager {
           )
 
         if (error != null) {
-          if (error == Media3ClipExporter.CANCELLED) {
-            _state.value = ClipExportState.Idle
-          } else {
-            _state.value = ClipExportState.Error(error)
-          }
+          _state.value = ClipExportState.Error(error)
           return@launch
         }
 
@@ -152,6 +154,8 @@ object ClipExportManager {
         val savedUri = saveToVideoLibrary(appContext, temporaryOutput, displayName)
         temporaryOutput = null
         _state.value = ClipExportState.Success(savedUri, displayName)
+      } catch (error: CancellationException) {
+        throw error
       } catch (error: Throwable) {
         _state.value =
           ClipExportState.Error(
@@ -160,16 +164,27 @@ object ClipExportManager {
       } finally {
         resolvedSource?.close?.invoke()
         temporaryOutput?.delete()
-        exporting.set(false)
       }
     }
+    activeJob = job
+    job.invokeOnCompletion { error ->
+      if (activeJob === job) {
+        activeJob = null
+        exporting.set(false)
+        if (error is CancellationException && _state.value is ClipExportState.Exporting) {
+          _state.value = ClipExportState.Idle
+        }
+      }
+    }
+    _state.value = ClipExportState.Exporting(0f)
+    job.start()
     return true
   }
 
   fun cancel() {
     val current = _state.value as? ClipExportState.Exporting ?: return
     _state.value = current.copy(cancelling = true)
-    Media3ClipExporter.cancel()
+    activeJob?.cancel()
   }
 
   fun consumeTerminalState() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipOverlayView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipOverlayView.kt
@@ -18,6 +18,7 @@ import android.graphics.RectF
 import android.graphics.Typeface
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -25,6 +26,8 @@ import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -33,7 +36,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.IconButton
@@ -41,17 +47,29 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.RangeSlider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -65,16 +83,19 @@ import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerViewModel
 import app.gyrolet.mpvrx.ui.player.controls.components.panels.DraggablePanel
 import app.gyrolet.mpvrx.ui.theme.MpvrxTheme
+import app.gyrolet.mpvrx.ui.theme.spacing
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+
+private const val MIN_CLIP_SECONDS = 0.05
 
 private data class ClipPanelState(
-  val startTime: String = "--:--",
-  val endTime: String? = null,
+  val clipDuration: String? = null,
   val startSeconds: Float = 0f,
   val endSeconds: Float? = null,
   val durationSeconds: Float = 0f,
@@ -84,6 +105,7 @@ private data class ClipPanelState(
   val cancelling: Boolean = false,
   val progress: Int = 0,
   val panelActive: Boolean = false,
+  val cropActive: Boolean = false,
 )
 
 /**
@@ -99,6 +121,7 @@ class ClipOverlayView @JvmOverloads constructor(
   attrs: AttributeSet? = null,
 ) : FrameLayout(context, attrs) {
   private data class ClipDraft(
+    val itemId: String,
     var startSeconds: Double,
     var endSeconds: Double? = null,
     var crop: ClipCrop? = null,
@@ -111,13 +134,13 @@ class ClipOverlayView @JvmOverloads constructor(
   private var cropView: CropSelectionView? = null
   private var cropControls: ComposeView? = null
   private var pausedBeforeCrop = true
-  private var reopenPanelAfterCrop = true
   private var lastTerminalState: ClipExportState? = null
   private var bottomInset = 0
 
   private val pollState =
     object : Runnable {
       override fun run() {
+        clearDraftIfMediaChanged()
         updateExportState()
         postDelayed(this, STATE_POLL_MS)
       }
@@ -146,6 +169,10 @@ class ClipOverlayView @JvmOverloads constructor(
   override fun onDetachedFromWindow() {
     removeCallbacks(pollState)
     if (cropView != null) exitCropMode(keepSelection = false)
+    draft = null
+    ClipEditorUiState.clear()
+    panelState = ClipPanelState()
+    panelView.visibility = GONE
     super.onDetachedFromWindow()
   }
 
@@ -162,57 +189,8 @@ class ClipOverlayView @JvmOverloads constructor(
   override fun onTouchEvent(event: MotionEvent): Boolean =
     if (cropView != null) true else super.onTouchEvent(event)
 
-  /** Opens the compact Clip editor from a long-press on the player control. */
-  fun openClip(cropImmediately: Boolean = false) {
-    beginClip(cropImmediately)
-  }
-
-  /** Marks the current playback position as the quick Clip start without opening the editor. */
-  fun markStartAtCurrent() {
-    if (PlaybackSession.state.value.currentItem == null) {
-      toast(R.string.clip_video_unavailable)
-      return
-    }
-    val current = currentPosition() ?: return
-    val active = draft ?: ClipDraft(startSeconds = current, endSeconds = null).also { draft = it }
-    active.startSeconds = current
-    if ((active.endSeconds ?: Double.POSITIVE_INFINITY) <= current + MIN_CLIP_SECONDS) {
-      active.endSeconds = null
-    }
-    // Quick Start behaves like A/B Loop point A: update the range without hiding player controls.
-    refreshDraftUi()
-  }
-
-  /** Marks the current playback position as the quick Clip end without opening the editor. */
-  fun markEndAtCurrent() {
-    if (PlaybackSession.state.value.currentItem == null) {
-      toast(R.string.clip_video_unavailable)
-      return
-    }
-    val current = currentPosition() ?: return
-    val active =
-      draft ?: ClipDraft(
-        startSeconds = (current - DEFAULT_CLIP_SECONDS).coerceAtLeast(0.0),
-        endSeconds = null,
-      ).also { draft = it }
-    if (current <= active.startSeconds + MIN_CLIP_SECONDS) {
-      toast(R.string.clip_invalid_range)
-      return
-    }
-    active.endSeconds = current
-    // Quick End behaves like A/B Loop point B: update the range without hiding player controls.
-    refreshDraftUi()
-  }
-
-  /** Opens only crop UI; Done/Cancel returns directly to normal player controls. */
-  fun openCrop() {
-    if (PlaybackSession.state.value.currentItem == null) {
-      toast(R.string.clip_video_unavailable)
-      return
-    }
-    ensureDraft()
-    refreshDraftUi()
-    enterCropMode(reopenEditorAfterCrop = false)
+  fun openClip() {
+    beginClip()
   }
 
   private fun playerViewModel(): PlayerViewModel? {
@@ -231,9 +209,12 @@ class ClipOverlayView @JvmOverloads constructor(
           ClipEditorPanel(
             state = panelState,
             onRangeChange = ::updateClipRange,
+            onStartTimeChange = ::updateClipStart,
+            onEndTimeChange = ::updateClipEnd,
             onMarkStart = ::markClipStart,
             onMarkEnd = ::markClipEnd,
             onCrop = ::enterCropMode,
+            onCropCancel = { exitCropMode(keepSelection = false) },
             onCancel = ::cancelOrClose,
             onSave = ::saveOrCancelExport,
           )
@@ -246,7 +227,7 @@ class ClipOverlayView @JvmOverloads constructor(
     )
   }
 
-  private fun beginClip(cropImmediately: Boolean) {
+  private fun beginClip() {
     if (PlaybackSession.state.value.currentItem == null) {
       toast(R.string.clip_video_unavailable)
       return
@@ -259,19 +240,18 @@ class ClipOverlayView @JvmOverloads constructor(
       return
     }
 
-    ensureDraft()
+    ensureDraft() ?: return
     refreshDraftUi()
     panelState = panelState.copy(panelActive = true)
     panelView.visibility = VISIBLE
 
     // Keep the seekbar visible while the draggable editor is open, without covering the video in controls.
     playerViewModel()?.autoHideControls()
-
-    if (cropImmediately) enterCropMode()
   }
 
-  private fun ensureDraft(): ClipDraft {
-    draft?.let { return it }
+  private fun ensureDraft(): ClipDraft? {
+    val itemId = PlaybackSession.state.value.currentItem?.stableId ?: return null
+    draft?.takeIf { it.itemId == itemId }?.let { return it }
 
     val duration = mediaDurationSeconds()
     var start = (currentPosition() ?: 0.0).coerceAtLeast(0.0)
@@ -286,6 +266,7 @@ class ClipOverlayView @JvmOverloads constructor(
       }
 
     return ClipDraft(
+      itemId = itemId,
       startSeconds = start,
       endSeconds = end.coerceAtLeast(start + MIN_CLIP_SECONDS),
     ).also {
@@ -299,7 +280,7 @@ class ClipOverlayView @JvmOverloads constructor(
     end: Float,
     preview: Float,
   ) {
-    val active = ensureDraft()
+    val active = ensureDraft() ?: return
     val duration = mediaDurationSeconds().takeIf { it > MIN_CLIP_SECONDS }
     val maxEnd = duration?.toFloat() ?: maxOf(end, start + 0.05f)
     val safeStart = start.coerceIn(0f, (maxEnd - 0.05f).coerceAtLeast(0f))
@@ -314,9 +295,19 @@ class ClipOverlayView @JvmOverloads constructor(
     playerViewModel()?.autoHideControls()
   }
 
+  private fun updateClipStart(seconds: Float) {
+    val end = ensureDraft()?.endSeconds?.toFloat() ?: return
+    updateClipRange(seconds, end, seconds)
+  }
+
+  private fun updateClipEnd(seconds: Float) {
+    val start = ensureDraft()?.startSeconds?.toFloat() ?: return
+    updateClipRange(start, seconds, seconds)
+  }
+
   private fun markClipStart() {
     val current = currentPosition() ?: return
-    val active = ensureDraft()
+    val active = ensureDraft() ?: return
     active.startSeconds = current
     if ((active.endSeconds ?: Double.POSITIVE_INFINITY) <= current + MIN_CLIP_SECONDS) {
       active.endSeconds = null
@@ -326,7 +317,7 @@ class ClipOverlayView @JvmOverloads constructor(
   }
 
   private fun markClipEnd() {
-    val active = ensureDraft()
+    val active = ensureDraft() ?: return
     val current = currentPosition() ?: return
     if (current <= active.startSeconds + MIN_CLIP_SECONDS) {
       toast(R.string.clip_invalid_range)
@@ -348,7 +339,12 @@ class ClipOverlayView @JvmOverloads constructor(
     val active = draft ?: return
     val end = active.endSeconds
     val item = PlaybackSession.state.value.currentItem
-    if (end == null || end <= active.startSeconds + MIN_CLIP_SECONDS || item == null) {
+    if (item == null || item.stableId != active.itemId) {
+      closeDraft()
+      toast(R.string.clip_video_unavailable)
+      return
+    }
+    if (end == null || end <= active.startSeconds + MIN_CLIP_SECONDS) {
       toast(R.string.clip_invalid_range)
       return
     }
@@ -386,13 +382,8 @@ class ClipOverlayView @JvmOverloads constructor(
   }
 
   private fun enterCropMode() {
-    enterCropMode(reopenEditorAfterCrop = true)
-  }
-
-  private fun enterCropMode(reopenEditorAfterCrop: Boolean) {
     if (cropView != null) return
-    this.reopenPanelAfterCrop = reopenEditorAfterCrop
-    val active = ensureDraft()
+    val active = ensureDraft() ?: return
     val sourceWidth = PlaybackSession.getPropertyInt("video-params/w") ?: 0
     val sourceHeight = PlaybackSession.getPropertyInt("video-params/h") ?: 0
     if (sourceWidth <= 0 || sourceHeight <= 0) {
@@ -408,7 +399,7 @@ class ClipOverlayView @JvmOverloads constructor(
     pausedBeforeCrop = PlaybackSession.getPropertyBoolean("pause") ?: true
     if (!pausedBeforeCrop) PlaybackSession.setPropertyBoolean("pause", true)
 
-    panelState = panelState.copy(panelActive = false)
+    panelState = panelState.copy(panelActive = false, cropActive = true)
     panelView.visibility = GONE
     val selector =
       CropSelectionView(
@@ -419,6 +410,7 @@ class ClipOverlayView @JvmOverloads constructor(
         displayHeight = outputHeight,
         rotation = rotation,
         initialCrop = active.crop,
+        onSelectionChanged = ::positionCropControls,
       )
     cropView = selector
     addView(selector, LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
@@ -427,18 +419,19 @@ class ClipOverlayView @JvmOverloads constructor(
     cropControls = controls
     addView(
       controls,
-      LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.BOTTOM).apply {
-        leftMargin = dp(8)
-        rightMargin = dp(8)
-        bottomMargin = bottomInset + dp(24)
-      },
+      LayoutParams(
+        dp(CROP_PILL_WIDTH_DP),
+        dp(CROP_PILL_HEIGHT_DP),
+        Gravity.START or Gravity.TOP,
+      ),
     )
+    controls.post { positionCropControls(selector.selectionBounds()) }
   }
 
   private fun buildCropControls(selector: CropSelectionView): ComposeView =
     ComposeView(context).apply {
       isClickable = true
-      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
       setContent {
         MpvrxTheme {
           ClipCropControls(
@@ -459,12 +452,14 @@ class ClipOverlayView @JvmOverloads constructor(
     }
     removeView(selector)
     cropView = null
-    cropControls?.let(::removeView)
+    cropControls?.let { controls ->
+      controls.disposeComposition()
+      removeView(controls)
+    }
     cropControls = null
     if (!pausedBeforeCrop) PlaybackSession.setPropertyBoolean("pause", false)
-    val reopenPanel = draft != null && reopenPanelAfterCrop
-    reopenPanelAfterCrop = true
-    panelState = panelState.copy(panelActive = reopenPanel)
+    val reopenPanel = draft != null
+    panelState = panelState.copy(panelActive = reopenPanel, cropActive = false)
     panelView.visibility = if (reopenPanel) VISIBLE else GONE
     refreshDraftUi()
     if (reopenPanel) {
@@ -519,14 +514,26 @@ class ClipOverlayView @JvmOverloads constructor(
     }
   }
 
+  private fun clearDraftIfMediaChanged() {
+    val active = draft ?: return
+    if (ClipExportManager.state.value is ClipExportState.Exporting) return
+    if (PlaybackSession.state.value.currentItem?.stableId == active.itemId) return
+
+    draft = null
+    if (cropView != null) exitCropMode(keepSelection = false)
+    ClipEditorUiState.clear()
+    panelState = ClipPanelState()
+    panelView.visibility = GONE
+    playerViewModel()?.showControls()
+  }
+
   private fun refreshDraftUi() {
     val active = draft
     if (active == null) {
       ClipEditorUiState.clear()
       panelState =
         panelState.copy(
-          startTime = "--:--",
-          endTime = null,
+          clipDuration = null,
           startSeconds = 0f,
           endSeconds = null,
           durationSeconds = 0f,
@@ -540,8 +547,7 @@ class ClipOverlayView @JvmOverloads constructor(
     ClipEditorUiState.publish(active.startSeconds, active.endSeconds)
     panelState =
       panelState.copy(
-        startTime = formatTime(active.startSeconds),
-        endTime = active.endSeconds?.let(::formatTime),
+        clipDuration = active.endSeconds?.let { formatTime((it - active.startSeconds).coerceAtLeast(0.0)) },
         startSeconds = active.startSeconds.toFloat(),
         endSeconds = active.endSeconds?.toFloat(),
         durationSeconds = duration,
@@ -553,10 +559,34 @@ class ClipOverlayView @JvmOverloads constructor(
   }
 
   private fun updateOverlayMargins() {
-    (cropControls?.layoutParams as? LayoutParams)?.let { params ->
-      params.bottomMargin = bottomInset + dp(24)
-      cropControls?.layoutParams = params
-    }
+    cropView?.selectionBounds()?.let(::positionCropControls)
+  }
+
+  private fun positionCropControls(bounds: RectF) {
+    val controls = cropControls ?: return
+    val pillWidth = dp(CROP_PILL_WIDTH_DP)
+    val pillHeight = dp(CROP_PILL_HEIGHT_DP)
+    val inset = dp(10).toFloat()
+    val handleClearance = dp(38).toFloat()
+    val edgeInset = dp(8).toFloat()
+
+    val desiredX =
+      if (bounds.width() >= pillWidth + handleClearance + inset) {
+        bounds.right - pillWidth - handleClearance
+      } else {
+        bounds.centerX() - pillWidth / 2f
+      }
+    val desiredY =
+      if (bounds.height() >= pillHeight + handleClearance + inset) {
+        bounds.bottom - pillHeight - handleClearance
+      } else {
+        bounds.centerY() - pillHeight / 2f
+      }
+    val maxX = (width - pillWidth).toFloat().minus(edgeInset).coerceAtLeast(edgeInset)
+    val maxY =
+      (height - bottomInset - pillHeight).toFloat().minus(edgeInset).coerceAtLeast(edgeInset)
+    controls.x = desiredX.coerceIn(edgeInset, maxX)
+    controls.y = desiredY.coerceIn(edgeInset, maxY)
   }
 
   private fun mediaDurationSeconds(): Double =
@@ -592,8 +622,9 @@ class ClipOverlayView @JvmOverloads constructor(
   companion object {
     private const val OVERLAY_TAG = "mpvrx_clip_overlay"
     private const val STATE_POLL_MS = 250L
-    private const val MIN_CLIP_SECONDS = 0.05
     private const val DEFAULT_CLIP_SECONDS = 10.0
+    private const val CROP_PILL_WIDTH_DP = 97
+    private const val CROP_PILL_HEIGHT_DP = 48
 
     /** Attaches the Clip editor above the player at runtime; no player_layout.xml host is needed. */
     internal fun ensureAttached(activity: PlayerActivity): ClipOverlayView {
@@ -618,132 +649,206 @@ class ClipOverlayView @JvmOverloads constructor(
 private fun ClipEditorPanel(
   state: ClipPanelState,
   onRangeChange: (Float, Float, Float) -> Unit,
+  onStartTimeChange: (Float) -> Unit,
+  onEndTimeChange: (Float) -> Unit,
   onMarkStart: () -> Unit,
   onMarkEnd: () -> Unit,
   onCrop: () -> Unit,
+  onCropCancel: () -> Unit,
   onCancel: () -> Unit,
   onSave: () -> Unit,
 ) {
+  var startTimeValid by remember { mutableStateOf(true) }
+  var endTimeValid by remember { mutableStateOf(true) }
   BackHandler(enabled = state.panelActive, onBack = onCancel)
+  BackHandler(enabled = state.cropActive, onBack = onCropCancel)
 
   DraggablePanel(
     header = {
       Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .padding(horizontal = MaterialTheme.spacing.medium)
+            .padding(top = MaterialTheme.spacing.small),
       ) {
         AppIcon(
-imageVector = Icons.RoundedFilled.ContentCut,
-contentDescription = null,
-tint = MaterialTheme.colorScheme.primary,
-modifier = Modifier.size(20.dp),
+          imageVector = Icons.RoundedFilled.ContentCut,
+          contentDescription = null,
+          tint = MaterialTheme.colorScheme.primary,
+          modifier = Modifier.size(22.dp),
         )
         Text(
-text = stringResource(R.string.clip_action),
-style = MaterialTheme.typography.titleMedium,
-modifier = Modifier.padding(start = 8.dp),
+          text = stringResource(R.string.clip_action),
+          style = MaterialTheme.typography.titleLarge,
+          modifier = Modifier.padding(start = 10.dp),
         )
         Spacer(Modifier.weight(1f))
         IconButton(onClick = onCancel) {
-AppIcon(
-  imageVector = Icons.RoundedFilled.Close,
-  contentDescription = stringResource(R.string.clip_cancel),
-  modifier = Modifier.size(24.dp),
-)
+          AppIcon(
+            imageVector = Icons.RoundedFilled.Close,
+            contentDescription = stringResource(R.string.clip_cancel),
+            modifier = Modifier.size(24.dp),
+          )
         }
       }
     },
   ) {
-    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-      Row(modifier = Modifier.fillMaxWidth()) {
-        ClipInfoPill(
-text = stringResource(R.string.clip_start_time, state.startTime),
-modifier = Modifier.weight(1f),
+    Column(
+      modifier = Modifier.padding(MaterialTheme.spacing.medium),
+      verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.medium),
+    ) {
+      val end = state.endSeconds
+      val duration = state.durationSeconds
+      val maxTime = duration.takeIf { it > MIN_CLIP_SECONDS.toFloat() } ?: Float.MAX_VALUE
+      val maxStart = ((end ?: maxTime) - MIN_CLIP_SECONDS.toFloat()).coerceAtLeast(0f)
+      val minEnd = (state.startSeconds + MIN_CLIP_SECONDS.toFloat()).coerceAtMost(maxTime)
+
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        ClipTimeField(
+          label = stringResource(R.string.clip_start_short),
+          seconds = state.startSeconds,
+          minSeconds = 0f,
+          maxSeconds = maxStart,
+          enabled = !state.exporting,
+          onCommit = onStartTimeChange,
+          onValidityChange = { startTimeValid = it },
+          modifier = Modifier.weight(1f),
         )
-        ClipInfoPill(
-text = state.endTime?.let { stringResource(R.string.clip_end_time, it) }
-  ?: stringResource(R.string.clip_end_not_set),
-modifier = Modifier.weight(1f).padding(start = 8.dp),
+        ClipTimeField(
+          label = stringResource(R.string.clip_end_short),
+          seconds = state.endSeconds,
+          minSeconds = minEnd,
+          maxSeconds = maxTime,
+          enabled = !state.exporting,
+          onCommit = onEndTimeChange,
+          onValidityChange = { endTimeValid = it },
+          modifier = Modifier.weight(1f),
         )
       }
 
-      val end = state.endSeconds
-      val duration = state.durationSeconds
       if (end != null && duration > 0.05f) {
         val start = state.startSeconds.coerceIn(0f, duration)
         val safeEnd = end.coerceIn(start + 0.05f, duration)
+        val rangeDescription = stringResource(R.string.clip_options)
         RangeSlider(
-value = start..safeEnd,
-onValueChange = { range ->
-  val startDelta = abs(range.start - start)
-  val endDelta = abs(range.endInclusive - safeEnd)
-  val preview = if (startDelta >= endDelta) range.start else range.endInclusive
-  onRangeChange(range.start, range.endInclusive, preview)
-},
-valueRange = 0f..duration,
-enabled = !state.exporting,
-modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+          value = start..safeEnd,
+          onValueChange = { range ->
+            val startDelta = abs(range.start - start)
+            val endDelta = abs(range.endInclusive - safeEnd)
+            val preview = if (startDelta >= endDelta) range.start else range.endInclusive
+            onRangeChange(range.start, range.endInclusive, preview)
+          },
+          valueRange = 0f..duration,
+          enabled = !state.exporting,
+          modifier = Modifier.fillMaxWidth().semantics { contentDescription = rangeDescription },
         )
       }
 
-      Text(
-        text = state.crop?.let { stringResource(R.string.clip_crop_size, it.width, it.height) }
-?: stringResource(R.string.clip_crop_full_frame),
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = 2.dp),
-      )
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        ClipMetadata(
+          icon = Icons.RoundedFilled.Timer,
+          text = state.clipDuration ?: "--:--",
+          modifier = Modifier.weight(0.7f),
+        )
+        ClipMetadata(
+          icon = Icons.RoundedFilled.AspectRatio,
+          text =
+            state.crop?.let { stringResource(R.string.clip_crop_size, it.width, it.height) }
+              ?: stringResource(R.string.clip_crop_full_frame),
+          modifier = Modifier.weight(1.3f),
+        )
+      }
 
-      Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-        FilledTonalButton(onClick = onMarkStart, enabled = !state.exporting, modifier = Modifier.weight(1f)) {
-Text(stringResource(R.string.clip_start_short), maxLines = 1)
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        FilledTonalButton(
+          onClick = onMarkStart,
+          enabled = !state.exporting,
+          modifier = Modifier.weight(1f).height(48.dp),
+        ) {
+          AppIcon(Icons.RoundedFilled.SkipPrevious, contentDescription = null, modifier = Modifier.size(18.dp))
+          Spacer(Modifier.width(8.dp))
+          Text(stringResource(R.string.clip_start_short), maxLines = 1)
         }
         FilledTonalButton(
-onClick = onCrop,
-enabled = !state.exporting,
-modifier = Modifier.weight(1f).padding(horizontal = 6.dp),
+          onClick = onMarkEnd,
+          enabled = !state.exporting,
+          modifier = Modifier.weight(1f).height(48.dp),
         ) {
-Text(stringResource(R.string.clip_crop), maxLines = 1)
-        }
-        FilledTonalButton(onClick = onMarkEnd, enabled = !state.exporting, modifier = Modifier.weight(1f)) {
-Text(stringResource(R.string.clip_end_short), maxLines = 1)
+          AppIcon(Icons.RoundedFilled.SkipNext, contentDescription = null, modifier = Modifier.size(18.dp))
+          Spacer(Modifier.width(8.dp))
+          Text(stringResource(R.string.clip_end_short), maxLines = 1)
         }
       }
 
-      if (state.exporting) {
-        LinearProgressIndicator(
-progress = { state.progress / 100f },
-modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-        )
-        Text(
-text = if (state.cancelling) stringResource(R.string.clip_cancelling)
-  else stringResource(R.string.clip_exporting, state.progress),
-style = MaterialTheme.typography.bodySmall,
-color = MaterialTheme.colorScheme.onSurfaceVariant,
-modifier = Modifier.padding(top = 4.dp),
-        )
+      OutlinedButton(
+        onClick = onCrop,
+        enabled = !state.exporting,
+        modifier = Modifier.fillMaxWidth().height(48.dp),
+      ) {
+        AppIcon(Icons.RoundedFilled.AspectRatio, contentDescription = null, modifier = Modifier.size(19.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(stringResource(R.string.clip_crop))
       }
 
       if (state.exporting) {
-        Button(
-onClick = onSave,
-enabled = !state.cancelling,
-modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+          LinearProgressIndicator(
+            progress = { state.progress / 100f },
+            modifier = Modifier.fillMaxWidth(),
+          )
+          Text(
+            text =
+              if (state.cancelling) {
+                stringResource(R.string.clip_cancelling)
+              } else {
+                stringResource(R.string.clip_exporting, state.progress)
+              },
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+        OutlinedButton(
+          onClick = onSave,
+          enabled = !state.cancelling,
+          modifier = Modifier.fillMaxWidth().height(48.dp),
         ) {
-Text(stringResource(R.string.clip_cancel))
+          AppIcon(Icons.RoundedFilled.Close, contentDescription = null, modifier = Modifier.size(18.dp))
+          Spacer(Modifier.width(8.dp))
+          Text(stringResource(R.string.clip_cancel))
         }
       } else {
-        Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-OutlinedButton(onClick = onCancel, modifier = Modifier.weight(1f)) {
-  Text(stringResource(R.string.clip_cancel))
-}
-Button(
-  onClick = onSave,
-  enabled = state.canSave,
-  modifier = Modifier.weight(1f).padding(start = 8.dp),
-) {
-  Text(stringResource(R.string.clip_save))
-}
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          TextButton(
+            onClick = onCancel,
+            modifier = Modifier.weight(1f).height(48.dp),
+          ) {
+            Text(stringResource(R.string.clip_cancel))
+          }
+          Button(
+            onClick = onSave,
+            enabled = state.canSave && startTimeValid && endTimeValid,
+            modifier = Modifier.weight(1.4f).height(48.dp),
+          ) {
+            AppIcon(Icons.RoundedFilled.ContentCut, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.clip_save), maxLines = 1)
+          }
         }
       }
     }
@@ -751,20 +856,131 @@ Button(
 }
 
 @Composable
-private fun ClipInfoPill(
+private fun ClipTimeField(
+  label: String,
+  seconds: Float?,
+  minSeconds: Float,
+  maxSeconds: Float,
+  enabled: Boolean,
+  onCommit: (Float) -> Unit,
+  onValidityChange: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var text by remember { mutableStateOf(seconds?.let(::formatEditableTime).orEmpty()) }
+  var focused by remember { mutableStateOf(false) }
+  val focusManager = LocalFocusManager.current
+
+  LaunchedEffect(seconds, minSeconds, maxSeconds, focused) {
+    if (!focused) {
+      text = seconds?.let(::formatEditableTime).orEmpty()
+      onValidityChange(seconds?.let { it in minSeconds..maxSeconds } == true)
+    }
+  }
+
+  fun commit() {
+    val parsed = parseClipTime(text)?.takeIf { it in minSeconds..maxSeconds }
+    if (parsed != null) onCommit(parsed)
+    text = parsed?.let(::formatEditableTime) ?: seconds?.let(::formatEditableTime).orEmpty()
+    onValidityChange(parsed != null || seconds?.let { it in minSeconds..maxSeconds } == true)
+  }
+
+  OutlinedTextField(
+    value = text,
+    onValueChange = { candidate ->
+      if (candidate.length <= 12 && candidate.all { it.isDigit() || it == ':' || it == '.' }) {
+        text = candidate
+        val parsed = parseClipTime(candidate)?.takeIf { it in minSeconds..maxSeconds }
+        onValidityChange(parsed != null)
+        parsed?.let(onCommit)
+      }
+    },
+    enabled = enabled,
+    label = { Text(label) },
+    placeholder = { Text("00:00.000") },
+    textStyle = MaterialTheme.typography.titleMedium.copy(textAlign = TextAlign.Center),
+    singleLine = true,
+    isError =
+      text.isNotBlank() &&
+        parseClipTime(text)?.let { it in minSeconds..maxSeconds } != true,
+    keyboardOptions =
+      KeyboardOptions(
+        keyboardType = KeyboardType.Ascii,
+        imeAction = ImeAction.Done,
+      ),
+    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+    modifier =
+      modifier.onFocusChanged { state ->
+        val lostFocus = focused && !state.isFocused
+        focused = state.isFocused
+        if (lostFocus) commit()
+      },
+  )
+}
+
+private fun parseClipTime(value: String): Float? {
+  val parts = value.trim().split(':')
+  if (parts.size !in 1..3 || parts.any(String::isBlank)) return null
+  val numbers =
+    parts.mapIndexed { index, part ->
+      if (index == parts.lastIndex) {
+        part.toDoubleOrNull() ?: return null
+      } else {
+        part.toLongOrNull()?.toDouble() ?: return null
+      }
+    }
+  if (numbers.any { it < 0.0 || !it.isFinite() }) return null
+
+  val seconds =
+    when (numbers.size) {
+      1 -> numbers[0]
+      2 -> {
+        if (numbers[1] >= 60.0) return null
+        numbers[0] * 60.0 + numbers[1]
+      }
+      else -> {
+        if (numbers[1] >= 60.0 || numbers[2] >= 60.0) return null
+        numbers[0] * 3600.0 + numbers[1] * 60.0 + numbers[2]
+      }
+    }
+  return seconds.takeIf { it <= Float.MAX_VALUE }?.toFloat()
+}
+
+private fun formatEditableTime(seconds: Float): String {
+  val totalMillis = (seconds.coerceAtLeast(0f) * 1000f).roundToLong()
+  val hours = totalMillis / 3_600_000L
+  val minutes = (totalMillis / 60_000L) % 60L
+  val wholeSeconds = (totalMillis / 1000L) % 60L
+  val millis = totalMillis % 1000L
+  return if (hours > 0) {
+    "%d:%02d:%02d.%03d".format(Locale.US, hours, minutes, wholeSeconds, millis)
+  } else {
+    "%02d:%02d.%03d".format(Locale.US, minutes, wholeSeconds, millis)
+  }
+}
+
+@Composable
+private fun ClipMetadata(
+  icon: app.gyrolet.mpvrx.ui.icons.AppIcon,
   text: String,
   modifier: Modifier = Modifier,
 ) {
-  Surface(
+  Row(
     modifier = modifier,
-    shape = MaterialTheme.shapes.large,
-    color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.72f),
-    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    verticalAlignment = Alignment.CenterVertically,
   ) {
+    AppIcon(
+      imageVector = icon,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier = Modifier.size(17.dp),
+    )
     Text(
       text = text,
-      style = MaterialTheme.typography.labelLarge,
-      modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+      modifier = Modifier.padding(start = 6.dp),
     )
   }
 }
@@ -774,49 +990,44 @@ private fun ClipCropControls(
   onCancel: () -> Unit,
   onDone: () -> Unit,
 ) {
-  BackHandler(onBack = onCancel)
-
-  Box(
-    modifier = Modifier.fillMaxWidth(),
-    contentAlignment = Alignment.Center,
+  Surface(
+    shape = CircleShape,
+    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.96f),
+    contentColor = MaterialTheme.colorScheme.onSurface,
+    tonalElevation = 6.dp,
+    shadowElevation = 8.dp,
+    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f)),
   ) {
-    Surface(
-      modifier = Modifier.widthIn(max = 460.dp).fillMaxWidth(),
-      shape = MaterialTheme.shapes.extraLarge,
-      color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.97f),
-      contentColor = MaterialTheme.colorScheme.onSurface,
-      tonalElevation = 6.dp,
-      shadowElevation = 8.dp,
-      border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f)),
+    Row(
+      modifier = Modifier.height(48.dp),
+      verticalAlignment = Alignment.CenterVertically,
     ) {
-      Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.padding(16.dp),
+      IconButton(
+        onClick = onCancel,
+        modifier = Modifier.size(48.dp),
       ) {
-        Text(
-          text = stringResource(R.string.clip_crop),
-          style = MaterialTheme.typography.titleMedium,
+        AppIcon(
+          imageVector = Icons.RoundedFilled.Close,
+          contentDescription = stringResource(R.string.clip_cancel),
+          modifier = Modifier.size(21.dp),
         )
-        Text(
-          text = stringResource(R.string.clip_select_crop),
-          style = MaterialTheme.typography.bodySmall,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-          modifier = Modifier.padding(top = 4.dp),
+      }
+      Box(
+        Modifier
+          .width(1.dp)
+          .height(24.dp)
+          .background(MaterialTheme.colorScheme.outlineVariant),
+      )
+      IconButton(
+        onClick = onDone,
+        modifier = Modifier.size(48.dp),
+      ) {
+        AppIcon(
+          imageVector = Icons.RoundedFilled.Check,
+          contentDescription = stringResource(R.string.clip_done),
+          tint = MaterialTheme.colorScheme.primary,
+          modifier = Modifier.size(22.dp),
         )
-        Row(modifier = Modifier.fillMaxWidth().padding(top = 12.dp)) {
-          OutlinedButton(
-            onClick = onCancel,
-            modifier = Modifier.weight(1f),
-          ) {
-            Text(stringResource(R.string.clip_cancel))
-          }
-          Button(
-            onClick = onDone,
-            modifier = Modifier.weight(1f).padding(start = 8.dp),
-          ) {
-            Text(stringResource(R.string.clip_done))
-          }
-        }
       }
     }
   }
@@ -830,6 +1041,7 @@ private class CropSelectionView(
   displayHeight: Int,
   private val rotation: Int,
   private val initialCrop: ClipCrop?,
+  private val onSelectionChanged: (RectF) -> Unit,
 ) : View(context) {
   private enum class DragMode {
     NONE,
@@ -854,11 +1066,24 @@ private class CropSelectionView(
       style = Paint.Style.STROKE
       strokeWidth = dpF(2f)
     }
-  private val handlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+  private val cornerHandlePaint =
+    Paint(Paint.ANTI_ALIAS_FLAG).apply {
+      color = Color.WHITE
+      style = Paint.Style.STROKE
+      strokeWidth = dpF(4f)
+      strokeCap = Paint.Cap.ROUND
+      strokeJoin = Paint.Join.ROUND
+    }
+  private val edgeHandlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+  private val gridPaint =
+    Paint(Paint.ANTI_ALIAS_FLAG).apply {
+      color = 0x99FFFFFF.toInt()
+      strokeWidth = dpF(1f)
+    }
   private val labelPaint =
     Paint(Paint.ANTI_ALIAS_FLAG).apply {
       color = Color.WHITE
-      textSize = spF(14f)
+      textSize = spF(12f)
       typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
     }
   private val labelBackgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xDD111111.toInt() }
@@ -868,6 +1093,7 @@ private class CropSelectionView(
   private val orientedHeight: Int
 
   private var dragMode = DragMode.NONE
+  private var activePointerId = MotionEvent.INVALID_POINTER_ID
   private var lastX = 0f
   private var lastY = 0f
   private var selectionInitialized = false
@@ -879,6 +1105,7 @@ private class CropSelectionView(
     contentAspectWidth = displayWidth.takeIf { it > 0 } ?: orientedWidth
     contentAspectHeight = displayHeight.takeIf { it > 0 } ?: orientedHeight
     isClickable = true
+    contentDescription = resources.getString(R.string.clip_select_crop)
     importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
   }
 
@@ -889,8 +1116,30 @@ private class CropSelectionView(
     oldh: Int,
   ) {
     super.onSizeChanged(w, h, oldw, oldh)
+    val normalizedSelection =
+      if (selectionInitialized && !videoBounds.isEmpty) {
+        floatArrayOf(
+          (selection.left - videoBounds.left) / videoBounds.width(),
+          (selection.top - videoBounds.top) / videoBounds.height(),
+          (selection.right - videoBounds.left) / videoBounds.width(),
+          (selection.bottom - videoBounds.top) / videoBounds.height(),
+        )
+      } else {
+        null
+      }
     updateVideoBounds(w.toFloat(), h.toFloat())
-    initializeSelectionIfNeeded()
+    if (normalizedSelection != null && !videoBounds.isEmpty) {
+      selection.set(
+        videoBounds.left + videoBounds.width() * normalizedSelection[0],
+        videoBounds.top + videoBounds.height() * normalizedSelection[1],
+        videoBounds.left + videoBounds.width() * normalizedSelection[2],
+        videoBounds.top + videoBounds.height() * normalizedSelection[3],
+      )
+      onSelectionChanged(RectF(selection))
+    } else {
+      initializeSelectionIfNeeded()
+    }
+    invalidate()
   }
 
   private fun updateVideoBounds(
@@ -931,6 +1180,7 @@ private class CropSelectionView(
       )
     }
     selectionInitialized = true
+    onSelectionChanged(RectF(selection))
   }
 
   override fun onDraw(canvas: Canvas) {
@@ -945,23 +1195,34 @@ private class CropSelectionView(
         addRoundRect(selection, dpF(4f), dpF(4f), Path.Direction.CW)
       }
     canvas.drawPath(outside, dimPaint)
+    for (step in 1..2) {
+      val x = selection.left + selection.width() * step / 3f
+      val y = selection.top + selection.height() * step / 3f
+      canvas.drawLine(x, selection.top, x, selection.bottom, gridPaint)
+      canvas.drawLine(selection.left, y, selection.right, y, gridPaint)
+    }
     canvas.drawRoundRect(selection, dpF(4f), dpF(4f), borderPaint)
-
-    val handleRadius = dpF(6f)
-    handlePoints().forEach { (x, y) -> canvas.drawCircle(x, y, handleRadius, handlePaint) }
+    drawResizeHandles(canvas)
 
     val crop = currentCrop()
-    val text = "${crop.width} × ${crop.height}"
+    val text = "${crop.width} × ${crop.height} px"
+    val maxLabelWidth = (width.toFloat() - dpF(8f)).coerceAtLeast(1f)
+    val horizontalPadding = min(dpF(10f), maxLabelWidth * 0.15f)
+    val maxTextWidth = (maxLabelWidth - horizontalPadding * 2f).coerceAtLeast(1f)
+    labelPaint.textSize = spF(12f)
+    val naturalTextWidth = labelPaint.measureText(text).coerceAtLeast(1f)
+    labelPaint.textSize *= (maxTextWidth / naturalTextWidth).coerceAtMost(1f)
     val textWidth = labelPaint.measureText(text)
     val textHeight = labelPaint.fontMetrics.run { bottom - top }
-    val horizontalPadding = dpF(10f)
     val verticalPadding = dpF(6f)
     val labelWidth = textWidth + horizontalPadding * 2f
     val labelHeight = textHeight + verticalPadding * 2f
-    val preferredTop = selection.top - labelHeight - dpF(8f)
-    val labelTop =
-      if (preferredTop >= videoBounds.top) preferredTop else min(selection.top + dpF(10f), selection.bottom - labelHeight - dpF(4f))
-    val labelLeft = (selection.centerX() - labelWidth / 2f).coerceIn(videoBounds.left, videoBounds.right - labelWidth)
+    val preferredTop = selection.top + dpF(10f)
+    val maxLabelTop = (height.toFloat() - labelHeight).coerceAtLeast(0f)
+    val maxInsideTop = (selection.bottom - labelHeight - dpF(8f)).coerceAtLeast(selection.top)
+    val labelTop = preferredTop.coerceAtMost(maxInsideTop).coerceIn(0f, maxLabelTop)
+    val maxLabelLeft = (width.toFloat() - labelWidth).coerceAtLeast(0f)
+    val labelLeft = (selection.centerX() - labelWidth / 2f).coerceIn(0f, maxLabelLeft)
     val labelRect = RectF(labelLeft, labelTop, labelLeft + labelWidth, labelTop + labelHeight)
     canvas.drawRoundRect(labelRect, dpF(12f), dpF(12f), labelBackgroundPaint)
     val baseline = labelRect.top + verticalPadding - labelPaint.fontMetrics.top
@@ -969,30 +1230,53 @@ private class CropSelectionView(
   }
 
   override fun onTouchEvent(event: MotionEvent): Boolean {
-    if (!isEnabled || selection.isEmpty) return false
+    if (!isEnabled) return false
+    initializeSelectionIfNeeded()
+    if (selection.isEmpty) return false
     when (event.actionMasked) {
       MotionEvent.ACTION_DOWN -> {
         dragMode = hitTest(event.x, event.y)
         if (dragMode == DragMode.NONE) return false
+        activePointerId = event.getPointerId(0)
+        performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
         lastX = event.x
         lastY = event.y
         parent?.requestDisallowInterceptTouchEvent(true)
+        invalidate()
         return true
       }
       MotionEvent.ACTION_MOVE -> {
         if (dragMode == DragMode.NONE) return false
-        val dx = event.x - lastX
-        val dy = event.y - lastY
+        val pointerIndex = event.findPointerIndex(activePointerId)
+        if (pointerIndex < 0) return false
+        val pointerX = event.getX(pointerIndex)
+        val pointerY = event.getY(pointerIndex)
+        val dx = pointerX - lastX
+        val dy = pointerY - lastY
         updateSelection(dx, dy)
-        lastX = event.x
-        lastY = event.y
+        lastX = pointerX
+        lastY = pointerY
         invalidate()
+        return true
+      }
+      MotionEvent.ACTION_POINTER_UP -> {
+        val releasedIndex = event.actionIndex
+        if (event.getPointerId(releasedIndex) == activePointerId) {
+          val replacementIndex = if (releasedIndex == 0) 1 else 0
+          if (replacementIndex < event.pointerCount) {
+            activePointerId = event.getPointerId(replacementIndex)
+            lastX = event.getX(replacementIndex)
+            lastY = event.getY(replacementIndex)
+          }
+        }
         return true
       }
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
         if (dragMode != DragMode.NONE) {
           dragMode = DragMode.NONE
+          activePointerId = MotionEvent.INVALID_POINTER_ID
           parent?.requestDisallowInterceptTouchEvent(false)
+          invalidate()
           performClick()
           return true
         }
@@ -1033,28 +1317,53 @@ private class CropSelectionView(
     )
   }
 
+  fun selectionBounds(): RectF = RectF(selection)
+
   private fun hitTest(
     x: Float,
     y: Float,
   ): DragMode {
-    val threshold = dpF(28f)
-    val nearLeft = kotlin.math.abs(x - selection.left) <= threshold
-    val nearRight = kotlin.math.abs(x - selection.right) <= threshold
-    val nearTop = kotlin.math.abs(y - selection.top) <= threshold
-    val nearBottom = kotlin.math.abs(y - selection.bottom) <= threshold
+    val threshold = dpF(32f)
+    val leftDistance = kotlin.math.abs(x - selection.left)
+    val rightDistance = kotlin.math.abs(x - selection.right)
+    val topDistance = kotlin.math.abs(y - selection.top)
+    val bottomDistance = kotlin.math.abs(y - selection.bottom)
+    val nearLeft = leftDistance <= threshold
+    val nearRight = rightDistance <= threshold
+    val nearTop = topDistance <= threshold
+    val nearBottom = bottomDistance <= threshold
     val withinHorizontal = x in (selection.left - threshold)..(selection.right + threshold)
     val withinVertical = y in (selection.top - threshold)..(selection.bottom + threshold)
 
+    if ((nearLeft || nearRight) && (nearTop || nearBottom)) {
+      val useLeft = leftDistance <= rightDistance
+      val useTop = topDistance <= bottomDistance
+      return when {
+        useLeft && useTop -> DragMode.TOP_LEFT
+        !useLeft && useTop -> DragMode.TOP_RIGHT
+        useLeft -> DragMode.BOTTOM_LEFT
+        else -> DragMode.BOTTOM_RIGHT
+      }
+    }
+
+    val verticalEdgeDistance = minOf(leftDistance, rightDistance)
+    val horizontalEdgeDistance = minOf(topDistance, bottomDistance)
+    val canResizeVertically = withinHorizontal && horizontalEdgeDistance <= threshold
+    val canResizeHorizontally = withinVertical && verticalEdgeDistance <= threshold
+
     return when {
-      nearLeft && nearTop -> DragMode.TOP_LEFT
-      nearRight && nearTop -> DragMode.TOP_RIGHT
-      nearLeft && nearBottom -> DragMode.BOTTOM_LEFT
-      nearRight && nearBottom -> DragMode.BOTTOM_RIGHT
-      nearLeft && withinVertical -> DragMode.LEFT
-      nearRight && withinVertical -> DragMode.RIGHT
-      nearTop && withinHorizontal -> DragMode.TOP
-      nearBottom && withinHorizontal -> DragMode.BOTTOM
+      canResizeHorizontally && (!canResizeVertically || verticalEdgeDistance <= horizontalEdgeDistance) ->
+        if (leftDistance <= rightDistance) DragMode.LEFT else DragMode.RIGHT
+      canResizeVertically -> if (topDistance <= bottomDistance) DragMode.TOP else DragMode.BOTTOM
       selection.contains(x, y) -> DragMode.MOVE
+      videoBounds.contains(x, y) && x < selection.left && y < selection.top -> DragMode.TOP_LEFT
+      videoBounds.contains(x, y) && x > selection.right && y < selection.top -> DragMode.TOP_RIGHT
+      videoBounds.contains(x, y) && x < selection.left && y > selection.bottom -> DragMode.BOTTOM_LEFT
+      videoBounds.contains(x, y) && x > selection.right && y > selection.bottom -> DragMode.BOTTOM_RIGHT
+      videoBounds.contains(x, y) && x < selection.left -> DragMode.LEFT
+      videoBounds.contains(x, y) && x > selection.right -> DragMode.RIGHT
+      videoBounds.contains(x, y) && y < selection.top -> DragMode.TOP
+      videoBounds.contains(x, y) && y > selection.bottom -> DragMode.BOTTOM
       else -> DragMode.NONE
     }
   }
@@ -1063,7 +1372,8 @@ private class CropSelectionView(
     dx: Float,
     dy: Float,
   ) {
-    val minSize = dpF(48f)
+    val minWidth = min(dpF(48f), videoBounds.width() * 0.5f).coerceAtLeast(2f)
+    val minHeight = min(dpF(48f), videoBounds.height() * 0.5f).coerceAtLeast(2f)
     when (dragMode) {
       DragMode.MOVE -> {
         var moveX = dx
@@ -1074,39 +1384,79 @@ private class CropSelectionView(
         if (selection.bottom + moveY > videoBounds.bottom) moveY = videoBounds.bottom - selection.bottom
         selection.offset(moveX, moveY)
       }
-      DragMode.LEFT, DragMode.TOP_LEFT, DragMode.BOTTOM_LEFT -> {
-        selection.left = (selection.left + dx).coerceIn(videoBounds.left, selection.right - minSize)
-        if (dragMode == DragMode.TOP_LEFT) {
-          selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minSize)
-        } else if (dragMode == DragMode.BOTTOM_LEFT) {
-          selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minSize, videoBounds.bottom)
-        }
-      }
-      DragMode.RIGHT, DragMode.TOP_RIGHT, DragMode.BOTTOM_RIGHT -> {
-        selection.right = (selection.right + dx).coerceIn(selection.left + minSize, videoBounds.right)
-        if (dragMode == DragMode.TOP_RIGHT) {
-          selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minSize)
-        } else if (dragMode == DragMode.BOTTOM_RIGHT) {
-          selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minSize, videoBounds.bottom)
-        }
-      }
-      DragMode.TOP -> selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minSize)
-      DragMode.BOTTOM -> selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minSize, videoBounds.bottom)
       DragMode.NONE -> Unit
+      else -> {
+        if (dragMode == DragMode.LEFT || dragMode == DragMode.TOP_LEFT || dragMode == DragMode.BOTTOM_LEFT) {
+          selection.left = (selection.left + dx).coerceIn(videoBounds.left, selection.right - minWidth)
+        }
+        if (dragMode == DragMode.RIGHT || dragMode == DragMode.TOP_RIGHT || dragMode == DragMode.BOTTOM_RIGHT) {
+          selection.right = (selection.right + dx).coerceIn(selection.left + minWidth, videoBounds.right)
+        }
+        if (dragMode == DragMode.TOP || dragMode == DragMode.TOP_LEFT || dragMode == DragMode.TOP_RIGHT) {
+          selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minHeight)
+        }
+        if (dragMode == DragMode.BOTTOM || dragMode == DragMode.BOTTOM_LEFT || dragMode == DragMode.BOTTOM_RIGHT) {
+          selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minHeight, videoBounds.bottom)
+        }
+      }
     }
+    onSelectionChanged(RectF(selection))
   }
 
-  private fun handlePoints(): List<Pair<Float, Float>> =
-    listOf(
-      selection.left to selection.top,
-      selection.centerX() to selection.top,
-      selection.right to selection.top,
-      selection.left to selection.centerY(),
-      selection.right to selection.centerY(),
-      selection.left to selection.bottom,
-      selection.centerX() to selection.bottom,
-      selection.right to selection.bottom,
+  private fun drawResizeHandles(canvas: Canvas) {
+    val leg = min(dpF(22f), min(selection.width(), selection.height()) * 0.28f)
+    val edgeLength = min(dpF(28f), min(selection.width(), selection.height()) * 0.3f)
+    val edgeThickness = dpF(5f)
+    val edgeRadius = edgeThickness / 2f
+
+    canvas.drawLine(selection.left, selection.top, selection.left + leg, selection.top, cornerHandlePaint)
+    canvas.drawLine(selection.left, selection.top, selection.left, selection.top + leg, cornerHandlePaint)
+    canvas.drawLine(selection.right - leg, selection.top, selection.right, selection.top, cornerHandlePaint)
+    canvas.drawLine(selection.right, selection.top, selection.right, selection.top + leg, cornerHandlePaint)
+    canvas.drawLine(selection.left, selection.bottom, selection.left + leg, selection.bottom, cornerHandlePaint)
+    canvas.drawLine(selection.left, selection.bottom - leg, selection.left, selection.bottom, cornerHandlePaint)
+    canvas.drawLine(selection.right - leg, selection.bottom, selection.right, selection.bottom, cornerHandlePaint)
+    canvas.drawLine(selection.right, selection.bottom - leg, selection.right, selection.bottom, cornerHandlePaint)
+
+    val centerX = selection.centerX()
+    val centerY = selection.centerY()
+    canvas.drawRoundRect(
+      centerX - edgeLength / 2f,
+      selection.top - edgeThickness / 2f,
+      centerX + edgeLength / 2f,
+      selection.top + edgeThickness / 2f,
+      edgeRadius,
+      edgeRadius,
+      edgeHandlePaint,
     )
+    canvas.drawRoundRect(
+      centerX - edgeLength / 2f,
+      selection.bottom - edgeThickness / 2f,
+      centerX + edgeLength / 2f,
+      selection.bottom + edgeThickness / 2f,
+      edgeRadius,
+      edgeRadius,
+      edgeHandlePaint,
+    )
+    canvas.drawRoundRect(
+      selection.left - edgeThickness / 2f,
+      centerY - edgeLength / 2f,
+      selection.left + edgeThickness / 2f,
+      centerY + edgeLength / 2f,
+      edgeRadius,
+      edgeRadius,
+      edgeHandlePaint,
+    )
+    canvas.drawRoundRect(
+      selection.right - edgeThickness / 2f,
+      centerY - edgeLength / 2f,
+      selection.right + edgeThickness / 2f,
+      centerY + edgeLength / 2f,
+      edgeRadius,
+      edgeRadius,
+      edgeHandlePaint,
+    )
+  }
 
   private fun evenFloor(value: Int): Int = value and -2
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipOverlayView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/ClipOverlayView.kt
@@ -1,0 +1,1116 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player.clip
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import app.gyrolet.mpvrx.R
+import app.gyrolet.mpvrx.ui.icons.Icon as AppIcon
+import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.player.PlaybackSession
+import app.gyrolet.mpvrx.ui.player.PlayerActivity
+import app.gyrolet.mpvrx.ui.player.PlayerViewModel
+import app.gyrolet.mpvrx.ui.player.controls.components.panels.DraggablePanel
+import app.gyrolet.mpvrx.ui.theme.MpvrxTheme
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+private data class ClipPanelState(
+  val startTime: String = "--:--",
+  val endTime: String? = null,
+  val startSeconds: Float = 0f,
+  val endSeconds: Float? = null,
+  val durationSeconds: Float = 0f,
+  val crop: ClipCrop? = null,
+  val canSave: Boolean = false,
+  val exporting: Boolean = false,
+  val cancelling: Boolean = false,
+  val progress: Int = 0,
+  val panelActive: Boolean = false,
+)
+
+/**
+ * Player-local editor surface for Clip.
+ *
+ * The scissors action itself is a normal customizable Compose player button. This sibling overlay
+ * exists only for UI that must sit directly over the video: the Clip editor card and crop selector.
+ * Outside those visible children it does not consume input, so the normal seekbar and gestures keep
+ * working while a Clip draft is open.
+ */
+class ClipOverlayView @JvmOverloads constructor(
+  context: Context,
+  attrs: AttributeSet? = null,
+) : FrameLayout(context, attrs) {
+  private data class ClipDraft(
+    var startSeconds: Double,
+    var endSeconds: Double? = null,
+    var crop: ClipCrop? = null,
+  )
+
+  private val panelView = ComposeView(context)
+  private var panelState by mutableStateOf(ClipPanelState())
+
+  private var draft: ClipDraft? = null
+  private var cropView: CropSelectionView? = null
+  private var cropControls: ComposeView? = null
+  private var pausedBeforeCrop = true
+  private var reopenPanelAfterCrop = true
+  private var lastTerminalState: ClipExportState? = null
+  private var bottomInset = 0
+
+  private val pollState =
+    object : Runnable {
+      override fun run() {
+        updateExportState()
+        postDelayed(this, STATE_POLL_MS)
+      }
+    }
+
+  init {
+    isClickable = false
+    isFocusable = false
+    clipChildren = false
+    clipToPadding = false
+    setupPanel()
+
+    ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
+      bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+      updateOverlayMargins()
+      insets
+    }
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    removeCallbacks(pollState)
+    post(pollState)
+  }
+
+  override fun onDetachedFromWindow() {
+    removeCallbacks(pollState)
+    if (cropView != null) exitCropMode(keepSelection = false)
+    super.onDetachedFromWindow()
+  }
+
+  override fun onSizeChanged(
+    w: Int,
+    h: Int,
+    oldw: Int,
+    oldh: Int,
+  ) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    updateOverlayMargins()
+  }
+
+  override fun onTouchEvent(event: MotionEvent): Boolean =
+    if (cropView != null) true else super.onTouchEvent(event)
+
+  /** Opens the compact Clip editor from a long-press on the player control. */
+  fun openClip(cropImmediately: Boolean = false) {
+    beginClip(cropImmediately)
+  }
+
+  /** Marks the current playback position as the quick Clip start without opening the editor. */
+  fun markStartAtCurrent() {
+    if (PlaybackSession.state.value.currentItem == null) {
+      toast(R.string.clip_video_unavailable)
+      return
+    }
+    val current = currentPosition() ?: return
+    val active = draft ?: ClipDraft(startSeconds = current, endSeconds = null).also { draft = it }
+    active.startSeconds = current
+    if ((active.endSeconds ?: Double.POSITIVE_INFINITY) <= current + MIN_CLIP_SECONDS) {
+      active.endSeconds = null
+    }
+    // Quick Start behaves like A/B Loop point A: update the range without hiding player controls.
+    refreshDraftUi()
+  }
+
+  /** Marks the current playback position as the quick Clip end without opening the editor. */
+  fun markEndAtCurrent() {
+    if (PlaybackSession.state.value.currentItem == null) {
+      toast(R.string.clip_video_unavailable)
+      return
+    }
+    val current = currentPosition() ?: return
+    val active =
+      draft ?: ClipDraft(
+        startSeconds = (current - DEFAULT_CLIP_SECONDS).coerceAtLeast(0.0),
+        endSeconds = null,
+      ).also { draft = it }
+    if (current <= active.startSeconds + MIN_CLIP_SECONDS) {
+      toast(R.string.clip_invalid_range)
+      return
+    }
+    active.endSeconds = current
+    // Quick End behaves like A/B Loop point B: update the range without hiding player controls.
+    refreshDraftUi()
+  }
+
+  /** Opens only crop UI; Done/Cancel returns directly to normal player controls. */
+  fun openCrop() {
+    if (PlaybackSession.state.value.currentItem == null) {
+      toast(R.string.clip_video_unavailable)
+      return
+    }
+    ensureDraft()
+    refreshDraftUi()
+    enterCropMode(reopenEditorAfterCrop = false)
+  }
+
+  private fun playerViewModel(): PlayerViewModel? {
+    val owner = findViewTreeViewModelStoreOwner() ?: return null
+    return ViewModelProvider(owner)[PlayerViewModel::class.java]
+  }
+
+  private fun setupPanel() {
+    panelView.apply {
+      visibility = GONE
+      isClickable = false
+      isFocusable = false
+      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+      setContent {
+        MpvrxTheme {
+          ClipEditorPanel(
+            state = panelState,
+            onRangeChange = ::updateClipRange,
+            onMarkStart = ::markClipStart,
+            onMarkEnd = ::markClipEnd,
+            onCrop = ::enterCropMode,
+            onCancel = ::cancelOrClose,
+            onSave = ::saveOrCancelExport,
+          )
+        }
+      }
+    }
+    addView(
+      panelView,
+      LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT),
+    )
+  }
+
+  private fun beginClip(cropImmediately: Boolean) {
+    if (PlaybackSession.state.value.currentItem == null) {
+      toast(R.string.clip_video_unavailable)
+      return
+    }
+
+    if (ClipExportManager.state.value is ClipExportState.Exporting) {
+      panelState = panelState.copy(panelActive = true)
+      panelView.visibility = VISIBLE
+      updateExportState()
+      return
+    }
+
+    ensureDraft()
+    refreshDraftUi()
+    panelState = panelState.copy(panelActive = true)
+    panelView.visibility = VISIBLE
+
+    // Keep the seekbar visible while the draggable editor is open, without covering the video in controls.
+    playerViewModel()?.autoHideControls()
+
+    if (cropImmediately) enterCropMode()
+  }
+
+  private fun ensureDraft(): ClipDraft {
+    draft?.let { return it }
+
+    val duration = mediaDurationSeconds()
+    var start = (currentPosition() ?: 0.0).coerceAtLeast(0.0)
+    val end =
+      if (duration > MIN_CLIP_SECONDS) {
+        if (start >= duration - MIN_CLIP_SECONDS) {
+          start = (duration - DEFAULT_CLIP_SECONDS).coerceAtLeast(0.0)
+        }
+        (start + DEFAULT_CLIP_SECONDS).coerceAtMost(duration)
+      } else {
+        start + DEFAULT_CLIP_SECONDS
+      }
+
+    return ClipDraft(
+      startSeconds = start,
+      endSeconds = end.coerceAtLeast(start + MIN_CLIP_SECONDS),
+    ).also {
+      draft = it
+      refreshDraftUi()
+    }
+  }
+
+  private fun updateClipRange(
+    start: Float,
+    end: Float,
+    preview: Float,
+  ) {
+    val active = ensureDraft()
+    val duration = mediaDurationSeconds().takeIf { it > MIN_CLIP_SECONDS }
+    val maxEnd = duration?.toFloat() ?: maxOf(end, start + 0.05f)
+    val safeStart = start.coerceIn(0f, (maxEnd - 0.05f).coerceAtLeast(0f))
+    val safeEnd = end.coerceIn(safeStart + 0.05f, maxEnd)
+    active.startSeconds = safeStart.toDouble()
+    active.endSeconds = safeEnd.toDouble()
+    refreshDraftUi()
+    PlaybackSession.setPropertyDouble(
+      "time-pos",
+      preview.coerceIn(safeStart, safeEnd).toDouble(),
+    )
+    playerViewModel()?.autoHideControls()
+  }
+
+  private fun markClipStart() {
+    val current = currentPosition() ?: return
+    val active = ensureDraft()
+    active.startSeconds = current
+    if ((active.endSeconds ?: Double.POSITIVE_INFINITY) <= current + MIN_CLIP_SECONDS) {
+      active.endSeconds = null
+    }
+    refreshDraftUi()
+    playerViewModel()?.autoHideControls()
+  }
+
+  private fun markClipEnd() {
+    val active = ensureDraft()
+    val current = currentPosition() ?: return
+    if (current <= active.startSeconds + MIN_CLIP_SECONDS) {
+      toast(R.string.clip_invalid_range)
+      return
+    }
+    active.endSeconds = current
+    refreshDraftUi()
+    playerViewModel()?.autoHideControls()
+  }
+
+  private fun saveOrCancelExport() {
+    val exportState = ClipExportManager.state.value
+    if (exportState is ClipExportState.Exporting) {
+      ClipExportManager.cancel()
+      updateExportState()
+      return
+    }
+
+    val active = draft ?: return
+    val end = active.endSeconds
+    val item = PlaybackSession.state.value.currentItem
+    if (end == null || end <= active.startSeconds + MIN_CLIP_SECONDS || item == null) {
+      toast(R.string.clip_invalid_range)
+      return
+    }
+
+    val accepted =
+      ClipExportManager.export(
+        context,
+        ClipRequest(
+          item = item,
+          startSeconds = active.startSeconds,
+          endSeconds = end,
+          crop = active.crop,
+        ),
+      )
+    if (!accepted) toast(R.string.clip_export_busy)
+    updateExportState()
+  }
+
+  private fun cancelOrClose() {
+    if (ClipExportManager.state.value is ClipExportState.Exporting) {
+      ClipExportManager.cancel()
+      updateExportState()
+    } else {
+      closeDraft()
+    }
+  }
+
+  private fun closeDraft() {
+    if (cropView != null) exitCropMode(keepSelection = false)
+    draft = null
+    ClipEditorUiState.clear()
+    panelState = ClipPanelState()
+    panelView.visibility = GONE
+    playerViewModel()?.showControls()
+  }
+
+  private fun enterCropMode() {
+    enterCropMode(reopenEditorAfterCrop = true)
+  }
+
+  private fun enterCropMode(reopenEditorAfterCrop: Boolean) {
+    if (cropView != null) return
+    this.reopenPanelAfterCrop = reopenEditorAfterCrop
+    val active = ensureDraft()
+    val sourceWidth = PlaybackSession.getPropertyInt("video-params/w") ?: 0
+    val sourceHeight = PlaybackSession.getPropertyInt("video-params/h") ?: 0
+    if (sourceWidth <= 0 || sourceHeight <= 0) {
+      toast(R.string.clip_video_unavailable)
+      return
+    }
+
+    val rotation = ((PlaybackSession.getPropertyInt("video-params/rotate") ?: 0) % 360 + 360) % 360
+    val outputWidth = PlaybackSession.getPropertyInt("video-out-params/dw") ?: 0
+    val outputHeight = PlaybackSession.getPropertyInt("video-out-params/dh") ?: 0
+
+    playerViewModel()?.hideControls()
+    pausedBeforeCrop = PlaybackSession.getPropertyBoolean("pause") ?: true
+    if (!pausedBeforeCrop) PlaybackSession.setPropertyBoolean("pause", true)
+
+    panelState = panelState.copy(panelActive = false)
+    panelView.visibility = GONE
+    val selector =
+      CropSelectionView(
+        context = context,
+        sourceWidth = sourceWidth,
+        sourceHeight = sourceHeight,
+        displayWidth = outputWidth,
+        displayHeight = outputHeight,
+        rotation = rotation,
+        initialCrop = active.crop,
+      )
+    cropView = selector
+    addView(selector, LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+
+    val controls = buildCropControls(selector)
+    cropControls = controls
+    addView(
+      controls,
+      LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.BOTTOM).apply {
+        leftMargin = dp(8)
+        rightMargin = dp(8)
+        bottomMargin = bottomInset + dp(24)
+      },
+    )
+  }
+
+  private fun buildCropControls(selector: CropSelectionView): ComposeView =
+    ComposeView(context).apply {
+      isClickable = true
+      setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+      setContent {
+        MpvrxTheme {
+          ClipCropControls(
+            onCancel = { exitCropMode(keepSelection = false) },
+            onDone = {
+              draft?.crop = selector.currentCrop()
+              exitCropMode(keepSelection = true)
+            },
+          )
+        }
+      }
+    }
+
+  private fun exitCropMode(keepSelection: Boolean) {
+    val selector = cropView ?: return
+    if (!keepSelection) {
+      // Cancelling crop intentionally keeps the previous crop selection, if one existed.
+    }
+    removeView(selector)
+    cropView = null
+    cropControls?.let(::removeView)
+    cropControls = null
+    if (!pausedBeforeCrop) PlaybackSession.setPropertyBoolean("pause", false)
+    val reopenPanel = draft != null && reopenPanelAfterCrop
+    reopenPanelAfterCrop = true
+    panelState = panelState.copy(panelActive = reopenPanel)
+    panelView.visibility = if (reopenPanel) VISIBLE else GONE
+    refreshDraftUi()
+    if (reopenPanel) {
+      playerViewModel()?.autoHideControls()
+    } else {
+      playerViewModel()?.showControls()
+    }
+  }
+
+  private fun updateExportState() {
+    when (val state = ClipExportManager.state.value) {
+      ClipExportState.Idle -> {
+        panelState =
+          panelState.copy(
+            exporting = false,
+            cancelling = false,
+            progress = 0,
+          )
+        lastTerminalState = null
+      }
+      is ClipExportState.Exporting -> {
+        panelView.visibility = VISIBLE
+        panelState =
+          panelState.copy(
+            exporting = true,
+            cancelling = state.cancelling,
+            progress = (state.progress * 100f).roundToInt().coerceIn(0, 100),
+            panelActive = true,
+          )
+      }
+      is ClipExportState.Success -> {
+        if (lastTerminalState !== state) {
+          toast(context.getString(R.string.clip_saved, state.displayName))
+          lastTerminalState = state
+          draft = null
+          ClipEditorUiState.clear()
+          panelState = ClipPanelState()
+          panelView.visibility = GONE
+          playerViewModel()?.showControls()
+          ClipExportManager.consumeTerminalState()
+        }
+      }
+      is ClipExportState.Error -> {
+        if (lastTerminalState !== state) {
+          toast(context.getString(R.string.clip_export_failed, state.message))
+          lastTerminalState = state
+          ClipExportManager.consumeTerminalState()
+          panelState = panelState.copy(exporting = false, cancelling = false)
+          refreshDraftUi()
+        }
+      }
+    }
+  }
+
+  private fun refreshDraftUi() {
+    val active = draft
+    if (active == null) {
+      ClipEditorUiState.clear()
+      panelState =
+        panelState.copy(
+          startTime = "--:--",
+          endTime = null,
+          startSeconds = 0f,
+          endSeconds = null,
+          durationSeconds = 0f,
+          crop = null,
+          canSave = false,
+        )
+      return
+    }
+
+    val duration = mediaDurationSeconds().toFloat().coerceAtLeast(0f)
+    ClipEditorUiState.publish(active.startSeconds, active.endSeconds)
+    panelState =
+      panelState.copy(
+        startTime = formatTime(active.startSeconds),
+        endTime = active.endSeconds?.let(::formatTime),
+        startSeconds = active.startSeconds.toFloat(),
+        endSeconds = active.endSeconds?.toFloat(),
+        durationSeconds = duration,
+        crop = active.crop,
+        canSave =
+          active.endSeconds?.let { it > active.startSeconds + MIN_CLIP_SECONDS } == true &&
+            ClipExportManager.state.value !is ClipExportState.Exporting,
+      )
+  }
+
+  private fun updateOverlayMargins() {
+    (cropControls?.layoutParams as? LayoutParams)?.let { params ->
+      params.bottomMargin = bottomInset + dp(24)
+      cropControls?.layoutParams = params
+    }
+  }
+
+  private fun mediaDurationSeconds(): Double =
+    PlaybackSession.getPropertyDouble("duration")
+      ?: PlaybackSession.getPropertyInt("duration")?.toDouble()
+      ?: 0.0
+
+  private fun currentPosition(): Double? = PlaybackSession.getPropertyDouble("time-pos")
+
+  private fun formatTime(seconds: Double): String {
+    val totalTenths = (seconds.coerceAtLeast(0.0) * 10.0).roundToInt()
+    val hours = totalTenths / 36_000
+    val minutes = (totalTenths / 600) % 60
+    val secs = (totalTenths / 10) % 60
+    val tenths = totalTenths % 10
+    return if (hours > 0) {
+      "%d:%02d:%02d.%d".format(Locale.US, hours, minutes, secs, tenths)
+    } else {
+      "%02d:%02d.%d".format(Locale.US, minutes, secs, tenths)
+    }
+  }
+
+  private fun toast(message: String) {
+    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+  }
+
+  private fun toast(messageRes: Int) {
+    Toast.makeText(context, messageRes, Toast.LENGTH_SHORT).show()
+  }
+
+  private fun dp(value: Int): Int = (value * resources.displayMetrics.density).roundToInt()
+
+  companion object {
+    private const val OVERLAY_TAG = "mpvrx_clip_overlay"
+    private const val STATE_POLL_MS = 250L
+    private const val MIN_CLIP_SECONDS = 0.05
+    private const val DEFAULT_CLIP_SECONDS = 10.0
+
+    /** Attaches the Clip editor above the player at runtime; no player_layout.xml host is needed. */
+    internal fun ensureAttached(activity: PlayerActivity): ClipOverlayView {
+      val contentRoot = activity.findViewById<ViewGroup>(android.R.id.content)
+      contentRoot.findViewWithTag<ClipOverlayView>(OVERLAY_TAG)?.let { return it }
+
+      return ClipOverlayView(activity).also { overlay ->
+        overlay.tag = OVERLAY_TAG
+        contentRoot.addView(
+          overlay,
+          ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+          ),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClipEditorPanel(
+  state: ClipPanelState,
+  onRangeChange: (Float, Float, Float) -> Unit,
+  onMarkStart: () -> Unit,
+  onMarkEnd: () -> Unit,
+  onCrop: () -> Unit,
+  onCancel: () -> Unit,
+  onSave: () -> Unit,
+) {
+  BackHandler(enabled = state.panelActive, onBack = onCancel)
+
+  DraggablePanel(
+    header = {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+      ) {
+        AppIcon(
+imageVector = Icons.RoundedFilled.ContentCut,
+contentDescription = null,
+tint = MaterialTheme.colorScheme.primary,
+modifier = Modifier.size(20.dp),
+        )
+        Text(
+text = stringResource(R.string.clip_action),
+style = MaterialTheme.typography.titleMedium,
+modifier = Modifier.padding(start = 8.dp),
+        )
+        Spacer(Modifier.weight(1f))
+        IconButton(onClick = onCancel) {
+AppIcon(
+  imageVector = Icons.RoundedFilled.Close,
+  contentDescription = stringResource(R.string.clip_cancel),
+  modifier = Modifier.size(24.dp),
+)
+        }
+      }
+    },
+  ) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+      Row(modifier = Modifier.fillMaxWidth()) {
+        ClipInfoPill(
+text = stringResource(R.string.clip_start_time, state.startTime),
+modifier = Modifier.weight(1f),
+        )
+        ClipInfoPill(
+text = state.endTime?.let { stringResource(R.string.clip_end_time, it) }
+  ?: stringResource(R.string.clip_end_not_set),
+modifier = Modifier.weight(1f).padding(start = 8.dp),
+        )
+      }
+
+      val end = state.endSeconds
+      val duration = state.durationSeconds
+      if (end != null && duration > 0.05f) {
+        val start = state.startSeconds.coerceIn(0f, duration)
+        val safeEnd = end.coerceIn(start + 0.05f, duration)
+        RangeSlider(
+value = start..safeEnd,
+onValueChange = { range ->
+  val startDelta = abs(range.start - start)
+  val endDelta = abs(range.endInclusive - safeEnd)
+  val preview = if (startDelta >= endDelta) range.start else range.endInclusive
+  onRangeChange(range.start, range.endInclusive, preview)
+},
+valueRange = 0f..duration,
+enabled = !state.exporting,
+modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        )
+      }
+
+      Text(
+        text = state.crop?.let { stringResource(R.string.clip_crop_size, it.width, it.height) }
+?: stringResource(R.string.clip_crop_full_frame),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 2.dp),
+      )
+
+      Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        FilledTonalButton(onClick = onMarkStart, enabled = !state.exporting, modifier = Modifier.weight(1f)) {
+Text(stringResource(R.string.clip_start_short), maxLines = 1)
+        }
+        FilledTonalButton(
+onClick = onCrop,
+enabled = !state.exporting,
+modifier = Modifier.weight(1f).padding(horizontal = 6.dp),
+        ) {
+Text(stringResource(R.string.clip_crop), maxLines = 1)
+        }
+        FilledTonalButton(onClick = onMarkEnd, enabled = !state.exporting, modifier = Modifier.weight(1f)) {
+Text(stringResource(R.string.clip_end_short), maxLines = 1)
+        }
+      }
+
+      if (state.exporting) {
+        LinearProgressIndicator(
+progress = { state.progress / 100f },
+modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        )
+        Text(
+text = if (state.cancelling) stringResource(R.string.clip_cancelling)
+  else stringResource(R.string.clip_exporting, state.progress),
+style = MaterialTheme.typography.bodySmall,
+color = MaterialTheme.colorScheme.onSurfaceVariant,
+modifier = Modifier.padding(top = 4.dp),
+        )
+      }
+
+      if (state.exporting) {
+        Button(
+onClick = onSave,
+enabled = !state.cancelling,
+modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        ) {
+Text(stringResource(R.string.clip_cancel))
+        }
+      } else {
+        Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+OutlinedButton(onClick = onCancel, modifier = Modifier.weight(1f)) {
+  Text(stringResource(R.string.clip_cancel))
+}
+Button(
+  onClick = onSave,
+  enabled = state.canSave,
+  modifier = Modifier.weight(1f).padding(start = 8.dp),
+) {
+  Text(stringResource(R.string.clip_save))
+}
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ClipInfoPill(
+  text: String,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    modifier = modifier,
+    shape = MaterialTheme.shapes.large,
+    color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.72f),
+    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+  ) {
+    Text(
+      text = text,
+      style = MaterialTheme.typography.labelLarge,
+      modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+    )
+  }
+}
+
+@Composable
+private fun ClipCropControls(
+  onCancel: () -> Unit,
+  onDone: () -> Unit,
+) {
+  BackHandler(onBack = onCancel)
+
+  Box(
+    modifier = Modifier.fillMaxWidth(),
+    contentAlignment = Alignment.Center,
+  ) {
+    Surface(
+      modifier = Modifier.widthIn(max = 460.dp).fillMaxWidth(),
+      shape = MaterialTheme.shapes.extraLarge,
+      color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.97f),
+      contentColor = MaterialTheme.colorScheme.onSurface,
+      tonalElevation = 6.dp,
+      shadowElevation = 8.dp,
+      border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f)),
+    ) {
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.padding(16.dp),
+      ) {
+        Text(
+          text = stringResource(R.string.clip_crop),
+          style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+          text = stringResource(R.string.clip_select_crop),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          modifier = Modifier.padding(top = 4.dp),
+        )
+        Row(modifier = Modifier.fillMaxWidth().padding(top = 12.dp)) {
+          OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier.weight(1f),
+          ) {
+            Text(stringResource(R.string.clip_cancel))
+          }
+          Button(
+            onClick = onDone,
+            modifier = Modifier.weight(1f).padding(start = 8.dp),
+          ) {
+            Text(stringResource(R.string.clip_done))
+          }
+        }
+      }
+    }
+  }
+}
+
+private class CropSelectionView(
+  context: Context,
+  private val sourceWidth: Int,
+  private val sourceHeight: Int,
+  displayWidth: Int,
+  displayHeight: Int,
+  private val rotation: Int,
+  private val initialCrop: ClipCrop?,
+) : View(context) {
+  private enum class DragMode {
+    NONE,
+    MOVE,
+    LEFT,
+    TOP,
+    RIGHT,
+    BOTTOM,
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_RIGHT,
+  }
+
+  private val density = resources.displayMetrics.density
+  private val videoBounds = RectF()
+  private val selection = RectF()
+  private val dimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0x99000000.toInt() }
+  private val borderPaint =
+    Paint(Paint.ANTI_ALIAS_FLAG).apply {
+      color = Color.WHITE
+      style = Paint.Style.STROKE
+      strokeWidth = dpF(2f)
+    }
+  private val handlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+  private val labelPaint =
+    Paint(Paint.ANTI_ALIAS_FLAG).apply {
+      color = Color.WHITE
+      textSize = spF(14f)
+      typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+    }
+  private val labelBackgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xDD111111.toInt() }
+  private val contentAspectWidth: Int
+  private val contentAspectHeight: Int
+  private val orientedWidth: Int
+  private val orientedHeight: Int
+
+  private var dragMode = DragMode.NONE
+  private var lastX = 0f
+  private var lastY = 0f
+  private var selectionInitialized = false
+
+  init {
+    val quarterTurns = ((rotation % 360 + 360) % 360) == 90 || ((rotation % 360 + 360) % 360) == 270
+    orientedWidth = if (quarterTurns) sourceHeight else sourceWidth
+    orientedHeight = if (quarterTurns) sourceWidth else sourceHeight
+    contentAspectWidth = displayWidth.takeIf { it > 0 } ?: orientedWidth
+    contentAspectHeight = displayHeight.takeIf { it > 0 } ?: orientedHeight
+    isClickable = true
+    importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+  }
+
+  override fun onSizeChanged(
+    w: Int,
+    h: Int,
+    oldw: Int,
+    oldh: Int,
+  ) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    updateVideoBounds(w.toFloat(), h.toFloat())
+    initializeSelectionIfNeeded()
+  }
+
+  private fun updateVideoBounds(
+    availableWidth: Float,
+    availableHeight: Float,
+  ) {
+    if (availableWidth <= 0f || availableHeight <= 0f) return
+    val aspect = contentAspectWidth.toFloat() / contentAspectHeight.toFloat().coerceAtLeast(1f)
+    val viewAspect = availableWidth / availableHeight
+    if (viewAspect > aspect) {
+      val videoWidth = availableHeight * aspect
+      val left = (availableWidth - videoWidth) / 2f
+      videoBounds.set(left, 0f, left + videoWidth, availableHeight)
+    } else {
+      val videoHeight = availableWidth / aspect
+      val top = (availableHeight - videoHeight) / 2f
+      videoBounds.set(0f, top, availableWidth, top + videoHeight)
+    }
+  }
+
+  private fun initializeSelectionIfNeeded() {
+    if (selectionInitialized || videoBounds.isEmpty) return
+    val existing = initialCrop?.takeIf { it.rotation == rotation && it.width > 0 && it.height > 0 }
+    if (existing != null) {
+      val left = videoBounds.left + videoBounds.width() * existing.x / orientedWidth.toFloat()
+      val top = videoBounds.top + videoBounds.height() * existing.y / orientedHeight.toFloat()
+      val right = videoBounds.left + videoBounds.width() * (existing.x + existing.width) / orientedWidth.toFloat()
+      val bottom = videoBounds.top + videoBounds.height() * (existing.y + existing.height) / orientedHeight.toFloat()
+      selection.set(left, top, right, bottom)
+    } else {
+      val horizontalInset = videoBounds.width() * 0.08f
+      val verticalInset = videoBounds.height() * 0.08f
+      selection.set(
+        videoBounds.left + horizontalInset,
+        videoBounds.top + verticalInset,
+        videoBounds.right - horizontalInset,
+        videoBounds.bottom - verticalInset,
+      )
+    }
+    selectionInitialized = true
+  }
+
+  override fun onDraw(canvas: Canvas) {
+    super.onDraw(canvas)
+    initializeSelectionIfNeeded()
+    if (selection.isEmpty) return
+
+    val outside =
+      Path().apply {
+        fillType = Path.FillType.EVEN_ODD
+        addRect(0f, 0f, width.toFloat(), height.toFloat(), Path.Direction.CW)
+        addRoundRect(selection, dpF(4f), dpF(4f), Path.Direction.CW)
+      }
+    canvas.drawPath(outside, dimPaint)
+    canvas.drawRoundRect(selection, dpF(4f), dpF(4f), borderPaint)
+
+    val handleRadius = dpF(6f)
+    handlePoints().forEach { (x, y) -> canvas.drawCircle(x, y, handleRadius, handlePaint) }
+
+    val crop = currentCrop()
+    val text = "${crop.width} × ${crop.height}"
+    val textWidth = labelPaint.measureText(text)
+    val textHeight = labelPaint.fontMetrics.run { bottom - top }
+    val horizontalPadding = dpF(10f)
+    val verticalPadding = dpF(6f)
+    val labelWidth = textWidth + horizontalPadding * 2f
+    val labelHeight = textHeight + verticalPadding * 2f
+    val preferredTop = selection.top - labelHeight - dpF(8f)
+    val labelTop =
+      if (preferredTop >= videoBounds.top) preferredTop else min(selection.top + dpF(10f), selection.bottom - labelHeight - dpF(4f))
+    val labelLeft = (selection.centerX() - labelWidth / 2f).coerceIn(videoBounds.left, videoBounds.right - labelWidth)
+    val labelRect = RectF(labelLeft, labelTop, labelLeft + labelWidth, labelTop + labelHeight)
+    canvas.drawRoundRect(labelRect, dpF(12f), dpF(12f), labelBackgroundPaint)
+    val baseline = labelRect.top + verticalPadding - labelPaint.fontMetrics.top
+    canvas.drawText(text, labelRect.left + horizontalPadding, baseline, labelPaint)
+  }
+
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    if (!isEnabled || selection.isEmpty) return false
+    when (event.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        dragMode = hitTest(event.x, event.y)
+        if (dragMode == DragMode.NONE) return false
+        lastX = event.x
+        lastY = event.y
+        parent?.requestDisallowInterceptTouchEvent(true)
+        return true
+      }
+      MotionEvent.ACTION_MOVE -> {
+        if (dragMode == DragMode.NONE) return false
+        val dx = event.x - lastX
+        val dy = event.y - lastY
+        updateSelection(dx, dy)
+        lastX = event.x
+        lastY = event.y
+        invalidate()
+        return true
+      }
+      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+        if (dragMode != DragMode.NONE) {
+          dragMode = DragMode.NONE
+          parent?.requestDisallowInterceptTouchEvent(false)
+          performClick()
+          return true
+        }
+      }
+    }
+    return super.onTouchEvent(event)
+  }
+
+  override fun performClick(): Boolean {
+    super.performClick()
+    return true
+  }
+
+  fun currentCrop(): ClipCrop {
+    val normalizedLeft = ((selection.left - videoBounds.left) / videoBounds.width()).coerceIn(0f, 1f)
+    val normalizedTop = ((selection.top - videoBounds.top) / videoBounds.height()).coerceIn(0f, 1f)
+    val normalizedRight = ((selection.right - videoBounds.left) / videoBounds.width()).coerceIn(0f, 1f)
+    val normalizedBottom = ((selection.bottom - videoBounds.top) / videoBounds.height()).coerceIn(0f, 1f)
+
+    var x = floor(normalizedLeft * orientedWidth).toInt().coerceIn(0, (orientedWidth - 2).coerceAtLeast(0))
+    var y = floor(normalizedTop * orientedHeight).toInt().coerceIn(0, (orientedHeight - 2).coerceAtLeast(0))
+    var right = ceil(normalizedRight * orientedWidth).toInt().coerceIn(x + 1, orientedWidth)
+    var bottom = ceil(normalizedBottom * orientedHeight).toInt().coerceIn(y + 1, orientedHeight)
+
+    x = evenFloor(x)
+    y = evenFloor(y)
+    right = evenFloor(right).coerceAtLeast(x + 2).coerceAtMost(evenFloor(orientedWidth))
+    bottom = evenFloor(bottom).coerceAtLeast(y + 2).coerceAtMost(evenFloor(orientedHeight))
+    if (right <= x) right = min(evenFloor(orientedWidth), x + 2)
+    if (bottom <= y) bottom = min(evenFloor(orientedHeight), y + 2)
+
+    return ClipCrop(
+      x = x,
+      y = y,
+      width = (right - x).coerceAtLeast(2),
+      height = (bottom - y).coerceAtLeast(2),
+      rotation = rotation,
+    )
+  }
+
+  private fun hitTest(
+    x: Float,
+    y: Float,
+  ): DragMode {
+    val threshold = dpF(28f)
+    val nearLeft = kotlin.math.abs(x - selection.left) <= threshold
+    val nearRight = kotlin.math.abs(x - selection.right) <= threshold
+    val nearTop = kotlin.math.abs(y - selection.top) <= threshold
+    val nearBottom = kotlin.math.abs(y - selection.bottom) <= threshold
+    val withinHorizontal = x in (selection.left - threshold)..(selection.right + threshold)
+    val withinVertical = y in (selection.top - threshold)..(selection.bottom + threshold)
+
+    return when {
+      nearLeft && nearTop -> DragMode.TOP_LEFT
+      nearRight && nearTop -> DragMode.TOP_RIGHT
+      nearLeft && nearBottom -> DragMode.BOTTOM_LEFT
+      nearRight && nearBottom -> DragMode.BOTTOM_RIGHT
+      nearLeft && withinVertical -> DragMode.LEFT
+      nearRight && withinVertical -> DragMode.RIGHT
+      nearTop && withinHorizontal -> DragMode.TOP
+      nearBottom && withinHorizontal -> DragMode.BOTTOM
+      selection.contains(x, y) -> DragMode.MOVE
+      else -> DragMode.NONE
+    }
+  }
+
+  private fun updateSelection(
+    dx: Float,
+    dy: Float,
+  ) {
+    val minSize = dpF(48f)
+    when (dragMode) {
+      DragMode.MOVE -> {
+        var moveX = dx
+        var moveY = dy
+        if (selection.left + moveX < videoBounds.left) moveX = videoBounds.left - selection.left
+        if (selection.right + moveX > videoBounds.right) moveX = videoBounds.right - selection.right
+        if (selection.top + moveY < videoBounds.top) moveY = videoBounds.top - selection.top
+        if (selection.bottom + moveY > videoBounds.bottom) moveY = videoBounds.bottom - selection.bottom
+        selection.offset(moveX, moveY)
+      }
+      DragMode.LEFT, DragMode.TOP_LEFT, DragMode.BOTTOM_LEFT -> {
+        selection.left = (selection.left + dx).coerceIn(videoBounds.left, selection.right - minSize)
+        if (dragMode == DragMode.TOP_LEFT) {
+          selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minSize)
+        } else if (dragMode == DragMode.BOTTOM_LEFT) {
+          selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minSize, videoBounds.bottom)
+        }
+      }
+      DragMode.RIGHT, DragMode.TOP_RIGHT, DragMode.BOTTOM_RIGHT -> {
+        selection.right = (selection.right + dx).coerceIn(selection.left + minSize, videoBounds.right)
+        if (dragMode == DragMode.TOP_RIGHT) {
+          selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minSize)
+        } else if (dragMode == DragMode.BOTTOM_RIGHT) {
+          selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minSize, videoBounds.bottom)
+        }
+      }
+      DragMode.TOP -> selection.top = (selection.top + dy).coerceIn(videoBounds.top, selection.bottom - minSize)
+      DragMode.BOTTOM -> selection.bottom = (selection.bottom + dy).coerceIn(selection.top + minSize, videoBounds.bottom)
+      DragMode.NONE -> Unit
+    }
+  }
+
+  private fun handlePoints(): List<Pair<Float, Float>> =
+    listOf(
+      selection.left to selection.top,
+      selection.centerX() to selection.top,
+      selection.right to selection.top,
+      selection.left to selection.centerY(),
+      selection.right to selection.centerY(),
+      selection.left to selection.bottom,
+      selection.centerX() to selection.bottom,
+      selection.right to selection.bottom,
+    )
+
+  private fun evenFloor(value: Int): Int = value and -2
+
+  private fun dpF(value: Float): Float = value * density
+
+  private fun spF(value: Float): Float = value * resources.displayMetrics.scaledDensity
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/Media3ClipExporter.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/Media3ClipExporter.kt
@@ -6,8 +6,6 @@ package app.gyrolet.mpvrx.ui.player.clip
 
 import android.content.Context
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
@@ -45,14 +43,7 @@ import kotlin.math.roundToLong
  */
 @UnstableApi
 internal object Media3ClipExporter {
-  const val CANCELLED = "cancelled"
   private const val PROGRESS_POLL_MS = 150L
-
-  @Volatile
-  private var activeTransformer: Transformer? = null
-
-  @Volatile
-  private var activeCompletion: CompletableDeferred<String?>? = null
 
   suspend fun export(
     context: Context,
@@ -71,9 +62,7 @@ internal object Media3ClipExporter {
         File(output).delete()
 
         val completion = CompletableDeferred<String?>()
-        activeCompletion = completion
         val transformer = buildTransformer(context, headers, completion)
-        activeTransformer = transformer
 
         val mediaItem =
           MediaItem.Builder()
@@ -107,24 +96,10 @@ internal object Media3ClipExporter {
           completion.await()
         } finally {
           progressJob.cancelAndJoin()
-          if (activeTransformer === transformer) activeTransformer = null
-          if (activeCompletion === completion) activeCompletion = null
+          if (completion.isActive) transformer.cancel()
         }
       }
     }
-
-  fun cancel() {
-    val action = {
-      activeTransformer?.cancel()
-      activeCompletion?.complete(CANCELLED)
-      Unit
-    }
-    if (Looper.myLooper() == Looper.getMainLooper()) {
-      action()
-    } else {
-      Handler(Looper.getMainLooper()).post(action)
-    }
-  }
 
   private fun buildTransformer(
     context: Context,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/Media3ClipExporter.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/clip/Media3ClipExporter.kt
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.gyrolet.mpvrx.ui.player.clip
+
+import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import androidx.media3.common.Effect
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.Clock
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.effect.Crop
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.transformer.Composition
+import androidx.media3.transformer.DefaultDecoderFactory
+import androidx.media3.transformer.EditedMediaItem
+import androidx.media3.transformer.Effects
+import androidx.media3.transformer.ExoPlayerAssetLoader
+import androidx.media3.transformer.ExportException
+import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.ProgressHolder
+import androidx.media3.transformer.Transformer
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.math.roundToLong
+
+/**
+ * Clip exporter backed by Media3 Transformer.
+ *
+ * The player itself remains libmpv, but Clip export deliberately does not create a second mpv core.
+ * Media3 uses Android MediaCodec for decoding/encoding and OpenGL for crop effects, avoiding
+ * libmpv builds that do not expose encoding mode and fail during mpv_initialize().
+ */
+@UnstableApi
+internal object Media3ClipExporter {
+  const val CANCELLED = "cancelled"
+  private const val PROGRESS_POLL_MS = 150L
+
+  @Volatile
+  private var activeTransformer: Transformer? = null
+
+  @Volatile
+  private var activeCompletion: CompletableDeferred<String?>? = null
+
+  suspend fun export(
+    context: Context,
+    source: String,
+    output: String,
+    startSeconds: Double,
+    endSeconds: Double,
+    crop: ClipCrop?,
+    cropFrameWidth: Int,
+    cropFrameHeight: Int,
+    headers: Map<String, String>,
+    onProgress: (Double) -> Unit,
+  ): String? =
+    withContext(Dispatchers.Main.immediate) {
+      coroutineScope {
+        File(output).delete()
+
+        val completion = CompletableDeferred<String?>()
+        activeCompletion = completion
+        val transformer = buildTransformer(context, headers, completion)
+        activeTransformer = transformer
+
+        val mediaItem =
+          MediaItem.Builder()
+            .setUri(toMediaUri(source))
+            .setClippingConfiguration(
+              MediaItem.ClippingConfiguration.Builder()
+                .setStartPositionMs((startSeconds.coerceAtLeast(0.0) * 1000.0).roundToLong())
+                .setEndPositionMs((endSeconds.coerceAtLeast(startSeconds) * 1000.0).roundToLong())
+                .build(),
+            ).build()
+
+        val editedMediaItem =
+          EditedMediaItem.Builder(mediaItem)
+            .setEffects(buildEffects(crop, cropFrameWidth, cropFrameHeight))
+            .build()
+
+        transformer.start(editedMediaItem, output)
+
+        val progressJob =
+          launch {
+            val holder = ProgressHolder()
+            while (completion.isActive) {
+              if (transformer.getProgress(holder) == Transformer.PROGRESS_STATE_AVAILABLE) {
+                onProgress((holder.progress / 100.0).coerceIn(0.0, 1.0))
+              }
+              delay(PROGRESS_POLL_MS)
+            }
+          }
+
+        try {
+          completion.await()
+        } finally {
+          progressJob.cancelAndJoin()
+          if (activeTransformer === transformer) activeTransformer = null
+          if (activeCompletion === completion) activeCompletion = null
+        }
+      }
+    }
+
+  fun cancel() {
+    val action = {
+      activeTransformer?.cancel()
+      activeCompletion?.complete(CANCELLED)
+      Unit
+    }
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      action()
+    } else {
+      Handler(Looper.getMainLooper()).post(action)
+    }
+  }
+
+  private fun buildTransformer(
+    context: Context,
+    headers: Map<String, String>,
+    completion: CompletableDeferred<String?>,
+  ): Transformer {
+    val httpFactory = DefaultHttpDataSource.Factory()
+    headers.entries
+      .firstOrNull { it.key.equals("User-Agent", ignoreCase = true) }
+      ?.value
+      ?.takeIf { it.isNotBlank() }
+      ?.let(httpFactory::setUserAgent)
+
+    val requestProperties = headers.filterKeys { !it.equals("User-Agent", ignoreCase = true) }
+    if (requestProperties.isNotEmpty()) {
+      httpFactory.setDefaultRequestProperties(requestProperties)
+    }
+
+    val dataSourceFactory = DefaultDataSource.Factory(context, httpFactory)
+    val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
+    val decoderFactory =
+      DefaultDecoderFactory.Builder(context)
+        .setEnableDecoderFallback(true)
+        .build()
+    val assetLoaderFactory =
+      ExoPlayerAssetLoader.Factory(
+        context,
+        decoderFactory,
+        Clock.DEFAULT,
+        mediaSourceFactory,
+      )
+
+    val listener =
+      object : Transformer.Listener {
+        override fun onCompleted(
+          composition: Composition,
+          exportResult: ExportResult,
+        ) {
+          completion.complete(null)
+        }
+
+        override fun onError(
+          composition: Composition,
+          exportResult: ExportResult,
+          exportException: ExportException,
+        ) {
+          completion.complete(
+            exportException.message?.takeIf { it.isNotBlank() }
+              ?: "Media3 clip export failed",
+          )
+        }
+      }
+
+    return Transformer.Builder(context)
+      .setAssetLoaderFactory(assetLoaderFactory)
+      .setVideoMimeType(MimeTypes.VIDEO_H264)
+      .setAudioMimeType(MimeTypes.AUDIO_AAC)
+      .addListener(listener)
+      .build()
+  }
+
+  private fun buildEffects(
+    crop: ClipCrop?,
+    frameWidth: Int,
+    frameHeight: Int,
+  ): Effects {
+    crop ?: return Effects.EMPTY
+    if (crop.width <= 0 || crop.height <= 0 || frameWidth <= 0 || frameHeight <= 0) {
+      return Effects.EMPTY
+    }
+
+    // CropSelectionView reports coordinates in the same oriented frame the user sees. Media3
+    // applies the container's rotation metadata before GL effects, so these normalized coordinates
+    // can be applied directly without an additional rotation transform.
+    val width = frameWidth.toFloat()
+    val height = frameHeight.toFloat()
+    val left = (-1f + 2f * crop.x / width).coerceIn(-1f, 1f)
+    val right = (-1f + 2f * (crop.x + crop.width) / width).coerceIn(-1f, 1f)
+    val top = (1f - 2f * crop.y / height).coerceIn(-1f, 1f)
+    val bottom = (1f - 2f * (crop.y + crop.height) / height).coerceIn(-1f, 1f)
+    if (right <= left || top <= bottom) return Effects.EMPTY
+
+    val videoEffects: List<Effect> = listOf(Crop(left, right, bottom, top))
+    return Effects(emptyList(), videoEffects)
+  }
+
+  private fun toMediaUri(source: String): Uri {
+    val parsed = Uri.parse(source)
+    if (!parsed.scheme.isNullOrBlank()) return parsed
+    return if (source.startsWith('/')) Uri.fromFile(File(source)) else parsed
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
@@ -893,6 +893,7 @@ fun PlayerControls(
           val showPortraitCustomButtons = areButtonsVisible && isPortrait && customButtons.isNotEmpty()
           val customButtonsRowVerticalPadding = 2.dp
           val skipChipToButtonsSpacing = 4.dp
+          val bottomControlsToSeekbarSpacing = spacing.smaller
           val bottomRightControlsBottomOffset =
             if (bottomRightControlsTopPx != null && controlsLayoutHeightPx > 0) {
               with(density) {
@@ -1748,7 +1749,7 @@ fun PlayerControls(
                     end.linkTo(parent.end, spacing.large)
                     width = Dimension.fillToConstraints
                   } else {
-                    bottom.linkTo(seekbar.top, spacing.medium)
+                    bottom.linkTo(seekbar.top, bottomControlsToSeekbarSpacing)
                     end.linkTo(parent.end, spacing.large)
                   }
                 }.onGloballyPositioned { coordinates ->
@@ -1811,7 +1812,7 @@ fun PlayerControls(
                     Modifier
                   },
                 ).constrainAs(bottomLeftControls) {
-                  bottom.linkTo(seekbar.top, spacing.medium)
+                  bottom.linkTo(seekbar.top, bottomControlsToSeekbarSpacing)
                   start.linkTo(parent.start, spacing.large)
                   width = Dimension.fillToConstraints
                   end.linkTo(bottomRightControls.start, spacing.small)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControlsShared.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControlsShared.kt
@@ -72,7 +72,6 @@ import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.ui.player.Panels
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerViewModel
-import app.gyrolet.mpvrx.ui.player.clip.ClipEditorUiState
 import app.gyrolet.mpvrx.ui.player.clip.ClipOverlayView
 import app.gyrolet.mpvrx.ui.player.Sheets
 import app.gyrolet.mpvrx.ui.player.VideoAspect
@@ -700,129 +699,13 @@ fun RenderPlayerButton(
 
     PlayerButton.CLIP -> {
       val clipOverlay = remember(activity) { ClipOverlayView.ensureAttached(activity) }
-      val clipRange by ClipEditorUiState.state.collectAsState()
-      var isClipExpanded by remember { mutableStateOf(false) }
-      val clipControlColor = if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface
-
-      AnimatedContent(
-        targetState = isClipExpanded,
-        transitionSpec = {
-(fadeIn(animationSpec = tween(200)) + expandHorizontally(animationSpec = tween(250)))
-  .togetherWith(fadeOut(animationSpec = tween(200)) + shrinkHorizontally(animationSpec = tween(250)))
-  .using(SizeTransform(clip = false))
-        },
-        label = "ClipExpandCollapse",
-      ) { expanded ->
-        if (expanded) {
-Surface(
-  shape = MaterialTheme.shapes.extraLarge,
-  color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f),
-  border =
-    if (hideBackground) null
-    else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
-  modifier = Modifier.height(buttonSize),
-) {
-  Row(
-    horizontalArrangement = Arrangement.spacedBy(2.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    modifier = Modifier.padding(horizontal = 4.dp),
-  ) {
-    Surface(
-      shape = CircleShape,
-      color = if (clipRange != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
-      modifier =
-        Modifier
-          .height(buttonSize - 4.dp)
-          .widthIn(min = buttonSize - 4.dp)
-          .clip(CircleShape)
-          .clickable {
-            clickEvent()
-            clipOverlay.markStartAtCurrent()
-          },
-    ) {
-      Box(contentAlignment = Alignment.Center) {
-        Text(
-          text = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_start_short),
-          style = MaterialTheme.typography.labelLarge,
-          color = if (clipRange != null) MaterialTheme.colorScheme.onTertiaryContainer else clipControlColor,
-          modifier = Modifier.padding(horizontal = 10.dp),
-        )
-      }
-    }
-
-    @OptIn(ExperimentalFoundationApi::class)
-    Surface(
-      shape = CircleShape,
-      color = MaterialTheme.colorScheme.primaryContainer,
-      modifier =
-        Modifier
-          .height(buttonSize - 4.dp)
-          .widthIn(min = buttonSize - 4.dp)
-          .clip(CircleShape)
-          .combinedClickable(
-            onClick = {
-              clickEvent()
-              isClipExpanded = false
-              clipOverlay.openCrop()
-            },
-            onLongClick = {
-              clickEvent()
-              isClipExpanded = false
-              clipOverlay.openClip()
-            },
-          ),
-    ) {
-      Box(contentAlignment = Alignment.Center) {
-        Text(
-          text = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_crop),
-          style = MaterialTheme.typography.labelLarge,
-          color = MaterialTheme.colorScheme.onPrimaryContainer,
-          modifier = Modifier.padding(horizontal = 10.dp),
-        )
-      }
-    }
-
-    Surface(
-      shape = CircleShape,
-      color = if (clipRange?.endSeconds != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
-      modifier =
-        Modifier
-          .height(buttonSize - 4.dp)
-          .widthIn(min = buttonSize - 4.dp)
-          .clip(CircleShape)
-          .clickable {
-            clickEvent()
-            clipOverlay.markEndAtCurrent()
-          },
-    ) {
-      Box(contentAlignment = Alignment.Center) {
-        Text(
-          text = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_end_short),
-          style = MaterialTheme.typography.labelLarge,
-          color = if (clipRange?.endSeconds != null) MaterialTheme.colorScheme.onTertiaryContainer else clipControlColor,
-          modifier = Modifier.padding(horizontal = 10.dp),
-        )
-      }
-    }
-  }
-}
-        } else {
-ControlsButton(
-  icon = button.icon,
-  onClick = {
-    clickEvent()
-    isClipExpanded = true
-  },
-  onLongClick = {
-    clickEvent()
-    clipOverlay.openClip()
-  },
-  title = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_action),
-  color = clipControlColor,
-  modifier = Modifier.size(buttonSize),
-)
-        }
-      }
+      ControlsButton(
+        icon = button.icon,
+        onClick = clipOverlay::openClip,
+        title = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_action),
+        color = if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.size(buttonSize),
+      )
     }
 
     PlayerButton.EQUALIZER -> {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControlsShared.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControlsShared.kt
@@ -47,8 +47,10 @@ import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -70,6 +72,8 @@ import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.ui.player.Panels
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerViewModel
+import app.gyrolet.mpvrx.ui.player.clip.ClipEditorUiState
+import app.gyrolet.mpvrx.ui.player.clip.ClipOverlayView
 import app.gyrolet.mpvrx.ui.player.Sheets
 import app.gyrolet.mpvrx.ui.player.VideoAspect
 import app.gyrolet.mpvrx.ui.player.controls.components.AbLoopIcon
@@ -692,6 +696,133 @@ fun RenderPlayerButton(
         color = if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface,
         modifier = Modifier.size(buttonSize),
       )
+    }
+
+    PlayerButton.CLIP -> {
+      val clipOverlay = remember(activity) { ClipOverlayView.ensureAttached(activity) }
+      val clipRange by ClipEditorUiState.state.collectAsState()
+      var isClipExpanded by remember { mutableStateOf(false) }
+      val clipControlColor = if (hideBackground) controlColor else MaterialTheme.colorScheme.onSurface
+
+      AnimatedContent(
+        targetState = isClipExpanded,
+        transitionSpec = {
+(fadeIn(animationSpec = tween(200)) + expandHorizontally(animationSpec = tween(250)))
+  .togetherWith(fadeOut(animationSpec = tween(200)) + shrinkHorizontally(animationSpec = tween(250)))
+  .using(SizeTransform(clip = false))
+        },
+        label = "ClipExpandCollapse",
+      ) { expanded ->
+        if (expanded) {
+Surface(
+  shape = MaterialTheme.shapes.extraLarge,
+  color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.55f),
+  border =
+    if (hideBackground) null
+    else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+  modifier = Modifier.height(buttonSize),
+) {
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(2.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.padding(horizontal = 4.dp),
+  ) {
+    Surface(
+      shape = CircleShape,
+      color = if (clipRange != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
+      modifier =
+        Modifier
+          .height(buttonSize - 4.dp)
+          .widthIn(min = buttonSize - 4.dp)
+          .clip(CircleShape)
+          .clickable {
+            clickEvent()
+            clipOverlay.markStartAtCurrent()
+          },
+    ) {
+      Box(contentAlignment = Alignment.Center) {
+        Text(
+          text = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_start_short),
+          style = MaterialTheme.typography.labelLarge,
+          color = if (clipRange != null) MaterialTheme.colorScheme.onTertiaryContainer else clipControlColor,
+          modifier = Modifier.padding(horizontal = 10.dp),
+        )
+      }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    Surface(
+      shape = CircleShape,
+      color = MaterialTheme.colorScheme.primaryContainer,
+      modifier =
+        Modifier
+          .height(buttonSize - 4.dp)
+          .widthIn(min = buttonSize - 4.dp)
+          .clip(CircleShape)
+          .combinedClickable(
+            onClick = {
+              clickEvent()
+              isClipExpanded = false
+              clipOverlay.openCrop()
+            },
+            onLongClick = {
+              clickEvent()
+              isClipExpanded = false
+              clipOverlay.openClip()
+            },
+          ),
+    ) {
+      Box(contentAlignment = Alignment.Center) {
+        Text(
+          text = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_crop),
+          style = MaterialTheme.typography.labelLarge,
+          color = MaterialTheme.colorScheme.onPrimaryContainer,
+          modifier = Modifier.padding(horizontal = 10.dp),
+        )
+      }
+    }
+
+    Surface(
+      shape = CircleShape,
+      color = if (clipRange?.endSeconds != null) MaterialTheme.colorScheme.tertiaryContainer else Color.Transparent,
+      modifier =
+        Modifier
+          .height(buttonSize - 4.dp)
+          .widthIn(min = buttonSize - 4.dp)
+          .clip(CircleShape)
+          .clickable {
+            clickEvent()
+            clipOverlay.markEndAtCurrent()
+          },
+    ) {
+      Box(contentAlignment = Alignment.Center) {
+        Text(
+          text = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_end_short),
+          style = MaterialTheme.typography.labelLarge,
+          color = if (clipRange?.endSeconds != null) MaterialTheme.colorScheme.onTertiaryContainer else clipControlColor,
+          modifier = Modifier.padding(horizontal = 10.dp),
+        )
+      }
+    }
+  }
+}
+        } else {
+ControlsButton(
+  icon = button.icon,
+  onClick = {
+    clickEvent()
+    isClipExpanded = true
+  },
+  onLongClick = {
+    clickEvent()
+    clipOverlay.openClip()
+  },
+  title = androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.clip_action),
+  color = clipControlColor,
+  modifier = Modifier.size(buttonSize),
+)
+        }
+      }
     }
 
     PlayerButton.EQUALIZER -> {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/Seekbar.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/Seekbar.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -68,6 +69,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -83,6 +85,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import app.gyrolet.mpvrx.preferences.SeekbarStyle
 import app.gyrolet.mpvrx.ui.player.SkipSegment
+import app.gyrolet.mpvrx.ui.player.clip.ClipEditorUiState
 import app.gyrolet.mpvrx.ui.player.controls.LocalPlayerButtonsClickEvent
 import app.gyrolet.mpvrx.ui.theme.AppMotion
 import app.gyrolet.mpvrx.ui.theme.spacing
@@ -460,6 +463,8 @@ private fun SeekbarContent(
   val isSeekerPressed by seekerInteractionSource.collectIsPressedAsState()
   val isSeekerDragged by seekerInteractionSource.collectIsDraggedAsState()
   val isVisuallyInteracting = isUserInteracting || isSeekerPressed || isSeekerDragged
+  val clipRange by ClipEditorUiState.state.collectAsState()
+  val clipRangeColor = MaterialTheme.colorScheme.tertiary
   val safeDuration = duration.takeIf { it.isFinite() && it > 0f } ?: 0f
   val seekerRange = 0f..safeDuration.coerceAtLeast(0.1f)
   val safeCommittedPosition =
@@ -649,6 +654,34 @@ private fun SeekbarContent(
             end = Offset(endX, trackHeight),
             strokeWidth = edgeStroke,
           )
+        }
+      }
+
+      val activeClip = clipRange
+      val clipEnd = activeClip?.endSeconds
+      if (activeClip != null && clipEnd != null && duration > 0f && clipEnd > activeClip.startSeconds) {
+        val startX = (activeClip.startSeconds / duration).coerceIn(0f, 1f) * size.width
+        val endX = (clipEnd / duration).coerceIn(0f, 1f) * size.width
+        if (endX > startX) {
+          drawRect(
+            color = clipRangeColor.copy(alpha = 0.08f),
+            topLeft = Offset(startX, 0f),
+            size = Size(endX - startX, size.height),
+          )
+          val stripeSpacing = 6.dp.toPx().coerceAtLeast(1f)
+          val stripeWidth = 1.25.dp.toPx()
+          val dashPattern = PathEffect.dashPathEffect(floatArrayOf(1.5.dp.toPx(), 1.75.dp.toPx()))
+          var x = startX
+          while (x <= endX) {
+            drawLine(
+              color = clipRangeColor.copy(alpha = 0.9f),
+              start = Offset(x, 0f),
+              end = Offset(x, size.height),
+              strokeWidth = stripeWidth,
+              pathEffect = dashPattern,
+            )
+            x += stripeSpacing
+          }
         }
       }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1791,4 +1791,29 @@
   <string name="lyrics_translating">جارٍ ترجمة كلمات الأغاني…</string>
   <string name="lyrics_translation_off">كلمات الأغاني الأصلية</string>
   <string name="lyrics_select_language">تحديد اللغة المستهدفة</string>
+
+  <!-- Clip -->
+  <string name="clip_action">إنشاء مقطع</string>
+  <string name="clip_options">خيارات المقطع</string>
+  <string name="clip_crop_action">اقتصاص وإنشاء مقطع</string>
+  <string name="clip_mark_start">تحديد البداية</string>
+  <string name="clip_mark_end">تحديد النهاية</string>
+  <string name="clip_crop">اقتصاص</string>
+  <string name="clip_save">حفظ المقطع</string>
+  <string name="clip_cancel">إلغاء</string>
+  <string name="clip_done">تم</string>
+  <string name="clip_clear">مسح المقطع</string>
+  <string name="clip_start_time">البداية: %1$s</string>
+  <string name="clip_end_time">النهاية: %1$s</string>
+  <string name="clip_end_not_set">النهاية: غير محددة</string>
+  <string name="clip_crop_size">الاقتصاص: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">الاقتصاص: الإطار الكامل</string>
+  <string name="clip_select_crop">غيّر حجم الإطار للاحتفاظ بالجزء المطلوب</string>
+  <string name="clip_exporting">جارٍ إنشاء المقطع… %1$d%%</string>
+  <string name="clip_cancelling">جارٍ إلغاء المقطع…</string>
+  <string name="clip_saved">تم حفظ %1$s</string>
+  <string name="clip_invalid_range">حدّد نقطة نهاية بعد نقطة البداية</string>
+  <string name="clip_video_unavailable">أبعاد الفيديو غير متاحة بعد</string>
+  <string name="clip_export_busy">يجري إنشاء مقطع آخر بالفعل</string>
+  <string name="clip_export_failed">فشل إنشاء المقطع: %1$s</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1789,4 +1789,29 @@ Bitte starten Sie die App neu, damit alle Änderungen wirksam werden.</string>
   <string name="lyrics_translating">Songtext wird übersetzt…</string>
   <string name="lyrics_translation_off">Original-Songtext</string>
   <string name="lyrics_select_language">Zielsprache auswählen</string>
+
+  <!-- Clip -->
+  <string name="clip_action">Clip erstellen</string>
+  <string name="clip_options">Clip-Optionen</string>
+  <string name="clip_crop_action">Zuschneiden &amp; Clip erstellen</string>
+  <string name="clip_mark_start">Start markieren</string>
+  <string name="clip_mark_end">Ende markieren</string>
+  <string name="clip_crop">Zuschneiden</string>
+  <string name="clip_save">Clip speichern</string>
+  <string name="clip_cancel">Abbrechen</string>
+  <string name="clip_done">Fertig</string>
+  <string name="clip_clear">Clip löschen</string>
+  <string name="clip_start_time">Start: %1$s</string>
+  <string name="clip_end_time">Ende: %1$s</string>
+  <string name="clip_end_not_set">Ende: Nicht festgelegt</string>
+  <string name="clip_crop_size">Zuschnitt: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">Zuschnitt: Vollbild</string>
+  <string name="clip_select_crop">Rahmen auf den gewünschten Bereich anpassen</string>
+  <string name="clip_exporting">Clip wird erstellt… %1$d%%</string>
+  <string name="clip_cancelling">Clip wird abgebrochen…</string>
+  <string name="clip_saved">%1$s gespeichert</string>
+  <string name="clip_invalid_range">Markiere einen Endpunkt nach dem Startpunkt</string>
+  <string name="clip_video_unavailable">Videoabmessungen sind noch nicht verfügbar</string>
+  <string name="clip_export_busy">Ein anderer Clip wird bereits erstellt</string>
+  <string name="clip_export_failed">Clip fehlgeschlagen: %1$s</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1789,4 +1789,29 @@ Reinicia la aplicación para que se apliquen todos los cambios.</string>
   <string name="lyrics_translating">Traduciendo letra…</string>
   <string name="lyrics_translation_off">Letra original</string>
   <string name="lyrics_select_language">Seleccionar idioma de destino</string>
+
+  <!-- Clip -->
+  <string name="clip_action">Crear clip</string>
+  <string name="clip_options">Opciones del clip</string>
+  <string name="clip_crop_action">Recortar y crear clip</string>
+  <string name="clip_mark_start">Marcar inicio</string>
+  <string name="clip_mark_end">Marcar fin</string>
+  <string name="clip_crop">Recortar</string>
+  <string name="clip_save">Guardar clip</string>
+  <string name="clip_cancel">Cancelar</string>
+  <string name="clip_done">Listo</string>
+  <string name="clip_clear">Borrar clip</string>
+  <string name="clip_start_time">Inicio: %1$s</string>
+  <string name="clip_end_time">Fin: %1$s</string>
+  <string name="clip_end_not_set">Fin: Sin definir</string>
+  <string name="clip_crop_size">Recorte: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">Recorte: Fotograma completo</string>
+  <string name="clip_select_crop">Redimensiona el marco para conservar el área deseada</string>
+  <string name="clip_exporting">Creando clip… %1$d%%</string>
+  <string name="clip_cancelling">Cancelando clip…</string>
+  <string name="clip_saved">%1$s guardado</string>
+  <string name="clip_invalid_range">Marca un punto final después del punto inicial</string>
+  <string name="clip_video_unavailable">Las dimensiones del video aún no están disponibles</string>
+  <string name="clip_export_busy">Ya se está creando otro clip</string>
+  <string name="clip_export_failed">Error al crear el clip: %1$s</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1789,4 +1789,29 @@ Veuillez redémarrer l’application pour appliquer toutes les modifications.</s
   <string name="lyrics_translating">Traduction des paroles…</string>
   <string name="lyrics_translation_off">Paroles originales</string>
   <string name="lyrics_select_language">Sélectionner la langue cible</string>
+
+  <!-- Clip -->
+  <string name="clip_action">Créer un clip</string>
+  <string name="clip_options">Options du clip</string>
+  <string name="clip_crop_action">Recadrer et créer un clip</string>
+  <string name="clip_mark_start">Marquer le début</string>
+  <string name="clip_mark_end">Marquer la fin</string>
+  <string name="clip_crop">Recadrer</string>
+  <string name="clip_save">Enregistrer le clip</string>
+  <string name="clip_cancel">Annuler</string>
+  <string name="clip_done">Terminé</string>
+  <string name="clip_clear">Effacer le clip</string>
+  <string name="clip_start_time">Début : %1$s</string>
+  <string name="clip_end_time">Fin : %1$s</string>
+  <string name="clip_end_not_set">Fin : Non définie</string>
+  <string name="clip_crop_size">Recadrage : %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">Recadrage : Image entière</string>
+  <string name="clip_select_crop">Redimensionnez le cadre pour conserver la zone souhaitée</string>
+  <string name="clip_exporting">Création du clip… %1$d%%</string>
+  <string name="clip_cancelling">Annulation du clip…</string>
+  <string name="clip_saved">%1$s enregistré</string>
+  <string name="clip_invalid_range">Marquez un point de fin après le point de début</string>
+  <string name="clip_video_unavailable">Les dimensions de la vidéo ne sont pas encore disponibles</string>
+  <string name="clip_export_busy">Un autre clip est déjà en cours de création</string>
+  <string name="clip_export_failed">Échec du clip : %1$s</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1693,4 +1693,29 @@
   <string name="lyrics_translating">बोल अनुवाद हो रहे हैं…</string>
   <string name="lyrics_translation_off">मूल बोल</string>
   <string name="lyrics_select_language">लक्षित भाषा चुनें</string>
+
+  <!-- Clip -->
+  <string name="clip_action">क्लिप बनाएँ</string>
+  <string name="clip_options">क्लिप विकल्प</string>
+  <string name="clip_crop_action">क्रॉप करके क्लिप बनाएँ</string>
+  <string name="clip_mark_start">शुरुआत चिन्हित करें</string>
+  <string name="clip_mark_end">अंत चिन्हित करें</string>
+  <string name="clip_crop">क्रॉप करें</string>
+  <string name="clip_save">क्लिप सहेजें</string>
+  <string name="clip_cancel">रद्द करें</string>
+  <string name="clip_done">हो गया</string>
+  <string name="clip_clear">क्लिप साफ़ करें</string>
+  <string name="clip_start_time">शुरुआत: %1$s</string>
+  <string name="clip_end_time">अंत: %1$s</string>
+  <string name="clip_end_not_set">अंत: सेट नहीं</string>
+  <string name="clip_crop_size">क्रॉप: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">क्रॉप: पूरा फ़्रेम</string>
+  <string name="clip_select_crop">जिस हिस्से को रखना है उसके अनुसार फ़्रेम का आकार बदलें</string>
+  <string name="clip_exporting">क्लिप बनाई जा रही है… %1$d%%</string>
+  <string name="clip_cancelling">क्लिप रद्द की जा रही है…</string>
+  <string name="clip_saved">%1$s सहेजा गया</string>
+  <string name="clip_invalid_range">शुरुआत के बाद एक अंत बिंदु चिन्हित करें</string>
+  <string name="clip_video_unavailable">वीडियो के आयाम अभी उपलब्ध नहीं हैं</string>
+  <string name="clip_export_busy">एक और क्लिप पहले से बनाई जा रही है</string>
+  <string name="clip_export_failed">क्लिप बनाने में विफल: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1789,4 +1789,29 @@
   <string name="lyrics_translating">歌詞を翻訳中…</string>
   <string name="lyrics_translation_off">元の歌詞</string>
   <string name="lyrics_select_language">翻訳先言語を選択</string>
+
+  <!-- Clip -->
+  <string name="clip_action">クリップを作成</string>
+  <string name="clip_options">クリップのオプション</string>
+  <string name="clip_crop_action">切り抜いてクリップを作成</string>
+  <string name="clip_mark_start">開始位置をマーク</string>
+  <string name="clip_mark_end">終了位置をマーク</string>
+  <string name="clip_crop">切り抜き</string>
+  <string name="clip_save">クリップを保存</string>
+  <string name="clip_cancel">キャンセル</string>
+  <string name="clip_done">完了</string>
+  <string name="clip_clear">クリップをクリア</string>
+  <string name="clip_start_time">開始: %1$s</string>
+  <string name="clip_end_time">終了: %1$s</string>
+  <string name="clip_end_not_set">終了: 未設定</string>
+  <string name="clip_crop_size">切り抜き: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">切り抜き: フレーム全体</string>
+  <string name="clip_select_crop">残す範囲に合わせて枠のサイズを変更してください</string>
+  <string name="clip_exporting">クリップを作成中… %1$d%%</string>
+  <string name="clip_cancelling">クリップをキャンセル中…</string>
+  <string name="clip_saved">%1$s を保存しました</string>
+  <string name="clip_invalid_range">開始位置より後に終了位置をマークしてください</string>
+  <string name="clip_video_unavailable">動画のサイズはまだ利用できません</string>
+  <string name="clip_export_busy">別のクリップを作成中です</string>
+  <string name="clip_export_failed">クリップの作成に失敗しました: %1$s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1789,4 +1789,29 @@ Reinicie o aplicativo para que todas as alterações entrem em vigor.</string>
   <string name="lyrics_translating">Traduzindo letras…</string>
   <string name="lyrics_translation_off">Letras originais</string>
   <string name="lyrics_select_language">Selecionar idioma de destino</string>
+
+  <!-- Clip -->
+  <string name="clip_action">Criar clipe</string>
+  <string name="clip_options">Opções do clipe</string>
+  <string name="clip_crop_action">Recortar e criar clipe</string>
+  <string name="clip_mark_start">Marcar início</string>
+  <string name="clip_mark_end">Marcar fim</string>
+  <string name="clip_crop">Recortar</string>
+  <string name="clip_save">Salvar clipe</string>
+  <string name="clip_cancel">Cancelar</string>
+  <string name="clip_done">Concluído</string>
+  <string name="clip_clear">Limpar clipe</string>
+  <string name="clip_start_time">Início: %1$s</string>
+  <string name="clip_end_time">Fim: %1$s</string>
+  <string name="clip_end_not_set">Fim: Não definido</string>
+  <string name="clip_crop_size">Recorte: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">Recorte: Quadro inteiro</string>
+  <string name="clip_select_crop">Redimensione o quadro para manter a área desejada</string>
+  <string name="clip_exporting">Criando clipe… %1$d%%</string>
+  <string name="clip_cancelling">Cancelando clipe…</string>
+  <string name="clip_saved">%1$s salvo</string>
+  <string name="clip_invalid_range">Marque um ponto final depois do ponto inicial</string>
+  <string name="clip_video_unavailable">As dimensões do vídeo ainda não estão disponíveis</string>
+  <string name="clip_export_busy">Outro clipe já está sendo criado</string>
+  <string name="clip_export_failed">Falha ao criar o clipe: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1789,4 +1789,29 @@
   <string name="lyrics_translating">Перевод текста песни…</string>
   <string name="lyrics_translation_off">Оригинальный текст</string>
   <string name="lyrics_select_language">Выбрать язык перевода</string>
+
+  <!-- Clip -->
+  <string name="clip_action">Создать клип</string>
+  <string name="clip_options">Параметры клипа</string>
+  <string name="clip_crop_action">Обрезать и создать клип</string>
+  <string name="clip_mark_start">Отметить начало</string>
+  <string name="clip_mark_end">Отметить конец</string>
+  <string name="clip_crop">Кадрировать</string>
+  <string name="clip_save">Сохранить клип</string>
+  <string name="clip_cancel">Отмена</string>
+  <string name="clip_done">Готово</string>
+  <string name="clip_clear">Очистить клип</string>
+  <string name="clip_start_time">Начало: %1$s</string>
+  <string name="clip_end_time">Конец: %1$s</string>
+  <string name="clip_end_not_set">Конец: Не задан</string>
+  <string name="clip_crop_size">Кадрирование: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">Кадрирование: Весь кадр</string>
+  <string name="clip_select_crop">Измените размер рамки, чтобы оставить нужную область</string>
+  <string name="clip_exporting">Создание клипа… %1$d%%</string>
+  <string name="clip_cancelling">Отмена создания клипа…</string>
+  <string name="clip_saved">%1$s сохранён</string>
+  <string name="clip_invalid_range">Отметьте конечную точку после начальной</string>
+  <string name="clip_video_unavailable">Размеры видео пока недоступны</string>
+  <string name="clip_export_busy">Другой клип уже создаётся</string>
+  <string name="clip_export_failed">Не удалось создать клип: %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1791,4 +1791,29 @@
   <string name="lyrics_translating">正在翻译歌词…</string>
   <string name="lyrics_translation_off">原始歌词</string>
   <string name="lyrics_select_language">选择目标语言</string>
+
+  <!-- Clip -->
+  <string name="clip_action">创建片段</string>
+  <string name="clip_options">片段选项</string>
+  <string name="clip_crop_action">裁剪并创建片段</string>
+  <string name="clip_mark_start">标记开始</string>
+  <string name="clip_mark_end">标记结束</string>
+  <string name="clip_crop">裁剪</string>
+  <string name="clip_save">保存片段</string>
+  <string name="clip_cancel">取消</string>
+  <string name="clip_done">完成</string>
+  <string name="clip_clear">清除片段</string>
+  <string name="clip_start_time">开始：%1$s</string>
+  <string name="clip_end_time">结束：%1$s</string>
+  <string name="clip_end_not_set">结束：未设置</string>
+  <string name="clip_crop_size">裁剪：%1$d × %2$d</string>
+  <string name="clip_crop_full_frame">裁剪：完整画面</string>
+  <string name="clip_select_crop">调整边框大小以保留需要的区域</string>
+  <string name="clip_exporting">正在创建片段… %1$d%%</string>
+  <string name="clip_cancelling">正在取消片段…</string>
+  <string name="clip_saved">已保存 %1$s</string>
+  <string name="clip_invalid_range">请在开始点之后标记结束点</string>
+  <string name="clip_video_unavailable">视频尺寸暂不可用</string>
+  <string name="clip_export_busy">已有另一个片段正在创建</string>
+  <string name="clip_export_failed">片段创建失败：%1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1788,4 +1788,31 @@
   <string name="lyrics_translating">Translating lyrics…</string>
   <string name="lyrics_translation_off">Original Lyrics</string>
   <string name="lyrics_select_language">Select Target Language</string>
+
+  <!-- Clip -->
+  <string name="clip_end_short">End</string>
+  <string name="clip_start_short">Start</string>
+  <string name="clip_action">Create clip</string>
+  <string name="clip_options">Clip options</string>
+  <string name="clip_crop_action">Crop &amp; create clip</string>
+  <string name="clip_mark_start">Mark start</string>
+  <string name="clip_mark_end">Mark end</string>
+  <string name="clip_crop">Crop</string>
+  <string name="clip_save">Save clip</string>
+  <string name="clip_cancel">Cancel</string>
+  <string name="clip_done">Done</string>
+  <string name="clip_clear">Clear clip</string>
+  <string name="clip_start_time">Start: %1$s</string>
+  <string name="clip_end_time">End: %1$s</string>
+  <string name="clip_end_not_set">End: Not set</string>
+  <string name="clip_crop_size">Crop: %1$d × %2$d</string>
+  <string name="clip_crop_full_frame">Crop: Full frame</string>
+  <string name="clip_select_crop">Resize the frame to keep</string>
+  <string name="clip_exporting">Creating clip… %1$d%%</string>
+  <string name="clip_cancelling">Cancelling clip…</string>
+  <string name="clip_saved">Saved %1$s</string>
+  <string name="clip_invalid_range">Mark an end point after the start point</string>
+  <string name="clip_video_unavailable">Video dimensions are not available yet</string>
+  <string name="clip_export_busy">Another clip is already being created</string>
+  <string name="clip_export_failed">Clip failed: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add Clip as a first-class **customizable player button** using the app's normal `PlayerButton` + `ControlsButton` pipeline
- use the rounded Material Symbols `Content_cut` icon through the shared mpvRx `Icons` registry
- keep `player_layout.xml` untouched; attach the Clip overlay at runtime only when needed
- export clips with **AndroidX Media3 Transformer** instead of spawning a second libmpv encoding core
- use Android MediaCodec for decode/encode and OpenGL effects for visual crop
- support export progress/cancellation and save completed MP4 clips to `Movies/mpvRx/Clips`
- preserve HTTP headers/user-agent for direct network exports and safely reopen content/network sources

## UX
- **tap scissors**: expand inline quick controls with the same horizontal interaction language as A/B Loop
- expanded controls are **Start | Crop | End**, with **Crop fixed in the center**
- Start and End mark the current playback position and **keep the expanded Clip controls visible**, matching A/B Loop point behavior
- center Crop opens the unobstructed on-video crop selector; Done/Cancel returns to normal player controls
- **long press scissors**: open the compact draggable Clip editor for precise range/crop/save work
- the compact editor keeps start/end times, range slider, Start/Crop/End actions, and Save/Cancel organized in one smaller panel
- the selected clip interval is shown across the seekbar as a repeated vertical dotted band
- crop mode hides the editor and normal controls, pauses playback if needed, and restores the appropriate UI/playback state afterward
- export progress and cancellation are shown inline

## Architecture
Playback remains owned by libmpv. Clip export uses a separate AndroidX Media3 Transformer editing pipeline with MediaCodec decoding/encoding and OpenGL crop effects. Start/end trimming is applied through `MediaItem.ClippingConfiguration`.

The Clip export path no longer creates or initializes a second libmpv core, so it does not depend on libmpv encoding support and cannot hit the previous `mpv_initialize(-4)` failure path.

Visual crop coordinates are selected over the actual player view, mapped to the displayed video frame, and applied during export. This is video processing, not Android screen recording.

Media3 receives Android `content://` sources directly. Saved MPVRX network items continue to use short-lived `NetworkStreamingProxy` registrations which are unregistered when export completes; direct HTTP headers and user-agent are passed through Media3's HTTP data source.