### PR TITLE
smooth 1-to-1 sliding pill animation for bottom navbar and mp3 embedded lyrics extraction

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -11,33 +11,24 @@ package app.gyrolet.mpvrx.ui.browser
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -49,6 +40,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -61,33 +55,32 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.preferences.AppearancePreferences
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
 import app.gyrolet.mpvrx.presentation.Screen
 import app.gyrolet.mpvrx.ui.browser.folderlist.FolderListScreen
-import app.gyrolet.mpvrx.ui.browser.medialibrary.MediaLibraryContent
 import app.gyrolet.mpvrx.ui.browser.music.MusicLibraryContent
 import app.gyrolet.mpvrx.ui.browser.networkstreaming.NetworkStreamingScreen
 import app.gyrolet.mpvrx.ui.browser.playlist.PlaylistScreen
@@ -95,8 +88,11 @@ import app.gyrolet.mpvrx.ui.browser.recentlyplayed.RecentlyPlayedScreen
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.ui.theme.AppMotion
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
+import kotlin.math.roundToInt
 
 @Serializable
 object MainScreen : Screen {
@@ -191,25 +187,61 @@ object MainScreen : Screen {
       NavigationBarState.isNavBarVisible = !hideNavigationBar && visibleTabs.isNotEmpty() && !isPermissionDenied
     }
 
-    var selectedTab by
+    val coroutineScope = rememberCoroutineScope()
+
+    val initialPageIndex =
       remember(visibleTabs) {
-        mutableStateOf(
-          persistentSelectedTab.takeIf { it in visibleTabs }
-            ?: visibleTabs.firstOrNull()
-            ?: MainTab.HOME,
-        )
+        val idx = visibleTabs.indexOf(persistentSelectedTab)
+        if (idx >= 0) idx else 0
       }
 
-    LaunchedEffect(selectedTab) {
-      persistentSelectedTab = selectedTab
-      if (selectedTab != MainTab.HOME) {
-        NavigationBarState.isDualPaneFolderSelected = false
+    val pagerState =
+      rememberPagerState(
+        initialPage = initialPageIndex,
+        pageCount = { visibleTabs.size },
+      )
+
+    // PagerState is the live navigation source of truth. Sync when settled.
+    LaunchedEffect(pagerState, visibleTabs) {
+      if (visibleTabs.isEmpty()) {
+        persistentSelectedTab = MainTab.HOME
+        return@LaunchedEffect
       }
+      val restorePage = visibleTabs.indexOf(persistentSelectedTab).takeIf { it >= 0 } ?: 0
+      if (pagerState.currentPage != restorePage && !pagerState.isScrollInProgress) {
+        pagerState.scrollToPage(restorePage)
+      }
+      snapshotFlow { pagerState.settledPage }
+        .collect { page ->
+          visibleTabs.getOrNull(page)?.let { settledTab ->
+            persistentSelectedTab = settledTab
+            if (settledTab != MainTab.HOME) {
+              NavigationBarState.isDualPaneFolderSelected = false
+            }
+          }
+        }
     }
 
+    val targetPage = pagerState.targetPage.coerceIn(0, (visibleTabs.size - 1).coerceAtLeast(0))
+    val selectedTab = visibleTabs.getOrNull(targetPage) ?: visibleTabs.firstOrNull() ?: MainTab.HOME
+
+    var tabNavigationJob by remember { mutableStateOf<Job?>(null) }
+
     val onTabSelected: (MainScreen.MainTab) -> Unit = { tab ->
-      if (tab in visibleTabs && tab != selectedTab) {
-        selectedTab = tab
+      val targetIndex = visibleTabs.indexOf(tab)
+      if (targetIndex >= 0 && targetIndex != pagerState.targetPage) {
+        tabNavigationJob?.cancel()
+        tabNavigationJob =
+          coroutineScope.launch {
+            pagerState.animateScrollToPage(
+              page = targetIndex,
+              animationSpec =
+                spring(
+                  dampingRatio = Spring.DampingRatioNoBouncy,
+                  stiffness = Spring.StiffnessMedium,
+                ),
+            )
+          }
       }
     }
 
@@ -218,6 +250,7 @@ object MainScreen : Screen {
         visibleTabs = visibleTabs,
         selectedTab = selectedTab,
         onTabSelected = onTabSelected,
+        pagerState = pagerState,
         modifier = modifier,
       )
     }
@@ -301,39 +334,20 @@ object MainScreen : Screen {
             FolderListScreen.Content()
           }
         } else {
-          val density = LocalDensity.current
-          AnimatedContent(
-            targetState = selectedTab,
-            transitionSpec = {
-              val slideDistance = with(density) { 48.dp.roundToPx() }
-              val duration = 250
-              if (targetState.ordinal > initialState.ordinal) {
-                (slideInHorizontally(
-                  animationSpec = tween(durationMillis = duration, easing = FastOutSlowInEasing),
-                  initialOffsetX = { slideDistance },
-                ) + fadeIn(animationSpec = tween(durationMillis = duration))) togetherWith
-                  (slideOutHorizontally(
-                    animationSpec = tween(durationMillis = duration, easing = FastOutSlowInEasing),
-                    targetOffsetX = { -slideDistance },
-                  ) + fadeOut(animationSpec = tween(durationMillis = duration)))
-              } else {
-                (slideInHorizontally(
-                  animationSpec = tween(durationMillis = duration, easing = FastOutSlowInEasing),
-                  initialOffsetX = { -slideDistance },
-                ) + fadeIn(animationSpec = tween(durationMillis = duration))) togetherWith
-                  (slideOutHorizontally(
-                    animationSpec = tween(durationMillis = duration, easing = FastOutSlowInEasing),
-                    targetOffsetX = { slideDistance },
-                  ) + fadeOut(animationSpec = tween(durationMillis = duration)))
-              }
-            },
-            modifier = Modifier.fillMaxSize().nestedScroll(NavigationBarState.navScrollConnection),
-            label = "tab_animation",
-          ) { tab ->
-            CompositionLocalProvider(
-              LocalNavigationBarHeight provides contentBottomPadding,
-              LocalMainNavigationBar provides mainNavBar,
-            ) {
+          CompositionLocalProvider(
+            LocalNavigationBarHeight provides contentBottomPadding,
+            LocalMainNavigationBar provides mainNavBar,
+          ) {
+            HorizontalPager(
+              state = pagerState,
+              beyondViewportPageCount = 1,
+              modifier =
+                Modifier
+                  .fillMaxSize()
+                  .nestedScroll(NavigationBarState.navScrollConnection),
+              key = { page -> visibleTabs.getOrNull(page) ?: page },
+            ) { page ->
+              val tab = visibleTabs.getOrNull(page) ?: return@HorizontalPager
               when (tab) {
                 MainTab.HOME -> FolderListScreen.Content()
                 MainTab.MUSIC -> MusicLibraryContent()
@@ -436,6 +450,7 @@ object MainScreen : Screen {
                 visibleTabs = visibleTabs,
                 selectedTab = selectedTab,
                 onTabSelected = onTabSelected,
+                pagerState = pagerState,
                 modifier =
                   Modifier.onGloballyPositioned { coords ->
                     val w = with(density) { coords.size.width.toDp() }
@@ -458,11 +473,87 @@ private fun ExpressivePillNavigationBar(
   selectedTab: MainScreen.MainTab,
   onTabSelected: (MainScreen.MainTab) -> Unit,
   modifier: Modifier = Modifier,
+  pagerState: PagerState? = null,
 ) {
   val haptics = LocalHapticFeedback.current
+  val coroutineScope = rememberCoroutineScope()
+  val density = LocalDensity.current
+  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+  val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+  var pillWidthPx by remember { mutableFloatStateOf(1f) }
+  var lastHapticIndex by remember { mutableIntStateOf(-1) }
+
+  val dragModifier =
+    if (pagerState != null && visibleTabs.size > 1) {
+      Modifier.pointerInput(pagerState, visibleTabs.size, pillWidthPx, screenWidthPx) {
+        detectHorizontalDragGestures(
+          onDragStart = {
+            lastHapticIndex = pagerState.currentPage
+          },
+          onHorizontalDrag = { change, dragAmount ->
+            change.consume()
+            val tabWidthPx = (pillWidthPx / visibleTabs.size).coerceAtLeast(1f)
+            val scrollRatio = screenWidthPx / tabWidthPx
+            val delta = -dragAmount * scrollRatio
+            pagerState.dispatchRawDelta(delta)
+
+            val currentApproxPage =
+              (pagerState.currentPage + pagerState.currentPageOffsetFraction)
+                .roundToInt()
+                .coerceIn(0, visibleTabs.size - 1)
+            if (currentApproxPage != lastHapticIndex) {
+              haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+              lastHapticIndex = currentApproxPage
+            }
+          },
+          onDragEnd = {
+            val targetPage =
+              (pagerState.currentPage + pagerState.currentPageOffsetFraction)
+                .roundToInt()
+                .coerceIn(0, visibleTabs.size - 1)
+            coroutineScope.launch {
+              pagerState.animateScrollToPage(
+                page = targetPage,
+                animationSpec =
+                  spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMedium,
+                  ),
+              )
+            }
+          },
+          onDragCancel = {
+            val targetPage =
+              (pagerState.currentPage + pagerState.currentPageOffsetFraction)
+                .roundToInt()
+                .coerceIn(0, visibleTabs.size - 1)
+            coroutineScope.launch {
+              pagerState.animateScrollToPage(
+                page = targetPage,
+                animationSpec =
+                  spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMedium,
+                  ),
+              )
+            }
+          },
+        )
+      }
+    } else {
+      Modifier
+    }
 
   Surface(
-    modifier = modifier,
+    modifier =
+      modifier
+        .onGloballyPositioned { coords ->
+          val w = coords.size.width.toFloat()
+          if (w > 0f && w != pillWidthPx) {
+            pillWidthPx = w
+          }
+        }
+        .then(dragModifier),
     shape = CircleShape,
     color = MaterialTheme.colorScheme.surfaceContainerHigh,
     tonalElevation = 6.dp,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -37,6 +39,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -48,15 +52,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -64,18 +71,26 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.util.lerp
+import kotlin.math.roundToInt
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.preferences.AppearancePreferences
 import app.gyrolet.mpvrx.preferences.preference.collectAsState
@@ -189,10 +204,18 @@ object MainScreen : Screen {
 
     val coroutineScope = rememberCoroutineScope()
 
-    val initialPageIndex =
+    var selectedTab by
       remember(visibleTabs) {
-        val idx = visibleTabs.indexOf(persistentSelectedTab)
-        if (idx >= 0) idx else 0
+        mutableStateOf(
+          persistentSelectedTab.takeIf { it in visibleTabs }
+            ?: visibleTabs.firstOrNull()
+            ?: MainTab.HOME,
+        )
+      }
+
+    val initialPageIndex =
+      remember(selectedTab, visibleTabs) {
+        visibleTabs.indexOf(selectedTab).coerceAtLeast(0)
       }
 
     val pagerState =
@@ -201,47 +224,39 @@ object MainScreen : Screen {
         pageCount = { visibleTabs.size },
       )
 
-    // PagerState is the live navigation source of truth. Sync when settled.
-    LaunchedEffect(pagerState, visibleTabs) {
-      if (visibleTabs.isEmpty()) {
-        persistentSelectedTab = MainTab.HOME
-        return@LaunchedEffect
-      }
-      val restorePage = visibleTabs.indexOf(persistentSelectedTab).takeIf { it >= 0 } ?: 0
-      if (pagerState.currentPage != restorePage && !pagerState.isScrollInProgress) {
-        pagerState.scrollToPage(restorePage)
-      }
-      snapshotFlow { pagerState.settledPage }
-        .collect { page ->
-          visibleTabs.getOrNull(page)?.let { settledTab ->
-            persistentSelectedTab = settledTab
-            if (settledTab != MainTab.HOME) {
-              NavigationBarState.isDualPaneFolderSelected = false
-            }
-          }
+    // Sync state when page settles, matching subpage logic in MusicLibraryContent
+    LaunchedEffect(pagerState.settledPage, visibleTabs) {
+      visibleTabs.getOrNull(pagerState.settledPage)?.let { tab ->
+        selectedTab = tab
+        persistentSelectedTab = tab
+        if (tab != MainTab.HOME) {
+          NavigationBarState.isDualPaneFolderSelected = false
         }
+      }
     }
 
-    val targetPage = pagerState.targetPage.coerceIn(0, (visibleTabs.size - 1).coerceAtLeast(0))
-    val selectedTab = visibleTabs.getOrNull(targetPage) ?: visibleTabs.firstOrNull() ?: MainTab.HOME
+    // Scroll to page when tab is selected
+    LaunchedEffect(selectedTab, visibleTabs) {
+      val targetIndex = visibleTabs.indexOf(selectedTab)
+      if (targetIndex >= 0 && pagerState.currentPage != targetIndex) {
+        pagerState.animateScrollToPage(targetIndex)
+      }
+    }
 
-    var tabNavigationJob by remember { mutableStateOf<Job?>(null) }
+    val pagerFlingBehavior =
+      androidx.compose.foundation.pager.PagerDefaults.flingBehavior(
+        state = pagerState,
+        snapPositionalThreshold = 0.2f,
+        snapAnimationSpec =
+          spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMedium,
+          ),
+      )
 
     val onTabSelected: (MainScreen.MainTab) -> Unit = { tab ->
-      val targetIndex = visibleTabs.indexOf(tab)
-      if (targetIndex >= 0 && targetIndex != pagerState.targetPage) {
-        tabNavigationJob?.cancel()
-        tabNavigationJob =
-          coroutineScope.launch {
-            pagerState.animateScrollToPage(
-              page = targetIndex,
-              animationSpec =
-                spring(
-                  dampingRatio = Spring.DampingRatioNoBouncy,
-                  stiffness = Spring.StiffnessMedium,
-                ),
-            )
-          }
+      if (tab in visibleTabs && tab != selectedTab) {
+        selectedTab = tab
       }
     }
 
@@ -271,6 +286,7 @@ object MainScreen : Screen {
         MainTab.NETWORK -> 50.dp
         MainTab.JELLYFIN -> 44.dp
       }
+
     val unselectedCount = (visibleTabs.size - 1).coerceAtLeast(0)
     val targetNavBarWidth =
       if (visibleTabs.isEmpty()) 0.dp
@@ -309,23 +325,21 @@ object MainScreen : Screen {
     // On portrait phones the edge-to-edge mini player sits above the pill nav bar,
     // so screens/FABs must clear it.
     val miniPlayerNavClearance = if (isMiniPlayerVisible && isPortrait && !isTablet) 96.dp else 0.dp
+    val contentBottomPadding = remember(miniPlayerNavClearance) { 88.dp + miniPlayerNavClearance }
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val jellyfinViewModel: app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel =
+      androidx.lifecycle.viewmodel.compose.viewModel(
+        factory =
+          app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel.factory(
+            context.applicationContext as android.app.Application,
+          ),
+      )
 
     // Scaffold with bottom navigation bar
     Scaffold(
       modifier = Modifier.fillMaxSize(),
     ) { paddingValues ->
       Box(modifier = Modifier.fillMaxSize()) {
-        val fabBottomPadding = 88.dp
-        val contentBottomPadding = fabBottomPadding + miniPlayerNavClearance
-        val context = androidx.compose.ui.platform.LocalContext.current
-        val jellyfinViewModel: app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel =
-          androidx.lifecycle.viewmodel.compose.viewModel(
-            factory =
-              app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinViewModel.factory(
-                context.applicationContext as android.app.Application,
-              ),
-          )
-
         if (visibleTabs.isEmpty()) {
           CompositionLocalProvider(
             LocalNavigationBarHeight provides contentBottomPadding,
@@ -340,12 +354,9 @@ object MainScreen : Screen {
           ) {
             HorizontalPager(
               state = pagerState,
+              modifier = Modifier.fillMaxSize(),
               beyondViewportPageCount = 1,
-              modifier =
-                Modifier
-                  .fillMaxSize()
-                  .nestedScroll(NavigationBarState.navScrollConnection),
-              key = { page -> visibleTabs.getOrNull(page) ?: page },
+              flingBehavior = pagerFlingBehavior,
             ) { page ->
               val tab = visibleTabs.getOrNull(page) ?: return@HorizontalPager
               when (tab) {
@@ -427,9 +438,13 @@ object MainScreen : Screen {
             )
 
             SideEffect {
-              NavigationBarState.navbarLeftOffset =
-                if (isCustomAligned) animatedLeftPadding else ((containerWidth - animatedWidthDp) / 2).coerceAtLeast(16.dp)
-              NavigationBarState.navbarWidth = animatedWidthDp
+              val targetLeft = if (isCustomAligned) animatedLeftPadding else ((containerWidth - animatedWidthDp) / 2).coerceAtLeast(16.dp)
+              if (NavigationBarState.navbarLeftOffset != targetLeft) {
+                NavigationBarState.navbarLeftOffset = targetLeft
+              }
+              if (NavigationBarState.navbarWidth != animatedWidthDp) {
+                NavigationBarState.navbarWidth = animatedWidthDp
+              }
             }
 
             Box(
@@ -476,84 +491,67 @@ private fun ExpressivePillNavigationBar(
   pagerState: PagerState? = null,
 ) {
   val haptics = LocalHapticFeedback.current
-  val coroutineScope = rememberCoroutineScope()
-  val density = LocalDensity.current
-  val configuration = androidx.compose.ui.platform.LocalConfiguration.current
-  val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
-  var pillWidthPx by remember { mutableFloatStateOf(1f) }
-  var lastHapticIndex by remember { mutableIntStateOf(-1) }
 
-  val dragModifier =
-    if (pagerState != null && visibleTabs.size > 1) {
-      Modifier.pointerInput(pagerState, visibleTabs.size, pillWidthPx, screenWidthPx) {
-        detectHorizontalDragGestures(
-          onDragStart = {
-            lastHapticIndex = pagerState.currentPage
-          },
-          onHorizontalDrag = { change, dragAmount ->
-            change.consume()
-            val tabWidthPx = (pillWidthPx / visibleTabs.size).coerceAtLeast(1f)
-            val scrollRatio = screenWidthPx / tabWidthPx
-            val delta = -dragAmount * scrollRatio
-            pagerState.dispatchRawDelta(delta)
-
-            val currentApproxPage =
-              (pagerState.currentPage + pagerState.currentPageOffsetFraction)
-                .roundToInt()
-                .coerceIn(0, visibleTabs.size - 1)
-            if (currentApproxPage != lastHapticIndex) {
-              haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-              lastHapticIndex = currentApproxPage
-            }
-          },
-          onDragEnd = {
-            val targetPage =
-              (pagerState.currentPage + pagerState.currentPageOffsetFraction)
-                .roundToInt()
-                .coerceIn(0, visibleTabs.size - 1)
-            coroutineScope.launch {
-              pagerState.animateScrollToPage(
-                page = targetPage,
-                animationSpec =
-                  spring(
-                    dampingRatio = Spring.DampingRatioNoBouncy,
-                    stiffness = Spring.StiffnessMedium,
-                  ),
-              )
-            }
-          },
-          onDragCancel = {
-            val targetPage =
-              (pagerState.currentPage + pagerState.currentPageOffsetFraction)
-                .roundToInt()
-                .coerceIn(0, visibleTabs.size - 1)
-            coroutineScope.launch {
-              pagerState.animateScrollToPage(
-                page = targetPage,
-                animationSpec =
-                  spring(
-                    dampingRatio = Spring.DampingRatioNoBouncy,
-                    stiffness = Spring.StiffnessMedium,
-                  ),
-              )
-            }
-          },
-        )
-      }
+  val position =
+    if (pagerState != null && visibleTabs.isNotEmpty()) {
+      (pagerState.currentPage + pagerState.currentPageOffsetFraction).coerceIn(
+        0f,
+        (visibleTabs.size - 1).toFloat(),
+      )
     } else {
-      Modifier
+      visibleTabs.indexOf(selectedTab).coerceAtLeast(0).toFloat()
+    }
+
+  fun activeTabWidth(tab: MainScreen.MainTab): androidx.compose.ui.unit.Dp =
+    when (tab) {
+      MainScreen.MainTab.HOME -> 92.dp
+      MainScreen.MainTab.MUSIC -> 92.dp
+      MainScreen.MainTab.RECENTS -> 104.dp
+      MainScreen.MainTab.PLAYLISTS -> 108.dp
+      MainScreen.MainTab.NETWORK -> 106.dp
+      MainScreen.MainTab.JELLYFIN -> 100.dp
+    }
+
+  val inactiveTabWidth = 44.dp
+  val spacing = 4.dp
+  val startPadding = 6.dp
+
+  val tabWidths = remember(position, visibleTabs) {
+    visibleTabs.mapIndexed { index, tab ->
+      val fraction = (1f - kotlin.math.abs(position - index)).coerceIn(0f, 1f)
+      androidx.compose.ui.unit.lerp(inactiveTabWidth, activeTabWidth(tab), fraction)
+    }
+  }
+
+  val tabOffsets = remember(tabWidths) {
+    var acc = startPadding
+    tabWidths.map { w ->
+      val left = acc
+      acc += w + spacing
+      left
+    }
+  }
+
+  val pageFloor = position.toInt().coerceIn(0, (visibleTabs.size - 1).coerceAtLeast(0))
+  val pageCeil = (pageFloor + 1).coerceIn(0, (visibleTabs.size - 1).coerceAtLeast(0))
+  val fraction = (position - pageFloor).coerceIn(0f, 1f)
+
+  val indicatorLeft =
+    if (tabOffsets.isNotEmpty()) {
+      androidx.compose.ui.unit.lerp(tabOffsets[pageFloor], tabOffsets[pageCeil], fraction)
+    } else {
+      startPadding
+    }
+
+  val indicatorWidth =
+    if (tabWidths.isNotEmpty()) {
+      androidx.compose.ui.unit.lerp(tabWidths[pageFloor], tabWidths[pageCeil], fraction)
+    } else {
+      inactiveTabWidth
     }
 
   Surface(
-    modifier =
-      modifier
-        .onGloballyPositioned { coords ->
-          val w = coords.size.width.toFloat()
-          if (w > 0f && w != pillWidthPx) {
-            pillWidthPx = w
-          }
-        }
-        .then(dragModifier),
+    modifier = modifier,
     shape = CircleShape,
     color = MaterialTheme.colorScheme.surfaceContainerHigh,
     tonalElevation = 6.dp,
@@ -564,141 +562,106 @@ private fun ExpressivePillNavigationBar(
         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.25f),
       ),
   ) {
-    Row(
+    Box(
       modifier =
         Modifier
           .wrapContentWidth()
-          .padding(horizontal = 6.dp, vertical = 6.dp),
-      horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-      verticalAlignment = Alignment.CenterVertically,
+          .padding(horizontal = startPadding, vertical = 6.dp),
     ) {
-      visibleTabs.forEach { tab ->
-        val isSelected = selectedTab == tab
+      // Sliding background pill indicator
+      Box(
+        modifier =
+          Modifier
+            .offset(x = indicatorLeft - startPadding, y = 0.dp)
+            .width(indicatorWidth)
+            .height(44.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primaryContainer),
+      )
 
-        val animatedPadding by animateDpAsState(
-          targetValue = if (isSelected) 14.dp else 10.dp,
-          animationSpec =
-            spring(
-              dampingRatio = Spring.DampingRatioNoBouncy,
-              stiffness = Spring.StiffnessMedium,
-            ),
-          label = "expressive_nav_padding",
-        )
+      // Tab buttons row positioned directly on top of the track
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        visibleTabs.forEachIndexed { index, tab ->
+          val tabFraction = (1f - kotlin.math.abs(position - index)).coerceIn(0f, 1f)
+          val tabWidth = tabWidths.getOrElse(index) { inactiveTabWidth }
 
-        val animatedContainerColor by animateColorAsState(
-          targetValue =
-            if (isSelected) {
-              MaterialTheme.colorScheme.primaryContainer
-            } else {
-              Color.Transparent
-            },
-          animationSpec = androidx.compose.animation.core.tween(durationMillis = 180),
-          label = "expressive_nav_container_color",
-        )
+          val contentColor =
+            androidx.compose.ui.graphics.lerp(
+              MaterialTheme.colorScheme.onSurfaceVariant,
+              MaterialTheme.colorScheme.onPrimaryContainer,
+              tabFraction,
+            )
 
-        val animatedContentColor by animateColorAsState(
-          targetValue =
-            if (isSelected) {
-              MaterialTheme.colorScheme.onPrimaryContainer
-            } else {
-              MaterialTheme.colorScheme.onSurfaceVariant
-            },
-          animationSpec = androidx.compose.animation.core.tween(durationMillis = 180),
-          label = "expressive_nav_content_color",
-        )
-
-        Surface(
-          onClick = {
-            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-            onTabSelected(tab)
-          },
-          shape = CircleShape,
-          color = animatedContainerColor,
-          contentColor = animatedContentColor,
-          modifier = Modifier.height(44.dp),
-        ) {
-          Row(
+          Box(
             modifier =
               Modifier
-                .padding(horizontal = animatedPadding)
-                .animateContentSize(
-                  animationSpec =
-                    spring(
-                      dampingRatio = Spring.DampingRatioNoBouncy,
-                      stiffness = Spring.StiffnessMedium,
-                    ),
-                ),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
+                .width(tabWidth)
+                .height(44.dp)
+                .clip(CircleShape)
+                .clickable(
+                  interactionSource = remember { MutableInteractionSource() },
+                  indication = androidx.compose.material3.ripple(bounded = true),
+                ) {
+                  haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                  onTabSelected(tab)
+                },
+            contentAlignment = Alignment.Center,
           ) {
-            when (tab) {
-              MainScreen.MainTab.HOME ->
-                Icon(
-                  Icons.RoundedFilled.Home,
-                  contentDescription = stringResource(R.string.ui_home),
-                  tint = animatedContentColor,
-                  modifier = Modifier.size(22.dp),
-                )
-              MainScreen.MainTab.MUSIC ->
-                Icon(
-                  Icons.RoundedFilled.Audiotrack,
-                  contentDescription = stringResource(R.string.ui_music),
-                  tint = animatedContentColor,
-                  modifier = Modifier.size(22.dp),
-                )
-              MainScreen.MainTab.RECENTS ->
-                Icon(
-                  Icons.RoundedFilled.History,
-                  contentDescription = stringResource(R.string.ui_recents),
-                  tint = animatedContentColor,
-                  modifier = Modifier.size(22.dp),
-                )
-              MainScreen.MainTab.PLAYLISTS ->
-                Icon(
-                  Icons.RoundedFilled.PlaylistPlay,
-                  contentDescription = stringResource(R.string.ui_playlists),
-                  tint = animatedContentColor,
-                  modifier = Modifier.size(22.dp),
-                )
-              MainScreen.MainTab.NETWORK ->
-                Icon(
-                  Icons.RoundedFilled.BringYourOwnIp,
-                  contentDescription = stringResource(R.string.ui_network),
-                  tint = animatedContentColor,
-                  modifier = Modifier.size(22.dp),
-                )
-              MainScreen.MainTab.JELLYFIN ->
-                androidx.compose.material3.Icon(
-                  painter = painterResource(R.drawable.ic_jellyfin),
-                  contentDescription = "Jellyfin",
-                  tint = animatedContentColor,
-                  modifier = Modifier.size(22.dp),
-                )
-            }
-
-            AnimatedVisibility(
-              visible = isSelected,
-              enter =
-                fadeIn(animationSpec = androidx.compose.animation.core.tween(150)) +
-                  expandHorizontally(
-                    animationSpec =
-                      spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy,
-                        stiffness = Spring.StiffnessMedium,
-                      ),
-                  ),
-              exit =
-                fadeOut(animationSpec = androidx.compose.animation.core.tween(100)) +
-                  shrinkHorizontally(
-                    animationSpec =
-                      spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy,
-                        stiffness = Spring.StiffnessMedium,
-                      ),
-                  ),
+            Row(
+              modifier = Modifier.padding(horizontal = 8.dp),
+              horizontalArrangement = Arrangement.Center,
+              verticalAlignment = Alignment.CenterVertically,
             ) {
-              Row(verticalAlignment = Alignment.CenterVertically) {
-                Spacer(modifier = Modifier.width(6.dp))
+              when (tab) {
+                MainScreen.MainTab.HOME ->
+                  Icon(
+                    Icons.RoundedFilled.Home,
+                    contentDescription = stringResource(R.string.ui_home),
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp),
+                  )
+                MainScreen.MainTab.MUSIC ->
+                  Icon(
+                    Icons.RoundedFilled.Audiotrack,
+                    contentDescription = stringResource(R.string.ui_music),
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp),
+                  )
+                MainScreen.MainTab.RECENTS ->
+                  Icon(
+                    Icons.RoundedFilled.History,
+                    contentDescription = stringResource(R.string.ui_recents),
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp),
+                  )
+                MainScreen.MainTab.PLAYLISTS ->
+                  Icon(
+                    Icons.RoundedFilled.PlaylistPlay,
+                    contentDescription = stringResource(R.string.ui_playlists),
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp),
+                  )
+                MainScreen.MainTab.NETWORK ->
+                  Icon(
+                    Icons.RoundedFilled.BringYourOwnIp,
+                    contentDescription = stringResource(R.string.ui_network),
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp),
+                  )
+                MainScreen.MainTab.JELLYFIN ->
+                  androidx.compose.material3.Icon(
+                    painter = painterResource(R.drawable.ic_jellyfin),
+                    contentDescription = "Jellyfin",
+                    tint = contentColor,
+                    modifier = Modifier.size(22.dp),
+                  )
+              }
+
+              if (tabFraction > 0.05f) {
+                Spacer(modifier = Modifier.width(androidx.compose.ui.unit.lerp(0.dp, 6.dp, tabFraction)))
                 Text(
                   text =
                     when (tab) {
@@ -711,9 +674,14 @@ private fun ExpressivePillNavigationBar(
                     },
                   style = MaterialTheme.typography.labelMedium,
                   fontWeight = FontWeight.Bold,
-                  color = animatedContentColor,
+                  color = contentColor,
                   maxLines = 1,
-                  overflow = TextOverflow.Ellipsis,
+                  softWrap = false,
+                  overflow = TextOverflow.Clip,
+                  modifier =
+                    Modifier.graphicsLayer {
+                      alpha = ((tabFraction - 0.25f) / 0.75f).coerceIn(0f, 1f)
+                    },
                 )
               }
             }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -1977,6 +1977,7 @@ class PlayerViewModel : ViewModel(),
     }
     syncplayManager.updateFileInfo(currentSyncplayFileInfo())
     applyEqualizerMpvFilters()
+    loadLyricsForCurrentTrack(forceRefresh = true)
   }
 
   fun updateTorrentState(state: TorrentStreamingState) {

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/EmbeddedLyricsExtractor.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/EmbeddedLyricsExtractor.kt
@@ -32,10 +32,7 @@ object EmbeddedLyricsExtractor {
     }
 
     // 2. Try MPV tag properties for embedded lyrics
-    val mpvLyrics = listOf("LYRICS", "SYNCEDLYRICS", "UNSYNCEDLYRICS", "USLT", "lyrics")
-      .firstNotNullOfOrNull { key ->
-        PlaybackSession.getPropertyString("metadata/by-key/$key")?.takeIf { it.isNotBlank() }
-      }
+    val mpvLyrics = findLyricsInMpvMetadata()
     if (mpvLyrics != null) {
       val parsed = LyricsUtils.parseLyrics(mpvLyrics, sourceType = LyricsSourceType.EMBEDDED)
       if (parsed.isValid()) {
@@ -44,7 +41,17 @@ object EmbeddedLyricsExtractor {
       }
     }
 
-    // 3. Fallback to MediaMetadataRetriever (key 1000 for lyrics)
+    // 3. Fallback: Direct ID3v2 parser from media file / content stream
+    val id3Lyrics = findLyricsDirectlyFromMedia(context, mediaPath)
+    if (id3Lyrics != null) {
+      val parsed = LyricsUtils.parseLyrics(id3Lyrics, sourceType = LyricsSourceType.EMBEDDED)
+      if (parsed.isValid()) {
+        Log.d(TAG, "Extracted embedded lyrics via direct ID3 stream parser")
+        return@withContext parsed
+      }
+    }
+
+    // 4. Fallback to MediaMetadataRetriever (for supported platforms)
     runCatching {
       val retriever = MediaMetadataRetriever()
       val cleanPath = when {
@@ -59,7 +66,7 @@ object EmbeddedLyricsExtractor {
         retriever.setDataSource(context, Uri.parse(mediaPath))
       }
 
-      // Key 1000 represents METADATA_KEY_LYRICS in MediaMetadataRetriever
+      // Key 1000 represents METADATA_KEY_LYRICS in vendor MediaMetadataRetriever extensions
       val rawLyrics = retriever.extractMetadata(1000)
       retriever.release()
 
@@ -75,6 +82,166 @@ object EmbeddedLyricsExtractor {
     }
 
     null
+  }
+
+  private fun findLyricsInMpvMetadata(): String? {
+    // 1. Dynamic scan through all MPV metadata entries
+    val count = PlaybackSession.getPropertyInt("metadata/list/count") ?: 0
+    for (i in 0 until count) {
+      val key = PlaybackSession.getPropertyString("metadata/list/$i/key") ?: continue
+      val keyLower = key.lowercase()
+      if (
+        keyLower.startsWith("lyrics") ||
+        keyLower.contains("unsynced") ||
+        keyLower.contains("synced") ||
+        keyLower in setOf("uslt", "sylt", "ult", "©lyr", "clyr")
+      ) {
+        val value = PlaybackSession.getPropertyString("metadata/list/$i/value")?.takeIf { it.isNotBlank() }
+        if (value != null) return value
+      }
+    }
+
+    // 2. Direct lookup for common FFmpeg ID3/Vorbis/MP4 metadata tags
+    val candidateKeys = listOf(
+      "lyrics-eng", "lyrics-und", "lyrics-xxx", "lyrics-",
+      "LYRICS", "lyrics", "Lyrics", "LYRICS_TEXT",
+      "UNSYNCED LYRICS", "UNSYNCEDLYRICS", "unsyncedlyrics", "unsynced_lyrics",
+      "SYNCED LYRICS", "SYNCEDLYRICS", "syncedlyrics", "synced_lyrics",
+      "USLT", "SYLT", "ULT", "©lyr", "clyr", "TIT3",
+    )
+    return candidateKeys.firstNotNullOfOrNull { key ->
+      PlaybackSession.getPropertyString("metadata/by-key/$key")?.takeIf { it.isNotBlank() }
+    }
+  }
+
+  private fun findLyricsDirectlyFromMedia(context: Context, mediaPath: String): String? {
+    return runCatching {
+      val cleanPath = when {
+        mediaPath.startsWith("file://") -> mediaPath.removePrefix("file://")
+        mediaPath.startsWith("content://") -> null
+        else -> mediaPath
+      }
+      val inputStream = if (cleanPath != null) {
+        val file = File(cleanPath)
+        if (!file.exists() || !file.canRead()) return null
+        file.inputStream()
+      } else {
+        context.contentResolver.openInputStream(Uri.parse(mediaPath))
+      }
+      inputStream?.use { extractLyricsFromStream(it) }
+    }.getOrNull()
+  }
+
+  private fun extractLyricsFromStream(inputStream: java.io.InputStream): String? {
+    try {
+      val header = ByteArray(10)
+      if (inputStream.read(header) < 10) return null
+      if (header[0] != 'I'.code.toByte() || header[1] != 'D'.code.toByte() || header[2] != '3'.code.toByte()) return null
+
+      val majorVersion = header[3].toInt() and 0xFF
+      val tagFlags = header[5].toInt() and 0xFF
+      val tagSize = ((header[6].toInt() and 0x7F) shl 21) or
+        ((header[7].toInt() and 0x7F) shl 14) or
+        ((header[8].toInt() and 0x7F) shl 7) or
+        (header[9].toInt() and 0x7F)
+
+      if (tagSize <= 0 || tagSize > 10 * 1024 * 1024) return null
+
+      val tagData = ByteArray(tagSize)
+      var bytesRead = 0
+      while (bytesRead < tagSize) {
+        val count = inputStream.read(tagData, bytesRead, tagSize - bytesRead)
+        if (count == -1) break
+        bytesRead += count
+      }
+      if (bytesRead < tagSize) return null
+
+      var offset = 0
+      // Check for extended header in ID3v2.3/2.4
+      if ((tagFlags and 0x40) != 0) {
+        if (majorVersion == 4 && offset + 4 <= tagSize) {
+          val extSize = ((tagData[offset].toInt() and 0x7F) shl 21) or
+            ((tagData[offset + 1].toInt() and 0x7F) shl 14) or
+            ((tagData[offset + 2].toInt() and 0x7F) shl 7) or
+            (tagData[offset + 3].toInt() and 0x7F)
+          offset += extSize
+        } else if (majorVersion == 3 && offset + 4 <= tagSize) {
+          val extSize = ((tagData[offset].toInt() and 0xFF) shl 24) or
+            ((tagData[offset + 1].toInt() and 0xFF) shl 16) or
+            ((tagData[offset + 2].toInt() and 0xFF) shl 8) or
+            (tagData[offset + 3].toInt() and 0xFF)
+          offset += extSize + 4
+        }
+      }
+
+      while (offset + 10 <= tagSize) {
+        val frameId = String(tagData, offset, if (majorVersion == 2) 3 else 4, Charsets.ISO_8859_1)
+        if (frameId.all { it == '\u0000' }) break
+
+        val (headerLen, frameSize) = if (majorVersion == 2) {
+          val size = ((tagData[offset + 3].toInt() and 0xFF) shl 16) or
+            ((tagData[offset + 4].toInt() and 0xFF) shl 8) or
+            (tagData[offset + 5].toInt() and 0xFF)
+          Pair(6, size)
+        } else if (majorVersion == 4) {
+          val size = ((tagData[offset + 4].toInt() and 0x7F) shl 21) or
+            ((tagData[offset + 5].toInt() and 0x7F) shl 14) or
+            ((tagData[offset + 6].toInt() and 0x7F) shl 7) or
+            (tagData[offset + 7].toInt() and 0x7F)
+          Pair(10, size)
+        } else {
+          // ID3v2.3
+          val size = ((tagData[offset + 4].toInt() and 0xFF) shl 24) or
+            ((tagData[offset + 5].toInt() and 0xFF) shl 16) or
+            ((tagData[offset + 6].toInt() and 0xFF) shl 8) or
+            (tagData[offset + 7].toInt() and 0xFF)
+          Pair(10, size)
+        }
+
+        val frameStart = offset + headerLen
+        val frameEnd = frameStart + frameSize
+        if (frameEnd > tagSize || frameSize <= 0) break
+
+        if (frameId == "USLT" || frameId == "ULT") {
+          val encodingByte = tagData[frameStart].toInt() and 0xFF
+          val (charset, nullTermSize) = when (encodingByte) {
+            1 -> Pair(Charsets.UTF_16, 2)
+            2 -> Pair(Charsets.UTF_16BE, 2)
+            3 -> Pair(Charsets.UTF_8, 1)
+            else -> Pair(Charsets.ISO_8859_1, 1)
+          }
+
+          // Skip 1 byte encoding + 3 bytes language
+          var contentOffset = frameStart + 4
+          // Skip descriptor (null-terminated string)
+          while (contentOffset < frameEnd) {
+            if (nullTermSize == 2) {
+              if (contentOffset + 1 < frameEnd && tagData[contentOffset] == 0.toByte() && tagData[contentOffset + 1] == 0.toByte()) {
+                contentOffset += 2
+                break
+              }
+              contentOffset += 2
+            } else {
+              if (tagData[contentOffset] == 0.toByte()) {
+                contentOffset += 1
+                break
+              }
+              contentOffset += 1
+            }
+          }
+
+          if (contentOffset < frameEnd) {
+            val text = String(tagData, contentOffset, frameEnd - contentOffset, charset).trim().trim('\u0000')
+            if (text.isNotBlank()) return text
+          }
+        }
+
+        offset = frameEnd
+      }
+    } catch (e: Exception) {
+      Log.d(TAG, "Error parsing ID3 tag: ${e.message}")
+    }
+    return null
   }
 
   private fun findLocalLrcFile(mediaPath: String): Lyrics? {


### PR DESCRIPTION
1. Stopped Root Recompositions: Isolated swipe offset tracking strictly to the navbar so the main screen and pages don't recompose on every sub-pixel drag frame.
2. Removed Layout Measurement Loops: Replaced onGloballyPositioned state callbacks with pure mathematical DP positioning, eliminating frame-dropping measure loops.
3. Removed Gesture Conflicts: Removed competing nestedScroll and drag interceptors from the pager to restore native 120 FPS swiping.
4. Light Snap Threshold (`0.2f`): Lowered the snap threshold from 50% to 20% so swipes snap forward instantly without mid-page resistance.
5. Single Sliding Pill: Switched from multiple animated surfaces to a single GPU-accelerated pill sliding smoothly behind the buttons.
6. Added mp3 embedded lyrics extraction #510 