### PR TITLE
Prompt before installing yt-dlp on first paste-link play

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/dialogs/SortDialog.kt
@@ -400,11 +400,7 @@ private fun SortOrderSelector(
         selected = index == selectedIndex,
         onClick = { onSortOrderChange(index == 0) },
         shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-        colors =
-          SegmentedButtonDefaults.colors(
-            activeContentColor = MaterialTheme.colorScheme.primary,
-            activeBorderColor = MaterialTheme.colorScheme.primary,
-          ),
+        colors = themedSegmentedButtonColors(),
         icon = {
           Icon(
             imageVector =

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -108,12 +108,18 @@ import app.gyrolet.mpvrx.ui.browser.dialogs.EditConnectionSheet
 import app.gyrolet.mpvrx.ui.icons.AppIcon
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.player.ytdlp.YtdlpInstallPromptDialog
+import app.gyrolet.mpvrx.ui.player.ytdlp.YtdlpInstallProgressDialog
+import app.gyrolet.mpvrx.ui.player.ytdlp.YtdlpManager
+import app.gyrolet.mpvrx.ui.preferences.YtdlpSettingsScreen
 import app.gyrolet.mpvrx.ui.torrent.TorrentSelectionInput
 import app.gyrolet.mpvrx.ui.torrent.TorrentSelectionScreen
 import app.gyrolet.mpvrx.ui.torrent.TorrentSelectionViewModel
 import app.gyrolet.mpvrx.ui.utils.LocalBackStack
 import app.gyrolet.mpvrx.utils.media.SharedUrlExtractor
 import app.gyrolet.mpvrx.utils.media.MediaUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import org.koin.compose.koinInject
@@ -159,6 +165,29 @@ object NetworkStreamingScreen : Screen {
     var showTorrentPicker by remember { mutableStateOf(false) }
     val navigationBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current
     val coroutineScope = rememberCoroutineScope()
+
+    // yt-dlp install gate for the "paste link -> Play" flow: instead of silently installing
+    // yt-dlp in the background while the player buffers on first use, we ask up front.
+    var pendingYtdlpUrl by remember { mutableStateOf<String?>(null) }
+    var showYtdlpInstallPrompt by remember { mutableStateOf(false) }
+    var showYtdlpInstallProgress by remember { mutableStateOf(false) }
+    var ytdlpInstallLastLog by remember { mutableStateOf("") }
+    var ytdlpInstallError by remember { mutableStateOf<String?>(null) }
+    var ytdlpInstallJob by remember { mutableStateOf<Job?>(null) }
+
+    fun proceedToPlay(url: String) {
+      viewModel.recordSubmittedLink(url)
+      MediaUtils.playFile(url, context, "network_stream")
+    }
+
+    fun playLinkGatingYtdlp(url: String) {
+      if (YtdlpManager.requiresYtdlp(url) && !YtdlpManager.isInstalled(context)) {
+        pendingYtdlpUrl = url
+        showYtdlpInstallPrompt = true
+      } else {
+        proceedToPlay(url)
+      }
+    }
 
     LaunchedEffect(torrentPickerViewModel) {
       torrentPickerViewModel.launches.collect { request ->
@@ -392,8 +421,7 @@ object NetworkStreamingScreen : Screen {
                     showTorrentPicker = true
                     torrentPickerViewModel.open(TorrentSelectionInput(source = playableSource))
                   } else {
-                    viewModel.recordSubmittedLink(playableSource)
-                    MediaUtils.playFile(playableSource, context, "network_stream")
+                    playLinkGatingYtdlp(playableSource)
                   }
                 },
                 onPlayRecent = { entry ->
@@ -476,6 +504,55 @@ object NetworkStreamingScreen : Screen {
         onSave = { connection ->
           viewModel.addConnection(connection)
           showAddSheet = false
+        },
+      )
+
+      YtdlpInstallPromptDialog(
+        isOpen = showYtdlpInstallPrompt,
+        onInstall = {
+          showYtdlpInstallPrompt = false
+          ytdlpInstallError = null
+          ytdlpInstallLastLog = ""
+          showYtdlpInstallProgress = true
+          ytdlpInstallJob =
+            coroutineScope.launch {
+              val success =
+                YtdlpManager.runInstall(context) { log ->
+                  // runInstall logs from an IO dispatcher; hop back to Main before touching state.
+                  coroutineScope.launch(Dispatchers.Main) {
+                    ytdlpInstallLastLog = log
+                  }
+                }
+              if (success) {
+                showYtdlpInstallProgress = false
+                pendingYtdlpUrl?.let { proceedToPlay(it) }
+                pendingYtdlpUrl = null
+              } else {
+                // Leave the progress dialog open so the error is visible; Cancel dismisses it.
+                ytdlpInstallError = context.getString(R.string.ytdlp_install_failed)
+              }
+            }
+        },
+        onConfigure = {
+          showYtdlpInstallPrompt = false
+          pendingYtdlpUrl = null
+          backstack.add(YtdlpSettingsScreen)
+        },
+        onDismiss = {
+          showYtdlpInstallPrompt = false
+          pendingYtdlpUrl = null
+        },
+      )
+
+      YtdlpInstallProgressDialog(
+        isOpen = showYtdlpInstallProgress,
+        lastLogLine = ytdlpInstallLastLog,
+        error = ytdlpInstallError,
+        onCancel = {
+          ytdlpInstallJob?.cancel()
+          ytdlpInstallJob = null
+          showYtdlpInstallProgress = false
+          pendingYtdlpUrl = null
         },
       )
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/ytdlp/YtdlpInstallProgressDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/ytdlp/YtdlpInstallProgressDialog.kt
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player.ytdlp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import app.gyrolet.mpvrx.R
+
+/**
+ * Progress UI shown while [YtdlpManager.runInstall] runs, triggered from
+ * [YtdlpInstallPromptDialog]'s Install action. There's no byte-level progress from the
+ * installer, so this shows an indeterminate bar plus the latest log line, same idea as
+ * [app.gyrolet.mpvrx.ui.securefolder.SecureFolderProgressDialog] but without a percentage.
+ *
+ * Not dismissable by back-press or outside-tap — [onCancel] is the only way out while busy,
+ * same as the secure-folder progress dialog.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun YtdlpInstallProgressDialog(
+  isOpen: Boolean,
+  lastLogLine: String,
+  error: String?,
+  onCancel: () -> Unit,
+) {
+  if (!isOpen) return
+
+  Dialog(
+    onDismissRequest = { /* no-op: cancel button is the only exit while busy */ },
+    properties =
+      DialogProperties(
+        dismissOnBackPress = false,
+        dismissOnClickOutside = false,
+      ),
+  ) {
+    Surface(
+      shape = MaterialTheme.shapes.extraLarge,
+      color = AlertDialogDefaults.containerColor,
+      tonalElevation = AlertDialogDefaults.TonalElevation,
+    ) {
+      Column(
+        modifier = Modifier.padding(28.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        Text(
+          stringResource(R.string.ytdlp_installing),
+          style = MaterialTheme.typography.titleLarge,
+          fontWeight = FontWeight.Bold,
+          color = AlertDialogDefaults.titleContentColor,
+        )
+
+        if (error == null) {
+          LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+
+        if (lastLogLine.isNotBlank()) {
+          Text(
+            lastLogLine,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+          )
+        }
+
+        if (error != null) {
+          Text(
+            error,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+          )
+        }
+
+        TextButton(
+          onClick = onCancel,
+          shape = MaterialTheme.shapes.extraLarge,
+        ) {
+          Text(
+            stringResource(R.string.generic_cancel),
+            fontWeight = FontWeight.Medium,
+          )
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/ytdlp/YtdlpInstallPromptDialog.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/ytdlp/YtdlpInstallPromptDialog.kt
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player.ytdlp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.gyrolet.mpvrx.R
+
+/**
+ * Shown instead of silently installing/updating yt-dlp in the background before playback
+ * (which used to leave the player buffering with no explanation on a link's first play).
+ *
+ * Mirrors the layout of [app.gyrolet.mpvrx.ui.securefolder.SecureConfirmDialog] /
+ * `ConfirmDialog`, but with a third, visually separated action ([onConfigure]) pinned to the
+ * start of the row so it doesn't get mistaken for a variant of confirm/cancel.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun YtdlpInstallPromptDialog(
+  isOpen: Boolean,
+  onInstall: () -> Unit,
+  onConfigure: () -> Unit,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  if (!isOpen) return
+
+  BasicAlertDialog(
+    onDismissRequest = onDismiss,
+    modifier = modifier,
+  ) {
+    Surface(
+      shape = MaterialTheme.shapes.extraLarge,
+      color = AlertDialogDefaults.containerColor,
+      tonalElevation = AlertDialogDefaults.TonalElevation,
+    ) {
+      Column(
+        modifier = Modifier.padding(28.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+      ) {
+        Text(
+          stringResource(R.string.ui_yt_dlp_not_installed),
+          style = MaterialTheme.typography.headlineMedium,
+          fontWeight = FontWeight.Bold,
+          color = AlertDialogDefaults.titleContentColor,
+        )
+        Text(
+          stringResource(R.string.ytdlp_install_prompt_subtitle),
+          style = MaterialTheme.typography.bodyLarge,
+          fontWeight = FontWeight.Medium,
+          color = AlertDialogDefaults.textContentColor,
+        )
+        Row(
+          Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+          TextButton(
+            onClick = onConfigure,
+            shape = MaterialTheme.shapes.extraLarge,
+          ) {
+            Text(
+              stringResource(R.string.generic_configure),
+              fontWeight = FontWeight.Medium,
+            )
+          }
+          Row {
+            TextButton(
+              onClick = onDismiss,
+              shape = MaterialTheme.shapes.extraLarge,
+            ) {
+              Text(
+                stringResource(R.string.generic_cancel),
+                fontWeight = FontWeight.Medium,
+              )
+            }
+            TextButton(
+              onClick = onInstall,
+              shape = MaterialTheme.shapes.extraLarge,
+            ) {
+              Text(
+                stringResource(R.string.generic_install),
+                fontWeight = FontWeight.Bold,
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/ytdlp/YtdlpManager.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/ytdlp/YtdlpManager.kt
@@ -384,7 +384,7 @@ object YtdlpManager {
     return runtimeAssetsPrepared
   }
 
-  private fun isInstalled(context: Context): Boolean {
+  fun isInstalled(context: Context): Boolean {
     val ytDlp = File(getYtdlDir(context), "yt-dlp")
     return ytDlp.isFile && ytDlp.length() > 0L
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
   <string name="generic_share">Share</string>
   <string name="generic_confirm">Confirm</string>
   <string name="generic_cancel">Cancel</string>
+  <string name="generic_install">Install</string>
+  <string name="generic_configure">Configure</string>
   <string name="generic_ok">OK</string>
   <string name="generic_unit_ms">ms</string>
   <string name="generic_disabled">Disabled</string>
@@ -1569,6 +1571,9 @@
   <string name="ui_yt_dlp_installed_build">Installed Build</string>
   <string name="ui_reading_installed_version">Reading installed version…</string>
   <string name="ui_install_stable_to_play_web_links">Install the stable release to play supported web links.</string>
+  <string name="ytdlp_install_prompt_subtitle">This link needs yt-dlp to play. Install it now, or configure it later from settings.</string>
+  <string name="ytdlp_installing">Installing yt-dlp…</string>
+  <string name="ytdlp_install_failed">Couldn\'t install yt-dlp. Check your connection and try again.</string>
   <string name="ui_yt_dlp_build_and_commit">Build %1$s • Commit %2$s</string>
   <string name="ui_yt_dlp_version">Version %1$s</string>
   <string name="ui_yt_dlp_commit">Commit %1$s</string>


### PR DESCRIPTION
Prompt before installing yt-dlp on first paste-link play

Previously yt-dlp installed silently in the background on first use,
leaving the player buffering with no explanation. Now, pasting a
yt-dlp-required link in Network Streaming and hitting Play shows a
dialog with Configure / Cancel / Install instead.

- Install: runs YtdlpManager.runInstall with a progress dialog,
  then plays the link on success
- Cancel: aborts, does not play
- Configure: opens YtdlpSettingsScreen

Exposes YtdlpManager.isInstalled (was private) for the pre-check."