### PR TITLE
feat: add live release channel to preview site

### DIFF
--- a/fastlane/metadata/android/preview-site/index.html
+++ b/fastlane/metadata/android/preview-site/index.html
@@ -4,10 +4,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-  <title>mpvRx Preview Builds for Android</title>
-  <meta name="description" content="Download verified Standard, Fongmi, and non-Vulkan preview APKs for the mpvRx Android media player.">
-  <meta name="robots" content="noindex,follow">
+  <title>mpvRx — Preview & Stable Releases</title>
+  <meta name="description" content="Preview and stable releases for the mpvRx Android media player, pulled live from GitHub.">
+  <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#6f4ee8">
+  <meta name="color-scheme" content="light dark">
   <link rel="canonical" href="https://riteshp2001.github.io/mpvRx/">
   <link rel="icon" href="icon.png" type="image/png">
   <link rel="apple-touch-icon" href="icon.png">
@@ -16,25 +17,25 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="mpvRx">
   <meta property="og:locale" content="en_US">
-  <meta property="og:title" content="mpvRx Preview Builds for Android">
-  <meta property="og:description" content="Verified Standard, Fongmi, and non-Vulkan preview APKs, published directly from GitHub Actions.">
+  <meta property="og:title" content="mpvRx — Preview & Stable Releases">
+  <meta property="og:description" content="Preview and stable releases for the mpvRx Android media player.">
   <meta property="og:url" content="https://riteshp2001.github.io/mpvRx/">
   <meta property="og:image" content="https://riteshp2001.github.io/mpvRx/icon.png">
   <meta property="og:image:width" content="324">
   <meta property="og:image:height" content="324">
   <meta property="og:image:alt" content="mpvRx app logo">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="mpvRx Preview Builds for Android">
-  <meta name="twitter:description" content="Verified Standard, Fongmi, and non-Vulkan preview APKs from GitHub Actions.">
+  <meta name="twitter:title" content="mpvRx — Preview & Stable Releases">
+  <meta name="twitter:description" content="Stable and preview release history, pulled live from GitHub.">
   <meta name="twitter:image" content="https://riteshp2001.github.io/mpvRx/icon.png">
 
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebSite",
-      "name": "mpvRx Preview Builds",
+      "name": "mpvRx",
       "url": "https://riteshp2001.github.io/mpvRx/",
-      "description": "Official preview APKs for the mpvRx Android media player."
+      "description": "Preview and stable releases for the mpvRx Android media player."
     }
   </script>
 
@@ -56,33 +57,29 @@
 
     * { box-sizing: border-box; }
 
-    html { scroll-behavior: smooth; }
+    html { scroll-behavior: smooth; overflow-x: hidden; }
 
     body {
       margin: 0;
       min-width: 320px;
+      overflow-x: hidden;
       background:
         radial-gradient(ellipse 80% 60% at 20% 0%, color-mix(in srgb, var(--violet) 8%, transparent), transparent 70%),
-        radial-gradient(ellipse 60% 50% at 90% 100%, color-mix(in srgb, var(--violet) 6%, transparent), transparent 60%),
+        radial-gradient(ellipse 60% 50% at 90% 100%, color-mix(in srgb, var(--acid) 6%, transparent), transparent 60%),
         var(--paper);
       color: var(--ink);
       font-family: Aptos, "Segoe UI Variable Text", "Helvetica Neue", sans-serif;
       text-rendering: optimizeLegibility;
     }
 
-    a { color: inherit; }
+    body.route-gate { visibility: hidden; }
 
+    a { color: inherit; }
     button, a { -webkit-tap-highlight-color: transparent; }
 
-    :focus-visible {
-      outline: 3px solid var(--violet);
-      outline-offset: 4px;
-    }
+    :focus-visible { outline: 3px solid var(--violet); outline-offset: 4px; }
 
-    .page {
-      width: min(1180px, calc(100% - 40px));
-      margin: 0 auto;
-    }
+    .page { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
 
     .topbar {
       display: flex;
@@ -93,18 +90,11 @@
       border-bottom: 1px solid var(--line);
     }
 
-    .brand {
-      display: inline-flex;
-      align-items: center;
-      gap: 12px;
-      text-decoration: none;
-    }
+    .brand { display: inline-flex; align-items: center; gap: 12px; text-decoration: none; }
 
     .brand-mark {
-      width: 48px;
-      height: 48px;
-      display: grid;
-      place-items: center;
+      width: 48px; height: 48px;
+      display: grid; place-items: center;
       overflow: hidden;
       border: 1px solid var(--line);
       border-radius: 14px;
@@ -113,17 +103,12 @@
     }
 
     .brand-mark img { width: 100%; height: 100%; object-fit: contain; }
-
     .brand-name { font-size: 19px; font-weight: 850; letter-spacing: -.03em; }
-
     .brand-name small {
-      display: block;
-      margin-top: 2px;
+      display: block; margin-top: 2px;
       color: var(--ink-soft);
-      font-size: 10px;
-      font-weight: 750;
-      letter-spacing: .13em;
-      text-transform: uppercase;
+      font-size: 10px; font-weight: 750;
+      letter-spacing: .13em; text-transform: uppercase;
     }
 
     .navlinks { display: flex; align-items: center; gap: 9px; }
@@ -133,77 +118,98 @@
       border: 1px solid var(--line);
       border-radius: 999px;
       background: color-mix(in srgb, var(--paper-raised) 76%, transparent);
-      font-size: 13px;
-      font-weight: 750;
+      font-size: 13px; font-weight: 750;
       text-decoration: none;
       transition: transform 180ms var(--ease-out), background 180ms ease, border-color 180ms ease;
     }
 
     .navlink:hover { transform: translateY(-2px); border-color: var(--violet); background: var(--paper-raised); }
+    .navlink.current { border-color: var(--violet); background: var(--violet-soft); color: var(--violet-deep); }
 
-    .hero {
-      display: grid;
-      grid-template-columns: minmax(0, 1.25fr) minmax(300px, .75fr);
-      gap: clamp(32px, 7vw, 92px);
-      align-items: center;
-      padding: clamp(64px, 10vw, 122px) 0 clamp(56px, 8vw, 96px);
-    }
+    h1, h2, h3 { font-family: Charter, "Bitstream Charter", "Iowan Old Style", serif; font-weight: 700; }
+
+    .hero-head { padding: clamp(48px, 8vw, 80px) 0 clamp(28px, 5vw, 44px); }
 
     .kicker {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-size: 11px;
-      font-weight: 850;
-      letter-spacing: .15em;
-      text-transform: uppercase;
+      display: flex; align-items: center; gap: 10px;
+      font-size: 11px; font-weight: 850;
+      letter-spacing: .15em; text-transform: uppercase;
     }
 
     .live-dot {
-      width: 9px;
-      height: 9px;
-      border-radius: 50%;
+      width: 9px; height: 9px; border-radius: 50%;
       background: var(--violet);
       box-shadow: 0 0 0 6px color-mix(in srgb, var(--violet) 13%, transparent);
       animation: breathe 2.4s ease-in-out infinite;
     }
 
-    h1, h2 {
-      font-family: Charter, "Bitstream Charter", "Iowan Old Style", serif;
-      font-weight: 700;
-    }
-
     h1 {
       max-width: 820px;
-      margin: 22px 0 24px;
-      font-size: clamp(52px, 8vw, 102px);
-      line-height: .91;
-      letter-spacing: -.065em;
+      margin: 22px 0 12px;
+      font-size: clamp(44px, 7vw, 82px);
+      line-height: .94;
+      letter-spacing: -.06em;
     }
 
     h1 em { color: var(--violet); font-style: italic; font-weight: 600; }
 
     .lead {
-      max-width: 650px;
+      max-width: 640px;
       margin: 0;
       color: var(--ink-soft);
-      font-size: clamp(16px, 2vw, 19px);
+      font-size: clamp(15px, 1.8vw, 18px);
       line-height: 1.65;
     }
 
-    .hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 32px; }
+    /* Channel tabs */
+    .tabs {
+      display: inline-flex;
+      gap: 4px;
+      margin-top: 30px;
+      padding: 4px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--paper-raised);
+    }
+
+    .tab-btn {
+      appearance: none;
+      border: 0;
+      padding: 10px 20px;
+      border-radius: 999px;
+      background: transparent;
+      color: var(--ink-soft);
+      font: inherit;
+      font-size: 13px;
+      font-weight: 800;
+      cursor: pointer;
+      transition: background 180ms ease, color 180ms ease;
+    }
+
+    .tab-btn[aria-selected="true"] { background: #10141c; color: #fffaff; }
+    .tab-btn .tag {
+      display: inline-block;
+      margin-left: 7px;
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: var(--acid);
+      color: #1f240f;
+      font-size: 9px;
+      font-weight: 900;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      vertical-align: 1px;
+    }
+
+    .panel { display: none; }
+    .panel.active { display: block; animation: reveal 460ms var(--ease-out); }
 
     .button {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 9px;
-      min-height: 48px;
-      padding: 0 18px;
+      display: inline-flex; align-items: center; justify-content: center; gap: 9px;
+      min-height: 48px; padding: 0 18px;
       border: 1px solid var(--ink);
       border-radius: 8px;
-      font-size: 13px;
-      font-weight: 850;
+      font-size: 13px; font-weight: 850;
       text-decoration: none;
       transition: transform 150ms var(--ease-out), box-shadow 180ms var(--ease-out), background 180ms ease;
     }
@@ -213,192 +219,183 @@
     .button.primary { background: var(--violet); color: #fcfaff; }
     .button.secondary { background: var(--paper-raised); }
 
-    .build-ticket {
+    /* Release hero ticket */
+    .ticket {
       position: relative;
       isolation: isolate;
       overflow: hidden;
-      min-height: 390px;
-      padding: 30px;
+      padding: clamp(26px, 4vw, 40px);
       border-radius: 4px 28px 4px 28px;
       background: var(--ink);
       color: #f8f4ff;
       box-shadow: 14px 14px 0 var(--violet-soft), var(--shadow);
+      margin-bottom: clamp(48px, 7vw, 72px);
     }
 
-    .build-ticket::after {
+    .ticket::after {
       content: "Rx";
-      position: absolute;
-      z-index: -1;
-      right: -18px;
-      bottom: -55px;
+      position: absolute; z-index: -1;
+      right: -18px; bottom: -55px;
       color: rgba(130, 96, 255, .24);
       font-family: Charter, "Bitstream Charter", serif;
-      font-size: 220px;
-      font-style: italic;
-      font-weight: 700;
-      line-height: 1;
+      font-size: 220px; font-style: italic; font-weight: 700; line-height: 1;
     }
 
-    .ticket-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-
+    .ticket-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
     .ticket-label { font-size: 10px; font-weight: 850; letter-spacing: .14em; text-transform: uppercase; }
 
-    .channel {
-      padding: 6px 9px;
-      border-radius: 999px;
-      background: var(--acid);
-      color: #20250e;
-      font-size: 10px;
-      font-weight: 900;
-      letter-spacing: .06em;
-      text-transform: uppercase;
+    .channel-pill {
+      padding: 6px 9px; border-radius: 999px;
+      background: var(--acid); color: #20250e;
+      font-size: 10px; font-weight: 900; letter-spacing: .06em; text-transform: uppercase;
     }
+    .channel-pill.preview { background: var(--violet-soft); color: var(--violet-deep); }
 
-    .build-number {
-      margin: 40px 0 36px;
+    .ticket-version {
+      margin: 26px 0 10px;
       font-family: Charter, "Bitstream Charter", serif;
-      font-size: clamp(60px, 9vw, 96px);
-      font-weight: 700;
-      letter-spacing: -.06em;
-      line-height: .8;
+      font-size: clamp(42px, 6.5vw, 68px);
+      font-weight: 700; letter-spacing: -.05em; line-height: .95;
     }
+    .ticket-version.loading { opacity: .46; animation: loading 1.25s ease-in-out infinite alternate; }
 
-    .build-number.loading { opacity: .46; animation: loading 1.25s ease-in-out infinite alternate; }
+    .ticket-sub { margin: 0 0 22px; color: rgba(248,244,255,.7); font-size: 14px; max-width: 560px; }
 
-    .build-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: rgba(255,255,255,.18); }
+    .ticket-meta { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: rgba(255,255,255,.18); margin-bottom: 24px; }
+    .ticket-meta div { min-width: 0; padding: 14px; background: var(--ink); }
+    .ticket-meta span { display: block; margin-bottom: 5px; color: #a9a0b4; font-size: 9px; letter-spacing: .11em; text-transform: uppercase; }
+    .ticket-meta strong { display: block; overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+    .ticket-meta a { text-decoration-color: var(--violet-soft); text-underline-offset: 3px; }
 
-    .build-meta div { min-width: 0; padding: 14px; background: var(--ink); }
-    .build-meta span { display: block; margin-bottom: 5px; color: #a9a0b4; font-size: 9px; letter-spacing: .11em; text-transform: uppercase; }
-    .build-meta strong { display: block; overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
-    .build-meta a { text-decoration-color: var(--violet-soft); text-underline-offset: 3px; }
+    .ticket-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+    .ticket-actions .button.secondary { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.3); color: #fffaff; }
+    .ticket-actions .button.secondary:hover { box-shadow: 5px 5px 0 rgba(255,255,255,.2); }
 
-    .warning-strip {
-      display: grid;
-      grid-template-columns: auto 1fr;
-      gap: 14px;
-      align-items: start;
-      margin-bottom: clamp(64px, 9vw, 112px);
-      padding: 18px 0;
-      border-block: 1px solid var(--line);
+    .section-head { display: grid; grid-template-columns: 1fr minmax(220px, 380px); gap: 32px; align-items: end; margin-bottom: 24px; }
+    .section-index { display: flex; align-items: center; gap: 8px; margin-bottom: 9px; color: var(--violet-deep); font-size: 11px; font-weight: 900; letter-spacing: .13em; text-transform: uppercase; }
+    .section-index::before { content: ""; width: 16px; height: 1px; background: var(--violet-deep); }
+    h2 { margin: 0; font-size: clamp(30px, 4vw, 46px); line-height: .98; letter-spacing: -.04em; }
+    .section-head p { margin: 0; color: var(--ink-soft); font-size: 13px; line-height: 1.6; }
+
+    section.block { margin-bottom: clamp(56px, 8vw, 88px); padding-top: clamp(32px, 5vw, 48px); border-top: 1px solid var(--line); }
+    section.block:first-of-type { padding-top: 0; border-top: 0; }
+
+    /* Stats */
+    .stats { display: grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: 12px; }
+    .stat-card {
+      padding: 18px; border: 1px solid var(--line); border-radius: 14px 4px 14px 4px;
+      background: var(--paper-raised);
+      opacity: 0; transform: translateY(16px);
+      animation: card-in 460ms var(--ease-out) forwards;
+      animation-delay: calc(var(--i, 0) * 70ms);
     }
+    .stat-card span { display: block; color: var(--ink-soft); font-size: 11px; font-weight: 750; text-transform: uppercase; letter-spacing: .06em; margin-bottom: 8px; }
+    .stat-card strong { font-family: Charter, "Bitstream Charter", serif; font-size: clamp(24px, 3vw, 34px); letter-spacing: -.03em; color: var(--violet-deep); }
 
-    .warning-strip strong { color: var(--violet-deep); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
-    .warning-strip p { margin: 0; color: var(--ink-soft); font-size: 13px; line-height: 1.55; }
-
-    .section-head {
-      display: grid;
-      grid-template-columns: 1fr minmax(260px, 430px);
-      gap: 32px;
-      align-items: end;
-      margin-bottom: 28px;
+    /* Release notes */
+    .notes {
+      padding: 26px; border: 1px solid var(--line); border-radius: 14px 4px 14px 4px;
+      background: var(--paper-raised); font-size: 14px; line-height: 1.7; color: var(--ink);
+      max-width: 100%; overflow-wrap: anywhere;
     }
+    .notes h3 { font-size: 17px; margin: 22px 0 8px; overflow-wrap: anywhere; }
+    .notes h3:first-child { margin-top: 0; }
+    .notes ul { margin: 0 0 14px; padding-left: 20px; }
+    .notes li { margin-bottom: 4px; color: var(--ink-soft); overflow-wrap: anywhere; }
+    .notes p { margin: 0 0 12px; color: var(--ink-soft); overflow-wrap: anywhere; }
+    .notes code { background: var(--violet-soft); color: var(--violet-deep); padding: 1px 6px; border-radius: 5px; font-size: 12px; word-break: break-word; }
+    .notes pre { max-width: 100%; overflow-x: auto; padding: 12px; margin: 0 0 14px; border-radius: 8px; background: color-mix(in srgb, var(--ink) 5%, var(--paper-raised)); white-space: pre-wrap; word-break: break-word; font-size: 12px; }
+    .notes strong { color: var(--ink); }
 
-    .section-index { display: block; margin-bottom: 9px; color: var(--violet-deep); font-size: 11px; font-weight: 900; letter-spacing: .13em; text-transform: uppercase; }
-    h2 { margin: 0; font-size: clamp(38px, 5vw, 64px); line-height: .96; letter-spacing: -.045em; }
-    .section-head p { margin: 0; color: var(--ink-soft); font-size: 14px; line-height: 1.65; }
-
-    .choice-guide {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      margin-bottom: 28px;
-      border-block: 1px solid var(--line);
-    }
-
-    .choice-guide div { padding: 20px 24px 20px 0; }
-    .choice-guide div + div { padding-left: 24px; border-left: 1px solid var(--line); }
-    .choice-guide strong { display: block; margin-bottom: 6px; font-size: 13px; }
-    .choice-guide span { color: var(--ink-soft); font-size: 12px; line-height: 1.5; }
-
-    .downloads {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      grid-auto-rows: auto;
-      gap: 14px;
-      min-height: 260px;
-    }
-
+    /* Download grid */
+    .downloads { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; min-height: 130px; }
     .download-card {
       --card-bg: var(--paper-raised);
-      display: flex;
-      min-height: 270px;
-      flex-direction: column;
-      padding: 22px;
-      border: 1px solid var(--line);
-      border-radius: 18px 4px 18px 4px;
+      display: flex; min-height: 138px; flex-direction: column; padding: 13px;
+      border: 1px solid var(--line); border-radius: 12px 4px 12px 4px;
       background: var(--card-bg);
-      box-shadow: 0 1px 0 rgba(255,255,255,.55) inset;
-      contain: content;
-      opacity: 0;
-      transform: translateY(20px);
+      opacity: 0; transform: translateY(20px);
       animation: card-in 480ms var(--ease-out) forwards;
       animation-delay: calc(var(--card-index, 0) * 70ms);
       transition: transform 220ms var(--ease-out), border-color 180ms ease, box-shadow 220ms var(--ease-out);
     }
-
-    .download-card:hover { transform: translateY(-6px); border-color: color-mix(in srgb, var(--violet) 58%, transparent); box-shadow: var(--shadow); }
-    .download-card.recommended { grid-column: span 2; grid-row: span 2; --card-bg: var(--violet); color: #fffaff; border-color: var(--violet); }
-    .download-card.fongmi { grid-column: span 2; background: linear-gradient(135deg, #2a1f4e, #1c1535); color: #ece4ff; border-color: color-mix(in srgb, var(--violet) 30%, transparent); }
-    .download-card.fongmi .card-description { color: #b8a7d4; }
-    .download-card.fongmi .target { color: #c9b5ff; }
-    .download-card.fongmi .pill { border-color: #9580cc; color: #d4c5ff; }
-    .download-card.no-vulkan { background: color-mix(in srgb, var(--acid) 12%, var(--paper-raised)); }
-
+    .download-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--violet) 58%, transparent); box-shadow: var(--shadow); }
+    .download-card.recommended {
+      grid-column: span 2;
+      --card-bg: color-mix(in srgb, var(--violet) 7%, var(--paper-raised));
+      border-color: color-mix(in srgb, var(--violet) 45%, var(--line));
+    }
+    .recommended .pill { border-color: var(--violet-deep); color: var(--violet-deep); }
+    .recommended .format { color: var(--ink-soft); }
+    .recommended .target { color: var(--violet-deep); }
+    .recommended .card-description { color: var(--ink-soft); }
+    .recommended .sha-button.copied { color: var(--violet-deep); }
     .card-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-    .pill { padding: 6px 8px; border: 1px solid currentColor; border-radius: 999px; font-size: 9px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
-    .format { color: var(--ink-soft); font-size: 10px; font-weight: 800; text-transform: uppercase; }
-    .recommended .format, .fongmi .format { color: rgba(255,255,255,.68); }
-    .download-card h3 { margin: 28px 0 5px; font-family: Charter, "Bitstream Charter", serif; font-size: 28px; letter-spacing: -.035em; }
-    .target { color: var(--violet-deep); font-size: 11px; font-weight: 850; letter-spacing: .07em; }
-    .recommended .target, .fongmi .target { color: var(--acid); }
-    .card-description { margin: 14px 0 24px; color: var(--ink-soft); font-size: 13px; line-height: 1.55; }
-    .recommended .card-description, .fongmi .card-description { color: rgba(255,255,255,.72); }
-
-    .file-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: auto; padding-top: 14px; border-top: 1px solid color-mix(in srgb, currentColor 18%, transparent); font-size: 10px; }
+    .pill { padding: 4px 7px; border: 1px solid currentColor; border-radius: 999px; font-size: 8.5px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+    .format { color: var(--ink-soft); font-size: 9px; font-weight: 800; text-transform: uppercase; }
+    .download-card h3 { margin: 10px 0 2px; font-family: Charter, "Bitstream Charter", serif; font-size: 17px; letter-spacing: -.03em; }
+    .target { color: var(--violet-deep); font-size: 9px; font-weight: 850; letter-spacing: .04em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .card-description { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; margin: 6px 0 10px; color: var(--ink-soft); font-size: 11px; line-height: 1.4; }
+    .file-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: auto; padding-top: 8px; border-top: 1px solid var(--line); font-size: 9.5px; }
     .sha-button { padding: 0; border: 0; background: none; color: inherit; cursor: pointer; font: inherit; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 3px; }
     .sha-button.copied { color: var(--violet-deep); transform: scale(1.04); }
-    .recommended .sha-button.copied, .fongmi .sha-button.copied { color: var(--acid); }
-
     .download-link {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin-top: 14px;
-      padding: 13px 14px;
-      border: 1px solid var(--ink);
-      border-radius: 7px;
-      background: var(--ink);
-      color: #fffaff;
-      font-size: 12px;
-      font-weight: 900;
-      text-decoration: none;
+      display: flex; align-items: center; justify-content: space-between; margin-top: 8px;
+      padding: 8px 10px; border: 1px solid var(--ink); border-radius: 7px;
+      background: var(--ink); color: #fcfaff; font-size: 11px; font-weight: 900; text-decoration: none;
       transition: transform 140ms var(--ease-out), background 180ms ease, color 180ms ease;
     }
-
     .download-link:hover { transform: translateX(3px); background: var(--acid); color: #1f240f; }
-    .recommended .download-link, .fongmi .download-link { background: #fffaff; color: var(--ink); }
-    .download-link::after { content: "↓"; font-size: 17px; }
+    .download-link::after { content: "↓"; font-size: 15px; }
+    .loading-card { min-height: 138px; border: 1px solid var(--line); border-radius: 12px 4px; background: linear-gradient(100deg, var(--paper-raised) 30%, var(--violet-soft) 50%, var(--paper-raised) 70%); background-size: 220% 100%; animation: skeleton 1.4s ease infinite; }
 
-    .loading-card { min-height: 270px; border: 1px solid var(--line); border-radius: 18px 4px; background: linear-gradient(100deg, var(--paper-raised) 30%, var(--violet-soft) 50%, var(--paper-raised) 70%); background-size: 220% 100%; animation: skeleton 1.4s ease infinite; }
+    /* Previous releases */
+    .prev-list { display: flex; flex-direction: column; gap: 10px; }
+    .prev-item {
+      display: flex; align-items: center; gap: 14px;
+      padding: 14px 16px; border: 1px solid var(--line); border-radius: 12px 4px 12px 4px;
+      background: var(--paper-raised);
+      text-decoration: none; color: var(--ink);
+      transition: transform 180ms var(--ease-out), border-color 180ms ease;
+    }
+    .prev-item:hover { transform: translateX(4px); border-color: color-mix(in srgb, var(--violet) 50%, transparent); }
+    .prev-item .v { flex-shrink: 0; padding: 5px 10px; border-radius: 999px; background: var(--violet-soft); color: var(--violet-deep); font-family: Charter, "Bitstream Charter", serif; font-size: 13px; font-weight: 700; }
+    .prev-item .body { flex: 1; min-width: 0; }
+    .prev-item .d { display: block; overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+    .prev-item .t { display: block; margin-top: 2px; color: var(--ink-soft); font-size: 10.5px; }
+    .prev-item .view { flex-shrink: 0; padding: 7px 12px; border: 1px solid var(--line); border-radius: 999px; color: var(--ink-soft); font-size: 11px; font-weight: 800; white-space: nowrap; transition: border-color 180ms ease, color 180ms ease; }
+    .prev-item:hover .view { border-color: var(--violet); color: var(--violet-deep); }
+
+    .empty-note { padding: 22px; border: 1px dashed var(--line); border-radius: 12px; color: var(--ink-soft); font-size: 13px; text-align: center; }
+
+    /* Preview channel: build-flavor context (kept from upstream, resized to this spacing scale) */
+    .warning-strip {
+      display: grid; grid-template-columns: auto 1fr; gap: 12px; align-items: start;
+      margin-bottom: clamp(40px, 6vw, 56px); padding: 14px 0; border-block: 1px solid var(--line);
+    }
+    .warning-strip strong { color: var(--violet-deep); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+    .warning-strip p { margin: 0; color: var(--ink-soft); font-size: 12px; line-height: 1.55; }
+
+    .choice-guide { display: grid; grid-template-columns: repeat(3, 1fr); margin-bottom: 18px; border-block: 1px solid var(--line); }
+    .choice-guide div { padding: 14px 16px 14px 0; }
+    .choice-guide div + div { padding-left: 16px; border-left: 1px solid var(--line); }
+    .choice-guide strong { display: block; margin-bottom: 5px; font-size: 12px; }
+    .choice-guide span { color: var(--ink-soft); font-size: 11px; line-height: 1.5; }
 
     .provenance {
-      display: grid;
-      grid-template-columns: auto 1fr auto;
-      gap: 18px;
-      align-items: center;
-      margin: 28px 0 clamp(70px, 10vw, 120px);
-      padding: 22px;
-      border: 1px solid var(--line);
-      background: color-mix(in srgb, var(--paper-raised) 82%, transparent);
+      display: grid; grid-template-columns: auto 1fr auto; gap: 14px; align-items: center;
+      margin-top: 24px; padding: 16px 18px; border: 1px solid var(--line); border-radius: 12px 4px 12px 4px;
     }
-
-    .seal { display: grid; width: 44px; height: 44px; place-items: center; border-radius: 50%; background: var(--acid); font-size: 20px; }
-    .provenance strong { display: block; margin-bottom: 3px; font-size: 13px; }
-    .provenance p { margin: 0; color: var(--ink-soft); font-size: 12px; line-height: 1.5; }
-    .provenance code { font-size: 10px; color: var(--violet-deep); }
+    .seal { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 50%; background: var(--acid); font-size: 16px; }
+    .provenance strong { display: block; margin-bottom: 3px; font-size: 12px; }
+    .provenance p { margin: 0; color: var(--ink-soft); font-size: 11px; line-height: 1.5; }
+    .provenance code { font-size: 9px; color: var(--violet-deep); }
 
     footer { padding: 28px 0 44px; border-top: 1px solid var(--line); }
     .footer-row { display: flex; align-items: center; justify-content: space-between; gap: 20px; color: var(--ink-soft); font-size: 11px; }
     .footer-row strong { color: var(--ink); }
+    .footer-row a { text-decoration-color: color-mix(in srgb, var(--ink-soft) 50%, transparent); text-underline-offset: 3px; transition: color 160ms ease; }
+    .footer-row a:hover { color: var(--violet); }
 
     .reveal { opacity: 0; transform: translateY(18px); animation: reveal 680ms var(--ease-out) forwards; }
     .delay-1 { animation-delay: 80ms; }
@@ -421,42 +418,41 @@
         --violet: #8b6cff;
         --violet-deep: #b9a7ff;
         --violet-soft: #31264b;
+        --acid: #c9f45a;
         --line: rgba(242, 237, 247, .14);
         --shadow: 0 22px 60px rgba(0, 0, 0, .32);
       }
-      .brand-mark, .build-ticket { background: #0f0c13; }
-      .download-card.fongmi { background: linear-gradient(135deg, #1e1640, #150f2e); }
-      .build-meta div { background: #0f0c13; }
+      .brand-mark, .ticket { background: #0f0c13; }
+      .ticket-meta div { background: #0f0c13; }
       .button.primary { color: #fffaff; }
-      .download-link { background: #f2edf7; color: #17131c; }
-      .recommended .download-link, .fongmi .download-link { background: #fffaff; color: #17131c; }
+      .navlink.current { background: color-mix(in srgb, var(--violet) 22%, transparent); }
     }
 
     @media (max-width: 900px) {
-      .hero { grid-template-columns: 1fr; }
-      .build-ticket { min-height: 340px; }
-      .downloads { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .download-card.recommended { grid-row: span 1; }
+      .stats { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .downloads { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .ticket-meta { grid-template-columns: repeat(2, 1fr); }
     }
 
     @media (max-width: 640px) {
       .page { width: min(100% - 24px, 1180px); }
       .topbar { min-height: 76px; }
       .brand-name small { display: none; }
-      .navlink:first-child { display: none; }
-      .hero { padding-top: 52px; }
-      h1 { font-size: clamp(48px, 15vw, 70px); }
-      .build-ticket { padding: 22px; }
-      .section-head { grid-template-columns: 1fr; gap: 16px; }
-      .choice-guide { grid-template-columns: 1fr; }
-      .choice-guide div { padding: 17px 0; }
-      .choice-guide div + div { padding-left: 0; border-top: 1px solid var(--line); border-left: 0; }
+      .navlink.nav-secondary { display: none; }
+      h1 { font-size: clamp(38px, 12vw, 58px); }
+      .section-head { grid-template-columns: 1fr; gap: 14px; }
+      .stats { grid-template-columns: 1fr 1fr; }
       .downloads { grid-template-columns: 1fr; }
-      .download-card.recommended { grid-column: auto; grid-row: auto; }
-      .download-card.fongmi { grid-column: auto; }
+      .download-card.recommended { grid-column: auto; }
+      .ticket-meta { grid-template-columns: 1fr 1fr; }
+      .prev-item { padding: 12px 14px; gap: 10px; }
+      .footer-row { align-items: flex-start; flex-direction: column; }
+      .prev-item .d { font-size: 12.5px; }
+      .choice-guide { grid-template-columns: 1fr; }
+      .choice-guide div { padding: 12px 0; }
+      .choice-guide div + div { padding-left: 0; border-top: 1px solid var(--line); border-left: 0; }
       .provenance { grid-template-columns: auto 1fr; }
       .provenance code { display: none; }
-      .footer-row { align-items: flex-start; flex-direction: column; }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -466,78 +462,160 @@
   </style>
 </head>
 
-<body>
+<body class="route-gate">
   <div class="page">
     <header class="topbar reveal">
-      <a class="brand" href="./" aria-label="mpvRx Preview home">
+      <a class="brand" href="./" aria-label="mpvRx home">
         <span class="brand-mark"><img src="icon.png" alt="" width="48" height="48"></span>
         <span class="brand-name">mpvRx<small>Android preview builds</small></span>
       </a>
-      <nav class="navlinks" aria-label="External links">
-        <a class="navlink" href="https://github.com/Riteshp2001/mpvRx/releases" target="_blank" rel="noreferrer">Stable releases</a>
-        <a class="navlink" href="https://github.com/Riteshp2001/mpvRx" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <nav class="navlinks" aria-label="Site and external links">
+        <a class="navlink" href="#release" id="nav-release-link">Releases</a>
+        <a class="navlink nav-secondary" href="https://github.com/Riteshp2001/mpvRx" target="_blank" rel="noreferrer">GitHub ↗</a>
       </nav>
     </header>
 
     <main>
-      <section class="hero">
-        <div>
-          <div class="kicker reveal delay-1"><span class="live-dot" aria-hidden="true"></span>Built from the latest selected source</div>
-          <h1 class="reveal delay-2">The next mpvRx,<br><em>ready to test.</em></h1>
-          <p class="lead reveal delay-3">Official Standard, Fongmi, and non-Vulkan preview APKs for Android, signed and published directly from GitHub Actions with a traceable commit and SHA-256 checksum.</p>
-          <div class="hero-actions reveal delay-3">
-            <a class="button primary" href="#downloads">Choose a build <span aria-hidden="true">↓</span></a>
-            <a class="button secondary" href="https://github.com/Riteshp2001/mpvRx/releases" target="_blank" rel="noreferrer">Use stable instead</a>
+      <section class="hero-head">
+        <div class="kicker reveal delay-1"><span class="live-dot" aria-hidden="true"></span>Live from GitHub</div>
+        <h1 class="reveal delay-2">Every build,<br><em>right here.</em></h1>
+        <p class="lead reveal delay-3">Preview and stable APKs for mpvRx — signed, checksummed, and published straight from GitHub Actions and Releases.</p>
+
+        <div class="tabs reveal delay-3" role="tablist" aria-label="Release channel">
+          <button class="tab-btn" id="tab-btn-preview" role="tab" type="button" aria-selected="false" aria-controls="panel-preview">Preview build</button>
+          <button class="tab-btn" id="tab-btn-release" role="tab" type="button" aria-selected="false" aria-controls="panel-release">Stable release</button>
+        </div>
+      </section>
+
+      <!-- STABLE RELEASE PANEL -->
+      <div class="panel" id="panel-release" role="tabpanel" aria-labelledby="tab-btn-release">
+        <div class="ticket">
+          <div class="ticket-head">
+            <span class="ticket-label">Latest stable</span>
+            <span class="channel-pill" id="rel-badge">Stable</span>
+          </div>
+          <div class="ticket-version loading" id="rel-version">v—</div>
+          <p class="ticket-sub" id="rel-name">Loading release information…</p>
+          <div class="ticket-meta">
+            <div><span>Published</span><strong id="rel-date">—</strong></div>
+            <div><span>Assets</span><strong id="rel-assets">—</strong></div>
+            <div><span>Total size</span><strong id="rel-size">—</strong></div>
+            <div><span>Tag</span><strong id="rel-tag">—</strong></div>
+          </div>
+          <div class="ticket-actions">
+            <a class="button primary" id="rel-cta" href="https://github.com/Riteshp2001/mpvRx/releases" target="_blank" rel="noreferrer">Download APK</a>
+            <a class="button secondary" id="rel-github" href="https://github.com/Riteshp2001/mpvRx/releases" target="_blank" rel="noreferrer">View on GitHub ↗</a>
           </div>
         </div>
 
-        <aside class="build-ticket reveal delay-2" aria-label="Current preview details">
-          <div class="ticket-head">
-            <span class="ticket-label">Current preview</span>
-            <span class="channel">Live manifest</span>
+        <section class="block">
+          <div class="section-head">
+            <div>
+              <span class="section-index">📊 Stats</span>
+              <h2>Straight from the repo.</h2>
+            </div>
+            <p>Stars and downloads update live — no fixed numbers.</p>
           </div>
-          <div id="build" class="build-number loading">r—</div>
-          <div class="build-meta">
-            <div><span>Commit</span><strong id="commit">—</strong></div>
-            <div><span>Actions run</span><strong id="run">—</strong></div>
-            <div><span>Published</span><strong id="published">—</strong></div>
-            <div><span>Flavor set</span><strong id="flavor">—</strong></div>
+          <div class="stats" id="rel-stats">
+            <div class="stat-card" style="--i:0"><span>⭐ GitHub stars</span><strong id="stat-stars">—</strong></div>
+            <div class="stat-card" style="--i:1"><span>⬇️ Downloads (latest)</span><strong id="stat-downloads">—</strong></div>
+            <div class="stat-card" style="--i:2"><span>🗂️ Total releases</span><strong id="stat-count">—</strong></div>
+            <div class="stat-card" style="--i:3"><span>🐞 Open issues</span><strong id="stat-issues">—</strong></div>
           </div>
-        </aside>
-      </section>
+        </section>
 
-      <div class="warning-strip reveal delay-3" role="note">
-        <strong>Preview channel</strong>
-        <p>These builds may be unstable. Back up important settings or choose a stable release for everyday playback.</p>
+        <section class="block">
+          <div class="section-head">
+            <div>
+              <span class="section-index">📝 Changelog</span>
+              <h2>What's new.</h2>
+            </div>
+            <p>Rendered directly from the GitHub release notes.</p>
+          </div>
+          <div class="notes" id="rel-notes">Loading release notes…</div>
+        </section>
+
+        <section class="block">
+          <div class="section-head">
+            <div>
+              <span class="section-index">📦 Download assets</span>
+              <h2>Pick the build that fits.</h2>
+            </div>
+            <p>File size and SHA-256 checksum come from the published release.</p>
+          </div>
+          <div class="downloads" id="rel-download-grid" aria-live="polite" aria-busy="true">
+            <div class="loading-card" aria-hidden="true"></div>
+            <div class="loading-card" aria-hidden="true"></div>
+            <div class="loading-card" aria-hidden="true"></div>
+          </div>
+        </section>
+
+        <section class="block">
+          <div class="section-head">
+            <div>
+              <span class="section-index">🕘 History</span>
+              <h2>Previous releases.</h2>
+            </div>
+            <p>The five releases before this one.</p>
+          </div>
+          <div class="prev-list" id="rel-prev-list"></div>
+        </section>
       </div>
 
-      <section id="downloads" aria-labelledby="downloads-title">
-        <div class="section-head">
-          <div>
-            <span class="section-index">01 / Downloads</span>
-            <h2 id="downloads-title">Pick the build that fits.</h2>
+      <!-- PREVIEW PANEL -->
+      <div class="panel" id="panel-preview" role="tabpanel" aria-labelledby="tab-btn-preview">
+        <div class="ticket">
+          <div class="ticket-head">
+            <span class="ticket-label">Current preview</span>
+            <span class="channel-pill preview">Preview</span>
           </div>
-          <p>Standard is the default. Fongmi enables its alternate Vulkan/MediaCodec core, while non-Vulkan provides a safe OpenGL-only Universal build.</p>
+          <div class="ticket-version loading" id="pre-build">r—</div>
+          <p class="ticket-sub">Built and signed automatically from the latest selected source on every manual preview run.</p>
+          <div class="ticket-meta">
+            <div><span>Commit</span><strong id="pre-commit">—</strong></div>
+            <div><span>Actions run</span><strong id="pre-run">—</strong></div>
+            <div><span>Published</span><strong id="pre-published">—</strong></div>
+            <div><span>Flavor set</span><strong id="pre-flavor">—</strong></div>
+          </div>
+          <div class="ticket-actions">
+            <a class="button primary" id="pre-cta" href="#downloads">Choose a build ↓</a>
+            <a class="button secondary" href="https://github.com/Riteshp2001/mpvRx" target="_blank" rel="noreferrer">View on GitHub ↗</a>
+          </div>
         </div>
 
-        <div class="choice-guide" aria-label="Build flavor guide">
-          <div><strong>Standard</strong><span>The regular mpvRx core, available as Universal and architecture-specific APKs.</span></div>
-          <div><strong>Fongmi</strong><span>Universal Vulkan core with direct MediaCodec and Dolby Vision support.</span></div>
-          <div><strong>Non-Vulkan</strong><span>Universal OpenGL-only core for devices without the required Vulkan support.</span></div>
+        <div class="warning-strip" role="note">
+          <strong>Preview channel</strong>
+          <p>These builds may be unstable. Back up important settings or choose a stable release for everyday playback.</p>
         </div>
 
-        <div id="download-grid" class="downloads" aria-live="polite" aria-busy="true">
-          <div class="loading-card" aria-hidden="true"></div>
-          <div class="loading-card" aria-hidden="true"></div>
-          <div class="loading-card" aria-hidden="true"></div>
-        </div>
-      </section>
+        <section class="block" id="downloads">
+          <div class="section-head">
+            <div>
+              <span class="section-index">📦 Download assets</span>
+              <h2>Pick the build that fits.</h2>
+            </div>
+            <p>Standard is the default. Fongmi enables its alternate Vulkan/MediaCodec core, while non-Vulkan provides a safe OpenGL-only Universal build.</p>
+          </div>
 
-      <aside class="provenance">
-        <span class="seal" aria-hidden="true">✓</span>
-        <div><strong>Build provenance included</strong><p>Each card reports the published file size and exact SHA-256 digest from the workflow manifest.</p></div>
-        <code>latest.json</code>
-      </aside>
+          <div class="choice-guide" aria-label="Build flavor guide">
+            <div><strong>Standard</strong><span>The regular mpvRx core, available as Universal and architecture-specific APKs.</span></div>
+            <div><strong>Fongmi</strong><span>Universal Vulkan core with direct MediaCodec and Dolby Vision support.</span></div>
+            <div><strong>Non-Vulkan</strong><span>Universal OpenGL-only core for devices without the required Vulkan support.</span></div>
+          </div>
+
+          <div class="downloads" id="pre-download-grid" aria-live="polite" aria-busy="true">
+            <div class="loading-card" aria-hidden="true"></div>
+            <div class="loading-card" aria-hidden="true"></div>
+            <div class="loading-card" aria-hidden="true"></div>
+          </div>
+
+          <aside class="provenance">
+            <span class="seal" aria-hidden="true">✓</span>
+            <div><strong>Build provenance included</strong><p>Each card reports the published file size and exact SHA-256 digest from the workflow manifest.</p></div>
+            <code>latest.json</code>
+          </aside>
+        </section>
+      </div>
     </main>
 
     <footer>
@@ -549,33 +627,94 @@
   </div>
 
   <script>
-    const buildInfo = {
-      "arm64-v8a": { title: "ARM 64-bit", badge: "Recommended", target: "STANDARD · ARM64", description: "Best for most modern Android phones, tablets, and TVs." },
-      "universal": { title: "Universal", badge: "All architectures", target: "STANDARD · UNIVERSAL", description: "Includes every supported ABI. Choose this when you are unsure." },
-      "fongmi": { title: "Fongmi", badge: "MediaCodec + Vulkan", target: "FONGMI · UNIVERSAL", description: "Alternate core with direct MediaCodec/Vulkan and Dolby Vision playback support." },
-      "no-vulkan": { title: "Non-Vulkan", badge: "OpenGL only", target: "NON-VULKAN · UNIVERSAL", description: "Safe Universal build for devices that do not meet Vulkan requirements." },
-      "armeabi-v7a": { title: "ARM 32-bit", badge: "Legacy", target: "STANDARD · ARM32", description: "For older 32-bit ARM Android hardware." },
-      "x86_64": { title: "x86 64-bit", badge: "Emulator", target: "STANDARD · X86_64", description: "For 64-bit x86 Android emulators and compatible devices." },
-      "x86": { title: "x86 32-bit", badge: "Legacy", target: "STANDARD · X86", description: "For older 32-bit x86 Android environments." }
-    };
+    const REPO = "Riteshp2001/mpvRx";
+    const API = `https://api.github.com/repos/${REPO}`;
 
-    const order = ["arm64-v8a", "universal", "fongmi", "no-vulkan", "armeabi-v7a", "x86_64", "x86"];
     const formatSize = bytes => {
       if (!bytes) return "Unknown size";
       const units = ["B", "KB", "MB", "GB"];
-      let value = bytes;
-      let unit = 0;
+      let value = bytes, unit = 0;
       while (value >= 1024 && unit < units.length - 1) { value /= 1024; unit += 1; }
       return `${value.toFixed(unit ? 1 : 0)} ${units[unit]}`;
     };
-    const shortHash = hash => hash ? `${hash.slice(0, 8)}…${hash.slice(-6)}` : "Unavailable";
-    const safeFlavorLabel = value => ({ all: "All three", dual: "Standard + Fongmi", standard: "Standard", fongmi: "Fongmi", no_vulkan: "Non-Vulkan" }[value] || "Selected builds");
+    const formatNum = n => n === null || n === undefined ? "—" : n.toLocaleString();
+    const shortHash = hash => hash ? `${hash.slice(0, 8)}…${hash.slice(-6)}` : null;
+    const fmtDate = iso => iso ? new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) : "—";
 
-    function createDownloadCard(asset, index) {
-      const key = asset.abi;
-      const info = buildInfo[key] || { title: key, badge: "Preview", target: key.toUpperCase(), description: "Android preview APK." };
+    // Minimal, safe markdown -> HTML for release bodies (headings, bullet lists, bold, inline code, links, paragraphs)
+    function escapeHtml(str) {
+      return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    }
+    function inlineMd(str) {
+      let s = escapeHtml(str);
+      s = s.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+      s = s.replace(/`([^`]+)`/g, "<code>$1</code>");
+      s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+      return s;
+    }
+    function renderReleaseNotes(body) {
+      if (!body) return "<p>No release notes provided.</p>";
+      // Strip the checksum appendix; it's rendered separately in the download cards.
+      const cut = body.split(/\n---\n### SHA-256 checksums/)[0];
+      const lines = cut.split("\n");
+      let html = "";
+      let inList = false;
+      let inCode = false;
+      for (const rawLine of lines) {
+        const line = rawLine.trimEnd();
+        if (line.trim().startsWith("```")) { inCode = !inCode; if (!inCode) html += "</pre>"; else html += "<pre>"; continue; }
+        if (inCode) { html += escapeHtml(line) + "\n"; continue; }
+        if (/^#{1,3}\s+/.test(line)) {
+          if (inList) { html += "</ul>"; inList = false; }
+          html += `<h3>${inlineMd(line.replace(/^#{1,3}\s+/, ""))}</h3>`;
+          continue;
+        }
+        if (/^[-*]\s+/.test(line.trim())) {
+          if (!inList) { html += "<ul>"; inList = true; }
+          html += `<li>${inlineMd(line.trim().replace(/^[-*]\s+/, ""))}</li>`;
+          continue;
+        }
+        if (line.trim() === "") { if (inList) { html += "</ul>"; inList = false; } continue; }
+        if (inList) { html += "</ul>"; inList = false; }
+        html += `<p>${inlineMd(line.trim())}</p>`;
+      }
+      if (inList) html += "</ul>";
+      return html || "<p>No release notes provided.</p>";
+    }
+
+    // Parse "sha256sum" output block from the release body into a filename -> hash map.
+    function parseChecksums(body) {
+      const map = {};
+      if (!body) return map;
+      const match = body.match(/```text\n([\s\S]*?)```/);
+      if (!match) return map;
+      match[1].split("\n").forEach(line => {
+        const m = line.trim().match(/^([a-f0-9]{64})\s+\S*\/?([^\s\/]+)$/i);
+        if (m) map[m[2]] = m[1];
+      });
+      return map;
+    }
+
+    function buildInfoFor(name) {
+      const n = name.toLowerCase();
+      const table = [
+        ["fongmi", { title: "Fongmi", badge: "MediaCodec + Vulkan", desc: "Direct MediaCodec, Vulkan, Dolby Vision." }],
+        ["no-vulkan", { title: "Non-Vulkan", badge: "OpenGL only", desc: "For devices without Vulkan support." }],
+        ["novulkan", { title: "Non-Vulkan", badge: "OpenGL only", desc: "For devices without Vulkan support." }],
+        ["arm64-v8a", { title: "ARM 64-bit", badge: "Recommended", desc: "Best for most modern phones & tablets." }],
+        ["armeabi-v7a", { title: "ARM 32-bit", badge: "Legacy", desc: "Older 32-bit ARM hardware." }],
+        ["x86_64", { title: "x86 64-bit", badge: "Emulator", desc: "64-bit x86 emulators & devices." }],
+        ["x86", { title: "x86 32-bit", badge: "Legacy", desc: "Older 32-bit x86 environments." }],
+        ["universal", { title: "Universal", badge: "All architectures", desc: "Every ABI. Pick this if unsure." }]
+      ];
+      for (const [key, info] of table) { if (n.includes(key)) return info; }
+      return { title: name.replace(/\.apk$/i, ""), badge: "APK", desc: "Android package." };
+    }
+
+    function createDownloadCard(asset, index, checksums) {
+      const info = buildInfoFor(asset.name);
       const card = document.createElement("article");
-      card.className = `download-card${key === "arm64-v8a" ? " recommended" : ""}${key === "fongmi" ? " fongmi" : ""}${key === "no-vulkan" ? " no-vulkan" : ""}`;
+      card.className = `download-card${info.badge === "Recommended" ? " recommended" : ""}`;
       card.style.setProperty("--card-index", index);
 
       const top = document.createElement("div");
@@ -586,80 +725,233 @@
       title.textContent = info.title;
       const target = document.createElement("div");
       target.className = "target";
-      target.textContent = info.target;
+      target.textContent = asset.name;
       const description = document.createElement("p");
       description.className = "card-description";
-      description.textContent = info.description;
+      description.textContent = info.desc;
 
       const meta = document.createElement("div");
       meta.className = "file-meta";
       const fileSize = document.createElement("span");
-      fileSize.textContent = formatSize(asset.size);
-      const hash = document.createElement("button");
-      hash.type = "button";
-      hash.className = "sha-button";
-      hash.textContent = `SHA ${shortHash(asset.sha256)}`;
-      hash.title = "Copy full SHA-256 checksum";
-      hash.addEventListener("click", async () => {
-        if (!asset.sha256) return;
-        try {
-          await navigator.clipboard.writeText(asset.sha256);
-          hash.textContent = "Checksum copied";
-          hash.classList.add("copied");
-          window.setTimeout(() => { hash.textContent = `SHA ${shortHash(asset.sha256)}`; hash.classList.remove("copied"); }, 1400);
-        } catch (_) {
-          hash.textContent = asset.sha256;
-        }
-      });
-      meta.append(fileSize, hash);
+      const dl = asset.download_count !== undefined ? ` · ${formatNum(asset.download_count)}↓` : "";
+      fileSize.textContent = formatSize(asset.size) + dl;
+      meta.append(fileSize);
+
+      const sha = checksums && checksums[asset.name];
+      if (sha) {
+        const hash = document.createElement("button");
+        hash.type = "button";
+        hash.className = "sha-button";
+        hash.textContent = `SHA ${shortHash(sha)}`;
+        hash.title = "Copy full SHA-256 checksum";
+        hash.addEventListener("click", async () => {
+          try {
+            await navigator.clipboard.writeText(sha);
+            hash.textContent = "Checksum copied";
+            hash.classList.add("copied");
+            window.setTimeout(() => { hash.textContent = `SHA ${shortHash(sha)}`; hash.classList.remove("copied"); }, 1400);
+          } catch (_) { hash.textContent = sha; }
+        });
+        meta.append(hash);
+      }
 
       const download = document.createElement("a");
       download.className = "download-link";
       download.href = asset.browser_download_url;
-      download.textContent = "Download APK";
-      download.setAttribute("aria-label", `Download ${info.title} preview APK`);
+      download.textContent = "Download";
+      download.setAttribute("aria-label", `Download ${info.title}`);
 
       card.append(top, title, target, description, meta, download);
       return card;
     }
 
+    // --- Tabs ---
+    function setActiveTab(which) {
+      document.getElementById("tab-btn-release").setAttribute("aria-selected", which === "release" ? "true" : "false");
+      document.getElementById("tab-btn-preview").setAttribute("aria-selected", which === "preview" ? "true" : "false");
+      document.getElementById("panel-release").classList.toggle("active", which === "release");
+      document.getElementById("panel-preview").classList.toggle("active", which === "preview");
+    }
+    document.getElementById("tab-btn-release").addEventListener("click", () => setActiveTab("release"));
+    document.getElementById("tab-btn-preview").addEventListener("click", () => setActiveTab("preview"));
+    document.getElementById("nav-release-link").addEventListener("click", event => {
+      event.preventDefault();
+      setActiveTab("release");
+      document.querySelector(".hero-head")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+
+    let releasePublished = null;
+    let previewPublished = null;
+    let latestReleaseAsset = null;
+    let latestPreviewAsset = null;
+    let releaseSettled = false;
+    let previewSettled = false;
+    let tabRevealed = false;
+
+    function decideDefaultTab() {
+      // Wait until both channels have finished loading (success or failure) so we
+      // pick the right tab once, instead of flashing an interim guess.
+      if (!releaseSettled || !previewSettled) return;
+      if (tabRevealed) return;
+      tabRevealed = true;
+
+      if (location.hash === "#release") {
+        setActiveTab("release");
+      } else if (releasePublished && previewPublished) {
+        setActiveTab(new Date(previewPublished) > new Date(releasePublished) ? "preview" : "release");
+      } else if (previewPublished && !releasePublished) {
+        setActiveTab("preview");
+      } else {
+        setActiveTab("release");
+      }
+      document.body.classList.remove("route-gate");
+    }
+
+    // Safety net: never leave the tabs hidden forever if a request hangs.
+    window.setTimeout(() => {
+      releaseSettled = true;
+      previewSettled = true;
+      decideDefaultTab();
+    }, 3500);
+
+    // --- Stable release ---
+    fetch(`${API}/releases/latest`)
+      .then(r => { if (!r.ok) throw new Error("no release"); return r.json(); })
+      .then(rel => {
+        releasePublished = rel.published_at;
+        document.getElementById("rel-version").textContent = rel.tag_name;
+        document.getElementById("rel-version").classList.remove("loading");
+        document.getElementById("rel-name").textContent = rel.name || rel.tag_name;
+        document.getElementById("rel-date").textContent = fmtDate(rel.published_at);
+        document.getElementById("rel-assets").textContent = String(rel.assets.length);
+        document.getElementById("rel-tag").textContent = rel.tag_name;
+        const totalSize = rel.assets.reduce((sum, a) => sum + (a.size || 0), 0);
+        document.getElementById("rel-size").textContent = formatSize(totalSize);
+        document.getElementById("rel-github").href = rel.html_url;
+
+        const totalDownloads = rel.assets.reduce((sum, a) => sum + (a.download_count || 0), 0);
+        document.getElementById("stat-downloads").textContent = formatNum(totalDownloads);
+
+        document.getElementById("rel-notes").innerHTML = renderReleaseNotes(rel.body);
+        const checksums = parseChecksums(rel.body);
+
+        const order = ["arm64-v8a", "universal", "fongmi", "no-vulkan", "armeabi-v7a", "x86_64", "x86"];
+        const rank = name => {
+          const idx = order.findIndex(k => name.toLowerCase().includes(k));
+          return idx === -1 ? order.length : idx;
+        };
+        const assets = [...rel.assets].sort((a, b) => rank(a.name) - rank(b.name));
+        const grid = document.getElementById("rel-download-grid");
+        grid.replaceChildren(...assets.map((a, i) => createDownloadCard(a, i, checksums)));
+        grid.setAttribute("aria-busy", "false");
+
+        const recommended = assets.find(a => a.name.toLowerCase().includes("arm64-v8a")) || assets[0];
+        latestReleaseAsset = recommended ? recommended.browser_download_url : rel.html_url;
+        document.getElementById("rel-cta").href = latestReleaseAsset;
+
+        releaseSettled = true;
+        decideDefaultTab();
+      })
+      .catch(() => {
+        document.getElementById("rel-version").textContent = "Unavailable";
+        document.getElementById("rel-version").classList.remove("loading");
+        document.getElementById("rel-name").textContent = "Could not reach the GitHub Releases API right now.";
+        document.getElementById("rel-notes").innerHTML = "<p>Release notes are unavailable. View releases directly on GitHub.</p>";
+        const grid = document.getElementById("rel-download-grid");
+        grid.innerHTML = '<div class="empty-note">Could not load release assets.</div>';
+        grid.setAttribute("aria-busy", "false");
+        releaseSettled = true;
+        decideDefaultTab();
+      });
+
+    // Repo-level stats + previous releases
+    fetch(API)
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(repo => {
+        document.getElementById("stat-stars").textContent = formatNum(repo.stargazers_count);
+        document.getElementById("stat-issues").textContent = formatNum(repo.open_issues_count);
+      })
+      .catch(() => {});
+
+    fetch(`${API}/releases?per_page=6`)
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(list => {
+        document.getElementById("stat-count").textContent = formatNum(list.length >= 6 ? "6+" : list.length);
+        const prevList = document.getElementById("rel-prev-list");
+        const rest = list.slice(1, 6);
+        if (!rest.length) {
+          prevList.innerHTML = '<div class="empty-note">No earlier releases yet.</div>';
+          return;
+        }
+        prevList.replaceChildren(...rest.map(rel => {
+          const a = document.createElement("a");
+          a.className = "prev-item";
+          a.href = rel.html_url;
+          a.target = "_blank";
+          a.rel = "noreferrer";
+          const rawLine = (rel.body || "").split("\n")
+            .map(l => l.trim())
+            .find(l => l && !l.startsWith("#") && !l.startsWith("---") && !/^\*\*Full Changelog/i.test(l));
+          const clean = (rawLine || "")
+            .replace(/^[-*>`]+\s*/, "")
+            .replace(/\*\*/g, "")
+            .replace(/`/g, "")
+            .trim();
+          const desc = clean || "See full release notes on GitHub";
+          a.innerHTML = `<span class="v">${rel.tag_name}</span><span class="body"><span class="d">${escapeHtml(desc)}</span><span class="t">${fmtDate(rel.published_at)}</span></span><span class="view">View →</span>`;
+          return a;
+        }));
+      })
+      .catch(() => {
+        document.getElementById("rel-prev-list").innerHTML = '<div class="empty-note">Could not load release history.</div>';
+      });
+
+    // --- Preview channel ---
     fetch("./latest.json", { cache: "no-store" })
-      .then(response => { if (!response.ok) throw new Error("Manifest unavailable"); return response.json(); })
+      .then(r => { if (!r.ok) throw new Error("no manifest"); return r.json(); })
       .then(manifest => {
-        const build = document.getElementById("build");
+        previewPublished = manifest.published_at;
+        const build = document.getElementById("pre-build");
         build.textContent = `r${manifest.commit_count}`;
         build.classList.remove("loading");
-        document.getElementById("commit").textContent = (manifest.commit_sha || "").slice(0, 7) || "Unknown";
-        document.getElementById("published").textContent = new Date(manifest.published_at).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
-        document.getElementById("flavor").textContent = safeFlavorLabel(manifest.selected_flavor);
+        document.getElementById("pre-commit").textContent = (manifest.commit_sha || "").slice(0, 7) || "Unknown";
+        document.getElementById("pre-published").textContent = fmtDate(manifest.published_at);
+        document.getElementById("pre-flavor").textContent = ({ all: "All three", dual: "Standard + Fongmi", standard: "Standard", fongmi: "Fongmi", no_vulkan: "Non-Vulkan" }[manifest.selected_flavor]) || "Selected builds";
 
-        const run = document.getElementById("run");
+        const run = document.getElementById("pre-run");
         if (manifest.run_url) {
           const link = document.createElement("a");
-          link.href = manifest.run_url;
-          link.target = "_blank";
-          link.rel = "noreferrer";
+          link.href = manifest.run_url; link.target = "_blank"; link.rel = "noreferrer";
           link.textContent = `#${manifest.run_number}`;
           run.replaceChildren(link);
         } else {
           run.textContent = `#${manifest.run_number || "—"}`;
         }
 
-        const grid = document.getElementById("download-grid");
-        const assets = order.map(key => (manifest.assets || []).find(asset => asset.abi === key)).filter(Boolean);
-        grid.replaceChildren(...assets.map((asset, index) => createDownloadCard(asset, index)));
+        const order = ["arm64-v8a", "universal", "fongmi", "no-vulkan", "armeabi-v7a", "x86_64", "x86"];
+        const assets = order.map(key => (manifest.assets || []).find(a => a.abi === key)).filter(Boolean)
+          .map(a => ({ name: a.name, size: a.size, browser_download_url: a.browser_download_url, download_count: undefined, sha256: a.sha256 }));
+        const checksums = {};
+        assets.forEach(a => { if (a.sha256) checksums[a.name] = a.sha256; });
+        const grid = document.getElementById("pre-download-grid");
+        grid.replaceChildren(...assets.map((a, i) => createDownloadCard(a, i, checksums)));
         grid.setAttribute("aria-busy", "false");
+
+        const recommended = (manifest.assets || []).find(a => a.abi === "arm64-v8a") || (manifest.assets || [])[0];
+        latestPreviewAsset = recommended ? recommended.browser_download_url : null;
+        if (latestPreviewAsset) document.getElementById("pre-cta").href = latestPreviewAsset;
+
+        previewSettled = true;
+        decideDefaultTab();
       })
       .catch(() => {
-        const build = document.getElementById("build");
-        build.textContent = "Offline";
-        build.classList.remove("loading");
-        const grid = document.getElementById("download-grid");
-        const message = document.createElement("article");
-        message.className = "download-card";
-        message.innerHTML = "<h3>Preview unavailable</h3><p class=\"card-description\">Run the Preview Build workflow or use the latest stable GitHub release.</p>";
-        grid.replaceChildren(message);
+        document.getElementById("pre-build").textContent = "Offline";
+        document.getElementById("pre-build").classList.remove("loading");
+        const grid = document.getElementById("pre-download-grid");
+        grid.innerHTML = '<div class="empty-note">No preview build available right now.</div>';
         grid.setAttribute("aria-busy", "false");
+        previewSettled = true;
+        decideDefaultTab();
       });
   </script>
 </body>


### PR DESCRIPTION
## What
Preview site ab do channels dikhata hai — Preview build aur Stable release — same page pe, tab switcher ke saath. Koi separate page/redirect nahi.

## Why
Ab tak preview site sirf preview builds dikhata tha; stable release ke liye GitHub Releases page pe alag jaana padta tha. Isse ek jagah dono milte hain, aur site khulte hi jo channel actually zyada recent hai (GitHub release ya preview build, published_at compare karke) wahi tab default dikhta hai.

## Changes
- Hero me "Preview build" / "Stable release" tab switcher add kiya.
- Stable release tab: GitHub Releases API se live version, changelog (release notes se render), stats (stars/downloads/issues), download assets (real size + SHA-256 checksum), aur pichhle 5 releases.
- Preview tab: existing choice-guide, warning strip, aur download grid same rakha, sirf ek panel me wrap kiya.
- Auto-channel-detection: dono channels ka data load hone tak page hidden rehta hai (`route-gate`), phir jo newer hai wahi tab khulta hai — koi flash/flicker nahi.
- Nav "Releases" link ab same-page tab switch karta hai (`#release` hash), page reload nahi.
- Existing branding/colors (violet, acid, cream paper, Rx watermark) untouched.


## Testing
- `node --check` se embedded JS syntax verify kiya.
- Sabhi `getElementById` calls ke corresponding `id` attributes cross-checked (koi missing id nahi).
- Manual: Actions → Preview Build workflow run karke live site pe channel switch aur auto-detect verify karna baaki hai.