### PR TITLE
Add automatic black bar cropping

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/domain/autocrop/AutoCropAnalyzer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/autocrop/AutoCropAnalyzer.kt
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.domain.autocrop
+
+import android.graphics.Bitmap
+import kotlin.math.max
+
+/** Edge widths expressed as fractions of the decoded frame size. */
+data class AutoCropEdges(
+  val left: Float,
+  val top: Float,
+  val right: Float,
+  val bottom: Float,
+)
+
+/**
+ * Detects encoded black bars without depending on the active playback core.
+ *
+ * The detector intentionally favours false negatives over false positives: a dark scene may leave
+ * a bar behind, but it must never be allowed to crop real picture content.
+ */
+object AutoCropAnalyzer {
+  private const val DARK_LUMA = 28
+  private const val CONTENT_LUMA = 42
+  private const val DARK_PIXEL_RATIO = 0.965f
+  private const val MIN_CONTENT_PIXEL_RATIO = 0.035f
+  private const val MAX_EDGE_FRACTION = 0.32f
+  private const val MIN_EDGE_FRACTION = 0.008f
+  private const val BOUNDARY_OVERLAP_PIXELS = 1
+
+  fun analyzeFrame(bitmap: Bitmap): AutoCropEdges? {
+    val width = bitmap.width
+    val height = bitmap.height
+    if (width < 32 || height < 32) return null
+
+    val pixels = IntArray(width * height)
+    bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+    if (!hasVisibleContent(pixels, width, height)) return null
+
+    val horizontalInset = max(1, (width * 0.05f).toInt())
+    val verticalInset = max(1, (height * 0.05f).toInt())
+    val top = scanHorizontalEdge(pixels, width, height, horizontalInset, fromStart = true)
+    val bottom = scanHorizontalEdge(pixels, width, height, horizontalInset, fromStart = false)
+    val left = scanVerticalEdge(pixels, width, height, verticalInset, fromStart = true)
+    val right = scanVerticalEdge(pixels, width, height, verticalInset, fromStart = false)
+
+    return AutoCropEdges(
+      left = normalizeEdge(left, width),
+      top = normalizeEdge(top, height),
+      right = normalizeEdge(right, width),
+      bottom = normalizeEdge(bottom, height),
+    )
+  }
+
+  /** Combines several samples while tolerating at most one noisy/outlier frame per edge. */
+  fun combine(samples: List<AutoCropEdges>): AutoCropEdges? {
+    if (samples.size < 3) return null
+
+    fun conservative(values: List<Float>): Float {
+      val sorted = values.sorted()
+      val candidate = if (sorted.size >= 5) sorted[1] else sorted.first()
+      return candidate.takeIf { it >= MIN_EDGE_FRACTION } ?: 0f
+    }
+
+    val result =
+      AutoCropEdges(
+        left = conservative(samples.map(AutoCropEdges::left)),
+        top = conservative(samples.map(AutoCropEdges::top)),
+        right = conservative(samples.map(AutoCropEdges::right)),
+        bottom = conservative(samples.map(AutoCropEdges::bottom)),
+      )
+
+    if (result.left + result.right > MAX_EDGE_FRACTION) return null
+    if (result.top + result.bottom > MAX_EDGE_FRACTION) return null
+    return result.takeIf { it.left > 0f || it.top > 0f || it.right > 0f || it.bottom > 0f }
+  }
+
+  private fun hasVisibleContent(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+  ): Boolean {
+    val left = width / 4
+    val right = width - left
+    val top = height / 4
+    val bottom = height - top
+    val step = 2
+    var sampled = 0
+    var visible = 0
+    for (y in top until bottom step step) {
+      val row = y * width
+      for (x in left until right step step) {
+        sampled++
+        if (luma(pixels[row + x]) > CONTENT_LUMA) visible++
+      }
+    }
+    return sampled > 0 && visible.toFloat() / sampled >= MIN_CONTENT_PIXEL_RATIO
+  }
+
+  private fun scanHorizontalEdge(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    inset: Int,
+    fromStart: Boolean,
+  ): Int {
+    val limit = (height * MAX_EDGE_FRACTION).toInt().coerceAtLeast(1)
+    var accepted = 0
+    var misses = 0
+    for (distance in 0 until limit) {
+      val y = if (fromStart) distance else height - 1 - distance
+      if (isDarkRow(pixels, width, y, inset)) {
+        accepted = distance + 1
+        misses = 0
+      } else if (++misses >= 2) {
+        break
+      }
+    }
+    return accepted
+  }
+
+  private fun scanVerticalEdge(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    inset: Int,
+    fromStart: Boolean,
+  ): Int {
+    val limit = (width * MAX_EDGE_FRACTION).toInt().coerceAtLeast(1)
+    var accepted = 0
+    var misses = 0
+    for (distance in 0 until limit) {
+      val x = if (fromStart) distance else width - 1 - distance
+      if (isDarkColumn(pixels, width, height, x, inset)) {
+        accepted = distance + 1
+        misses = 0
+      } else if (++misses >= 2) {
+        break
+      }
+    }
+    return accepted
+  }
+
+  private fun isDarkRow(
+    pixels: IntArray,
+    width: Int,
+    y: Int,
+    inset: Int,
+  ): Boolean {
+    val start = inset
+    val end = width - inset
+    var dark = 0
+    for (x in start until end) {
+      if (luma(pixels[y * width + x]) <= DARK_LUMA) dark++
+    }
+    return dark.toFloat() / (end - start).coerceAtLeast(1) >= DARK_PIXEL_RATIO
+  }
+
+  private fun isDarkColumn(
+    pixels: IntArray,
+    width: Int,
+    height: Int,
+    x: Int,
+    inset: Int,
+  ): Boolean {
+    val start = inset
+    val end = height - inset
+    var dark = 0
+    for (y in start until end) {
+      if (luma(pixels[y * width + x]) <= DARK_LUMA) dark++
+    }
+    return dark.toFloat() / (end - start).coerceAtLeast(1) >= DARK_PIXEL_RATIO
+  }
+
+  private fun normalizeEdge(
+    pixels: Int,
+    dimension: Int,
+  ): Float {
+    if (pixels <= 0) return 0f
+    // Scaling blends the last black row with the first picture row. Include one analysis pixel so
+    // the reconstructed source crop does not leave a thin black seam behind.
+    val fraction = (pixels + BOUNDARY_OVERLAP_PIXELS).toFloat() / dimension
+    return fraction.takeIf { it >= MIN_EDGE_FRACTION } ?: 0f
+  }
+
+  private fun luma(color: Int): Int {
+    val red = color shr 16 and 0xff
+    val green = color shr 8 and 0xff
+    val blue = color and 0xff
+    return (red * 54 + green * 183 + blue * 19) shr 8
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/domain/autocrop/AutoCropAnalyzer.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/domain/autocrop/AutoCropAnalyzer.kt
@@ -59,13 +59,18 @@ object AutoCropAnalyzer {
     )
   }
 
-  /** Combines several samples while tolerating at most one noisy/outlier frame per edge. */
+  /**
+   * Combines several samples conservatively.
+   *
+   * A zero edge in any sample wins for that edge. This intentionally treats an expanded IMAX or
+   * other variable-aspect-ratio frame as real picture instead of an outlier, so a static crop does
+   * not override an expanded frame present in the sample set.
+   */
   fun combine(samples: List<AutoCropEdges>): AutoCropEdges? {
     if (samples.size < 3) return null
 
     fun conservative(values: List<Float>): Float {
-      val sorted = values.sorted()
-      val candidate = if (sorted.size >= 5) sorted[1] else sorted.first()
+      val candidate = values.minOrNull() ?: 0f
       return candidate.takeIf { it >= MIN_EDGE_FRACTION } ?: 0f
     }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/MpvConfigOverride.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/MpvConfigOverride.kt
@@ -279,6 +279,8 @@ object MpvConfigControlledFeatures {
 
   val VIDEO_ASPECT = setOf("video-aspect-override", "panscan")
 
+  val AUTO_CROP = setOf("video-crop")
+
   val HARDWARE_DECODER = setOf("hwdec", "gpu-api", "gpu-context")
 }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/PlayerPreferences.kt
@@ -62,6 +62,7 @@ class PlayerPreferences(
   val customAspectRatios = preferenceStore.getStringSet("custom_aspect_ratios", emptySet())
   val lastVideoAspect = preferenceStore.getEnum("last_video_aspect", VideoAspect.Fit)
   val lastCustomAspectRatio = preferenceStore.getFloat("last_custom_aspect_ratio", -1f)
+  val autoCropBlackBars = preferenceStore.getBoolean("auto_crop_black_bars", false)
 
   val defaultSpeed = preferenceStore.getFloat("default_speed", 1f)
   val speedPresets =

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -493,12 +493,13 @@ class PlayerViewModel : ViewModel(),
   private val metadataCache = object : android.util.LruCache<String, Pair<String, String>>(100) {}
   private val playbackStateDispatcher = Dispatchers.Default.limitedParallelism(1)
   private val renderPrepDispatcher = Dispatchers.Default.limitedParallelism(1)
-  private val ambientCropRegex = Regex("""^(\d+)x(\d+)""")
+  private val videoCropDimensionsRegex = Regex("""^(\d+)x(\d+)""")
   private var autoCropJob: Job? = null
   private var autoCropReadinessJob: Job? = null
   private var autoCropAnalyzedGeneration = -1L
   private var autoCropApplied = false
-  private val autoCropResultCache = LruCache<String, AutoCropEdges>(20)
+  // Memory-only analysis cache. This is not playback history and does not enable auto-crop.
+  private val autoCropResultCache = LruCache<String, AutoCropEdges>(AUTO_CROP_CACHE_CAPACITY)
   private val _autoCropState = MutableStateFlow(AutoCropState.IDLE)
   val autoCropState: StateFlow<AutoCropState> = _autoCropState.asStateFlow()
 
@@ -2426,6 +2427,7 @@ class PlayerViewModel : ViewModel(),
     const val AUTO_CROP_MIN_VALID_SAMPLES = 3
     const val AUTO_CROP_THUMBNAIL_SIZE = 640
     const val AUTO_CROP_READY_TIMEOUT_MS = 15_000L
+    const val AUTO_CROP_CACHE_CAPACITY = 20
     const val AUTO_SHOW_SKIP_CHIP_DURATION = 10.0
     const val SEEK_COALESCE_DELAY_MS = 60L
     const val PREVIEW_SEEK_INTERVAL_MS = 25L
@@ -6010,19 +6012,9 @@ class PlayerViewModel : ViewModel(),
       // Landscape mode: ambient glow goes on left/right (pillarbox)
       // Both are handled by the same scaleX/scaleY math below
 
-      var vidW = (PlaybackSession.getPropertyInt("video-params/w") ?: 1920).toDouble()
-      var vidH = (PlaybackSession.getPropertyInt("video-params/h") ?: 1080).toDouble()
+      var (vidW, vidH) = currentEffectiveVideoDimensions()
       val par = PlaybackSession.getPropertyDouble("video-params/par") ?: 1.0
       val rot = PlaybackSession.getPropertyInt("video-params/rotate") ?: 0
-
-      // Intercept autocrop boundaries — if a crop is active, use the cropped dimensions
-      // so the shader's aspect-ratio math matches the actual visible video area
-      val crop = PlaybackSession.getPropertyString("video-crop") ?: ""
-      val cropMatch = ambientCropRegex.find(crop)
-      if (cropMatch != null) {
-        vidW = cropMatch.groupValues[1].toDouble()
-        vidH = cropMatch.groupValues[2].toDouble()
-      }
 
       if (osdW <= 0 || osdH <= 0 || vidW <= 0.0 || vidH <= 0.0) return
 
@@ -6130,6 +6122,22 @@ class PlayerViewModel : ViewModel(),
       if (e is kotlinx.coroutines.CancellationException) throw e
       Log.e(TAG, "Failed to update ambient stretch", e)
     }
+  }
+
+  /**
+   * Returns the dimensions mpv is actually displaying.
+   *
+   * `video-crop` is the single source of truth shared by normal playback and Ambient Glow. The
+   * auto-crop analyzer only writes that property; Ambient never keeps a second crop state.
+   */
+  private fun currentEffectiveVideoDimensions(): Pair<Double, Double> {
+    val sourceWidth = (PlaybackSession.getPropertyInt("video-params/w") ?: 1920).toDouble()
+    val sourceHeight = (PlaybackSession.getPropertyInt("video-params/h") ?: 1080).toDouble()
+    val cropMatch =
+      PlaybackSession.getPropertyString("video-crop")
+        ?.let(videoCropDimensionsRegex::find)
+        ?: return sourceWidth to sourceHeight
+    return cropMatch.groupValues[1].toDouble() to cropMatch.groupValues[2].toDouble()
   }
 
   /**

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -493,7 +493,6 @@ class PlayerViewModel : ViewModel(),
   private val metadataCache = object : android.util.LruCache<String, Pair<String, String>>(100) {}
   private val playbackStateDispatcher = Dispatchers.Default.limitedParallelism(1)
   private val renderPrepDispatcher = Dispatchers.Default.limitedParallelism(1)
-  private val videoCropDimensionsRegex = Regex("""^(\d+)x(\d+)""")
   private var autoCropJob: Job? = null
   private var autoCropReadinessJob: Job? = null
   private var autoCropAnalyzedGeneration = -1L
@@ -4365,7 +4364,10 @@ class PlayerViewModel : ViewModel(),
 
         // Set aspect override first, then reset panscan
         // This prevents the brief flash of Fit mode
-        PlaybackSession.setPropertyDouble("video-aspect-override", screenRatio)
+        PlaybackSession.setPropertyDouble(
+          "video-aspect-override",
+          VideoAspectGeometry.stretchAspectOverride(screenRatio),
+        )
         PlaybackSession.setPropertyDouble("panscan", 0.0)
       }
     }
@@ -4529,6 +4531,7 @@ class PlayerViewModel : ViewModel(),
 
           autoCropResultCache.put(cacheKey, sourceEdges)
           PlaybackSession.setPropertyString("video-crop", cropValue)
+          refreshStretchAspectAfterCropChange()
           Log.i(TAG, "Auto-crop applied generation=$generation crop=$cropValue edges=$sourceEdges")
           autoCropApplied = true
           _autoCropState.value = AutoCropState.APPLIED
@@ -4661,6 +4664,13 @@ class PlayerViewModel : ViewModel(),
   private fun clearAutoCropProperty() {
     PlaybackSession.setPropertyString("video-crop", "")
     autoCropApplied = false
+    refreshStretchAspectAfterCropChange()
+  }
+
+  private fun refreshStretchAspectAfterCropChange() {
+    if (playerPreferences.lastCustomAspectRatio.get() > 0f) return
+    if (playerPreferences.lastVideoAspect.get() != VideoAspect.Stretch) return
+    changeVideoAspect(VideoAspect.Stretch, showUpdate = false)
   }
 
   // ==================== Screen Rotation ====================
@@ -6012,7 +6022,7 @@ class PlayerViewModel : ViewModel(),
       // Landscape mode: ambient glow goes on left/right (pillarbox)
       // Both are handled by the same scaleX/scaleY math below
 
-      var (vidW, vidH) = currentEffectiveVideoDimensions()
+      var (vidW, vidH) = VideoAspectGeometry.currentEffectiveDimensions()
       val par = PlaybackSession.getPropertyDouble("video-params/par") ?: 1.0
       val rot = PlaybackSession.getPropertyInt("video-params/rotate") ?: 0
 
@@ -6122,22 +6132,6 @@ class PlayerViewModel : ViewModel(),
       if (e is kotlinx.coroutines.CancellationException) throw e
       Log.e(TAG, "Failed to update ambient stretch", e)
     }
-  }
-
-  /**
-   * Returns the dimensions mpv is actually displaying.
-   *
-   * `video-crop` is the single source of truth shared by normal playback and Ambient Glow. The
-   * auto-crop analyzer only writes that property; Ambient never keeps a second crop state.
-   */
-  private fun currentEffectiveVideoDimensions(): Pair<Double, Double> {
-    val sourceWidth = (PlaybackSession.getPropertyInt("video-params/w") ?: 1920).toDouble()
-    val sourceHeight = (PlaybackSession.getPropertyInt("video-params/h") ?: 1080).toDouble()
-    val cropMatch =
-      PlaybackSession.getPropertyString("video-crop")
-        ?.let(videoCropDimensionsRegex::find)
-        ?: return sourceWidth to sourceHeight
-    return cropMatch.groupValues[1].toDouble() to cropMatch.groupValues[2].toDouble()
   }
 
   /**

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -14,9 +14,12 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
 import android.media.AudioManager
 import android.net.Uri
 import android.os.BatteryManager
+import android.os.Build
 import android.os.SystemClock
 import `is`.xyz.mpv.MPVNode
 import android.provider.OpenableColumns
@@ -35,6 +38,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.gyrolet.mpvrx.R
 import app.gyrolet.mpvrx.domain.anime4k.Anime4KManager
+import app.gyrolet.mpvrx.domain.autocrop.AutoCropAnalyzer
+import app.gyrolet.mpvrx.domain.autocrop.AutoCropEdges
 import app.gyrolet.mpvrx.domain.hdr.HdrToysManager
 import app.gyrolet.mpvrx.domain.network.NetworkPlaybackUri
 import app.gyrolet.mpvrx.domain.torrent.TorrentStreamingState
@@ -104,6 +109,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -126,7 +132,17 @@ import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.properties.ReadOnlyProperty
+import kotlin.random.Random
 import kotlin.reflect.KProperty
+
+enum class AutoCropState {
+  IDLE,
+  ANALYZING,
+  APPLIED,
+  NO_BARS,
+  UNSUPPORTED,
+  ERROR,
+}
 
 @Suppress("TooManyFunctions")
 class PlayerViewModel : ViewModel(),
@@ -478,6 +494,18 @@ class PlayerViewModel : ViewModel(),
   private val playbackStateDispatcher = Dispatchers.Default.limitedParallelism(1)
   private val renderPrepDispatcher = Dispatchers.Default.limitedParallelism(1)
   private val ambientCropRegex = Regex("""^(\d+)x(\d+)""")
+  private var autoCropJob: Job? = null
+  private var autoCropReadinessJob: Job? = null
+  private var autoCropAnalyzedGeneration = -1L
+  private var autoCropApplied = false
+  private val autoCropResultCache = LruCache<String, AutoCropEdges>(20)
+  private val _autoCropState = MutableStateFlow(AutoCropState.IDLE)
+  val autoCropState: StateFlow<AutoCropState> = _autoCropState.asStateFlow()
+
+  private data class AutoCropSamples(
+    val edges: List<AutoCropEdges>,
+    val framesWereRotated: Boolean,
+  )
 
   private fun updateMetadataCache(
     key: String,
@@ -1932,6 +1960,15 @@ class PlayerViewModel : ViewModel(),
 
   fun onVideoLoadStarted() {
     introLookupJob?.cancel()
+    autoCropJob?.cancel()
+    autoCropJob = null
+    autoCropReadinessJob?.cancel()
+    autoCropReadinessJob = null
+    autoCropAnalyzedGeneration = -1L
+    if (autoCropApplied || playerPreferences.autoCropBlackBars.get()) {
+      clearAutoCropProperty()
+    }
+    _autoCropState.value = AutoCropState.IDLE
     // PlaybackSession is process-wide, while this ViewModel can be recreated. Clear both halves of
     // the timeline so a stopped file's last position cannot be rendered beside the incoming file's
     // reset 00:00 duration while mpv is still opening it.
@@ -1966,6 +2003,7 @@ class PlayerViewModel : ViewModel(),
     syncplayManager.updateFileInfo(currentSyncplayFileInfo())
     applyEqualizerMpvFilters()
     loadLyricsForCurrentTrack(forceRefresh = true)
+    scheduleAutoCropAnalysis()
   }
 
   fun updateTorrentState(state: TorrentStreamingState) {
@@ -2384,6 +2422,10 @@ class PlayerViewModel : ViewModel(),
 
   private companion object {
     const val TAG = "PlayerViewModel"
+    const val AUTO_CROP_SAMPLE_COUNT = 7
+    const val AUTO_CROP_MIN_VALID_SAMPLES = 3
+    const val AUTO_CROP_THUMBNAIL_SIZE = 640
+    const val AUTO_CROP_READY_TIMEOUT_MS = 15_000L
     const val AUTO_SHOW_SKIP_CHIP_DURATION = 10.0
     const val SEEK_COALESCE_DELAY_MS = 60L
     const val PREVIEW_SEEK_INTERVAL_MS = 25L
@@ -4360,6 +4402,263 @@ class PlayerViewModel : ViewModel(),
     }
 
     changeVideoAspect(playerPreferences.lastVideoAspect.get(), showUpdate)
+  }
+
+  fun setAutoCropBlackBars(enabled: Boolean) {
+    playerPreferences.autoCropBlackBars.set(enabled)
+    autoCropJob?.cancel()
+    autoCropJob = null
+    autoCropReadinessJob?.cancel()
+    autoCropReadinessJob = null
+    autoCropAnalyzedGeneration = -1L
+    if (!enabled) {
+      clearAutoCropProperty()
+      _autoCropState.value = AutoCropState.IDLE
+      restartAmbientIfActive()
+      return
+    }
+    if (MpvConfigOverridePolicy.ownsAny(MpvConfigControlledFeatures.AUTO_CROP)) {
+      _autoCropState.value = AutoCropState.UNSUPPORTED
+      return
+    }
+    clearAutoCropProperty()
+    scheduleAutoCropAnalysis(force = true)
+  }
+
+  private fun scheduleAutoCropAnalysis(force: Boolean = false) {
+    if (!playerPreferences.autoCropBlackBars.get()) return
+    if (MpvConfigOverridePolicy.ownsAny(MpvConfigControlledFeatures.AUTO_CROP)) {
+      _autoCropState.value = AutoCropState.UNSUPPORTED
+      return
+    }
+
+    val session = PlaybackSession.state.value
+    if (session.phase !in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) {
+      if (session.phase == PlaybackPhase.LOADING && autoCropReadinessJob?.isActive != true) {
+        val expectedGeneration = session.generation
+        _autoCropState.value = AutoCropState.ANALYZING
+        autoCropReadinessJob =
+          viewModelScope.launch {
+            val readyState =
+              withTimeoutOrNull(AUTO_CROP_READY_TIMEOUT_MS) {
+                PlaybackSession.state.first { state ->
+                  state.generation != expectedGeneration ||
+                    state.phase in
+                    setOf(
+                      PlaybackPhase.READY,
+                      PlaybackPhase.BACKGROUND,
+                      PlaybackPhase.ERROR,
+                      PlaybackPhase.IDLE,
+                    )
+                }
+              }
+            autoCropReadinessJob = null
+            if (
+              readyState?.generation == expectedGeneration &&
+              readyState.phase in setOf(PlaybackPhase.READY, PlaybackPhase.BACKGROUND)
+            ) {
+              scheduleAutoCropAnalysis(force)
+            } else if (PlaybackSession.isCurrentGeneration(expectedGeneration)) {
+              _autoCropState.value = AutoCropState.ERROR
+            }
+          }
+      }
+      return
+    }
+    val generation = session.generation
+    if (!force && autoCropAnalyzedGeneration == generation) return
+    val source = runCatching { host.currentThumbnailSource() }.getOrNull()?.takeIf(String::isNotBlank)
+    val durationSeconds = PlaybackSession.getPropertyDouble("duration") ?: preciseDuration.value.toDouble()
+    val sourceWidth = PlaybackSession.getPropertyInt("video-params/w") ?: 0
+    val sourceHeight = PlaybackSession.getPropertyInt("video-params/h") ?: 0
+    val rotation = (PlaybackSession.getPropertyInt("video-params/rotate") ?: 0).mod(360)
+    if (source == null || durationSeconds <= 0.0 || sourceWidth <= 0 || sourceHeight <= 0) {
+      autoCropAnalyzedGeneration = generation
+      _autoCropState.value = AutoCropState.UNSUPPORTED
+      return
+    }
+
+    autoCropAnalyzedGeneration = generation
+    autoCropJob?.cancel()
+    _autoCropState.value = AutoCropState.ANALYZING
+    val cacheKey = "$source|$sourceWidth|$sourceHeight|${durationSeconds.toLong()}"
+    autoCropJob =
+      viewModelScope.launch(Dispatchers.IO) {
+        Log.i(TAG, "Auto-crop analyzing generation=$generation source=$source")
+        val combined =
+          autoCropResultCache.get(cacheKey)?.let { cached ->
+            AutoCropSamples(listOf(cached, cached, cached), framesWereRotated = false)
+          } ?: run {
+            val positions = autoCropSamplePositions(source, durationSeconds)
+            extractAutoCropSamples(source, positions)
+          }
+        val detected = combined?.let { AutoCropAnalyzer.combine(it.edges) }
+
+        withContext(Dispatchers.Main) {
+          if (!PlaybackSession.isCurrentGeneration(generation) || !playerPreferences.autoCropBlackBars.get()) {
+            return@withContext
+          }
+          if (combined == null) {
+            Log.w(TAG, "Auto-crop could not decode enough frames for generation=$generation")
+            clearAutoCropProperty()
+            _autoCropState.value = AutoCropState.ERROR
+            return@withContext
+          }
+          if (detected == null) {
+            Log.i(TAG, "Auto-crop found no persistent black bars for generation=$generation")
+            clearAutoCropProperty()
+            _autoCropState.value = AutoCropState.NO_BARS
+            return@withContext
+          }
+
+          val sourceEdges =
+            if (combined.framesWereRotated) {
+              mapRotatedEdgesToSource(detected, rotation)
+            } else {
+              detected
+            }
+          val cropValue = buildAutoCropValue(sourceEdges, sourceWidth, sourceHeight)
+          if (cropValue == null) {
+            Log.i(TAG, "Auto-crop result was too small or unsafe for generation=$generation edges=$sourceEdges")
+            clearAutoCropProperty()
+            _autoCropState.value = AutoCropState.NO_BARS
+            return@withContext
+          }
+
+          autoCropResultCache.put(cacheKey, sourceEdges)
+          PlaybackSession.setPropertyString("video-crop", cropValue)
+          Log.i(TAG, "Auto-crop applied generation=$generation crop=$cropValue edges=$sourceEdges")
+          autoCropApplied = true
+          _autoCropState.value = AutoCropState.APPLIED
+          restartAmbientIfActive()
+        }
+      }
+  }
+
+  private fun autoCropSamplePositions(
+    source: String,
+    durationSeconds: Double,
+  ): List<Double> {
+    val random = Random(source.hashCode())
+    val start = durationSeconds * 0.05
+    val span = durationSeconds * 0.90
+    val segment = span / AUTO_CROP_SAMPLE_COUNT
+    return List(AUTO_CROP_SAMPLE_COUNT) { index ->
+      start + segment * (index + random.nextDouble(0.2, 0.8))
+    }
+  }
+
+  private suspend fun extractAutoCropSamples(
+    source: String,
+    positionsSeconds: List<Double>,
+  ): AutoCropSamples? {
+    if (isAndroidReadableMediaSource(source)) {
+      extractAutoCropWithRetriever(source, positionsSeconds)?.let { samples ->
+        if (samples.size >= AUTO_CROP_MIN_VALID_SAMPLES) {
+          return AutoCropSamples(samples, framesWereRotated = false)
+        }
+      }
+    }
+
+    val samples =
+      positionsSeconds.mapNotNull { position ->
+        currentCoroutineContext().ensureActive()
+        val bitmap = PlaybackSession.grabThumbnailFast(source, position, AUTO_CROP_THUMBNAIL_SIZE, true)
+        bitmap?.analyzeAndRecycle()
+      }
+    return samples.takeIf { it.size >= AUTO_CROP_MIN_VALID_SAMPLES }?.let {
+      AutoCropSamples(it, framesWereRotated = true)
+    }
+  }
+
+  private suspend fun extractAutoCropWithRetriever(
+    source: String,
+    positionsSeconds: List<Double>,
+  ): List<AutoCropEdges>? =
+    runCatching {
+      val retriever = MediaMetadataRetriever()
+      try {
+        val uri = Uri.parse(source)
+        when (uri.scheme?.lowercase()) {
+          null, "" -> retriever.setDataSource(source)
+          "file" -> retriever.setDataSource(uri.path ?: source)
+          "content", "android.resource" -> retriever.setDataSource(appContext, uri)
+          else -> return@runCatching null
+        }
+        val sourceWidth =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull()
+            ?: AUTO_CROP_THUMBNAIL_SIZE
+        val sourceHeight =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull()
+            ?: AUTO_CROP_THUMBNAIL_SIZE
+        val scale = AUTO_CROP_THUMBNAIL_SIZE.toDouble() / maxOf(sourceWidth, sourceHeight).coerceAtLeast(1)
+        val targetWidth = (sourceWidth * scale).roundToInt().coerceAtLeast(2)
+        val targetHeight = (sourceHeight * scale).roundToInt().coerceAtLeast(2)
+        positionsSeconds.mapNotNull { position ->
+          currentCoroutineContext().ensureActive()
+          val timeUs = (position * 1_000_000.0).toLong()
+          val bitmap =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+              retriever.getScaledFrameAtTime(
+                timeUs,
+                MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+                targetWidth,
+                targetHeight,
+              )
+            } else {
+              retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+            }
+          bitmap?.analyzeAndRecycle()
+        }
+      } finally {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) retriever.close() else retriever.release()
+      }
+    }.getOrNull()
+
+  private fun Bitmap.analyzeAndRecycle(): AutoCropEdges? =
+    try {
+      AutoCropAnalyzer.analyzeFrame(this)
+    } finally {
+      recycle()
+    }
+
+  private fun isAndroidReadableMediaSource(source: String): Boolean {
+    val scheme = Uri.parse(source).scheme?.lowercase()
+    return scheme.isNullOrBlank() || scheme in setOf("file", "content", "android.resource")
+  }
+
+  private fun mapRotatedEdgesToSource(
+    edges: AutoCropEdges,
+    rotation: Int,
+  ): AutoCropEdges =
+    when (rotation) {
+      90 -> AutoCropEdges(left = edges.top, top = edges.right, right = edges.bottom, bottom = edges.left)
+      180 -> AutoCropEdges(left = edges.right, top = edges.bottom, right = edges.left, bottom = edges.top)
+      270 -> AutoCropEdges(left = edges.bottom, top = edges.left, right = edges.top, bottom = edges.right)
+      else -> edges
+    }
+
+  private fun buildAutoCropValue(
+    edges: AutoCropEdges,
+    sourceWidth: Int,
+    sourceHeight: Int,
+  ): String? {
+    fun evenFloor(value: Float): Int = (value.toInt().coerceAtLeast(0) / 2) * 2
+
+    val left = evenFloor(edges.left * sourceWidth)
+    val top = evenFloor(edges.top * sourceHeight)
+    val right = evenFloor(edges.right * sourceWidth)
+    val bottom = evenFloor(edges.bottom * sourceHeight)
+    val width = evenFloor((sourceWidth - left - right).toFloat())
+    val height = evenFloor((sourceHeight - top - bottom).toFloat())
+    if (width < sourceWidth / 2 || height < sourceHeight / 2) return null
+    if (sourceWidth - width < 4 && sourceHeight - height < 4) return null
+    return "${width}x$height+$left+$top"
+  }
+
+  private fun clearAutoCropProperty() {
+    PlaybackSession.setPropertyString("video-crop", "")
+    autoCropApplied = false
   }
 
   // ==================== Screen Rotation ====================

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/StretchAwarePlayerLayout.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/StretchAwarePlayerLayout.kt
@@ -51,7 +51,10 @@ class StretchAwarePlayerLayout @JvmOverloads constructor(
           w.toDouble() / h.toDouble()
         }
 
-      PlaybackSession.setPropertyDouble("video-aspect-override", viewportRatio)
+      PlaybackSession.setPropertyDouble(
+        "video-aspect-override",
+        VideoAspectGeometry.stretchAspectOverride(viewportRatio),
+      )
       PlaybackSession.setPropertyDouble("panscan", 0.0)
     }
   }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/VideoAspectGeometry.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/VideoAspectGeometry.kt
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package app.gyrolet.mpvrx.ui.player
+
+internal data class VideoDimensions(
+  val width: Double,
+  val height: Double,
+)
+
+/** Geometry shared by playback aspect modes and Ambient Glow. */
+internal object VideoAspectGeometry {
+  private val cropDimensionsRegex = Regex("""^(\d+)x(\d+)""")
+
+  fun currentEffectiveDimensions(
+    fallbackWidth: Double = 1920.0,
+    fallbackHeight: Double = 1080.0,
+  ): VideoDimensions {
+    val source = currentSourceDimensions() ?: VideoDimensions(fallbackWidth, fallbackHeight)
+    return currentCropDimensions() ?: source
+  }
+
+  /**
+   * Converts a desired post-crop display ratio to mpv's full-source aspect override.
+   *
+   * mpv applies `video-crop` to the source rectangle before anamorphic/aspect stretching. Therefore
+   * passing the viewport ratio directly makes a cropped image too wide or too tall. Compensating
+   * for the crop keeps the final visible rectangle at the requested viewport ratio.
+   */
+  fun stretchAspectOverride(viewportRatio: Double): Double {
+    if (!viewportRatio.isFinite() || viewportRatio <= 0.0) return viewportRatio
+    val source = currentSourceDimensions() ?: return viewportRatio
+    val crop = currentCropDimensions() ?: return viewportRatio
+    val widthFraction = crop.width / source.width
+    val heightFraction = crop.height / source.height
+    if (widthFraction <= 0.0 || heightFraction <= 0.0) return viewportRatio
+    return viewportRatio * heightFraction / widthFraction
+  }
+
+  private fun currentSourceDimensions(): VideoDimensions? {
+    val width = (PlaybackSession.getPropertyInt("video-params/w") ?: 0).toDouble()
+    val height = (PlaybackSession.getPropertyInt("video-params/h") ?: 0).toDouble()
+    return VideoDimensions(width, height).takeIf { it.width > 0.0 && it.height > 0.0 }
+  }
+
+  private fun currentCropDimensions(): VideoDimensions? {
+    val match =
+      PlaybackSession.getPropertyString("video-crop")
+        ?.let(cropDimensionsRegex::find)
+        ?: return null
+    val width = match.groupValues[1].toDoubleOrNull() ?: return null
+    val height = match.groupValues[2].toDoubleOrNull() ?: return null
+    return VideoDimensions(width, height).takeIf { it.width > 0.0 && it.height > 0.0 }
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerSheets.kt
@@ -423,7 +423,9 @@ fun PlayerSheets(
     Sheets.AspectRatios -> {
       val playerPreferences = koinInject<app.gyrolet.mpvrx.preferences.PlayerPreferences>()
       val customRatiosSet by playerPreferences.customAspectRatios.collectAsState()
+      val autoCropEnabled by playerPreferences.autoCropBlackBars.collectAsState()
       val currentRatio by viewModel.currentAspectRatio.composeCollectAsState()
+      val autoCropState by viewModel.autoCropState.composeCollectAsState()
       val customRatios =
         customRatiosSet.mapNotNull { str ->
           val parts = str.split("|")
@@ -441,6 +443,10 @@ fun PlayerSheets(
       AspectRatioSheet(
         currentRatio = currentRatio,
         customRatios = customRatios,
+        autoCropEnabled = autoCropEnabled,
+        autoCropState = autoCropState,
+        autoCropControlEnabled = MpvConfigControlledFeatures.AUTO_CROP.none(configOwnedOptions::contains),
+        onAutoCropChanged = viewModel::setAutoCropBlackBars,
         onSelectRatio = { ratio ->
           if (ratio < 0) {
             // Default selected - apply Fit mode

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/AspectRatioSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/components/sheets/AspectRatioSheet.kt
@@ -24,8 +24,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,6 +42,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.gyrolet.mpvrx.presentation.components.PlayerSheet
+import app.gyrolet.mpvrx.ui.player.AutoCropState
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
 import app.gyrolet.mpvrx.ui.theme.spacing
@@ -54,6 +57,10 @@ data class AspectRatio(
 fun AspectRatioSheet(
   currentRatio: Double?,
   customRatios: List<AspectRatio>,
+  autoCropEnabled: Boolean,
+  autoCropState: AutoCropState,
+  autoCropControlEnabled: Boolean,
+  onAutoCropChanged: (Boolean) -> Unit,
   onSelectRatio: (Double) -> Unit,
   onAddCustomRatio: (String, Double) -> Unit,
   onDeleteCustomRatio: (AspectRatio) -> Unit,
@@ -89,6 +96,35 @@ fun AspectRatioSheet(
           Modifier
             .padding(horizontal = MaterialTheme.spacing.medium)
             .padding(bottom = MaterialTheme.spacing.small),
+      )
+
+      val autoCropSummary =
+        when {
+          !autoCropControlEnabled -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_managed
+          !autoCropEnabled -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_summary
+          autoCropState == AutoCropState.ANALYZING -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_analyzing
+          autoCropState == AutoCropState.APPLIED -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_applied
+          autoCropState == AutoCropState.NO_BARS -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_none
+          autoCropState == AutoCropState.UNSUPPORTED -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_unsupported
+          autoCropState == AutoCropState.ERROR -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_failed
+          else -> app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars_summary
+        }
+      ListItem(
+        headlineContent = {
+          Text(androidx.compose.ui.res.stringResource(app.gyrolet.mpvrx.R.string.ui_auto_crop_black_bars))
+        },
+        supportingContent = { Text(androidx.compose.ui.res.stringResource(autoCropSummary)) },
+        trailingContent = {
+          Switch(
+            checked = autoCropEnabled,
+            onCheckedChange = onAutoCropChanged,
+            enabled = autoCropControlEnabled,
+          )
+        },
+        modifier =
+          Modifier.clickable(enabled = autoCropControlEnabled) {
+            onAutoCropChanged(!autoCropEnabled)
+          },
       )
 
       // Preset ratios

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1313,6 +1313,14 @@
   <string name="ui_install_core">تثبيت النواة</string>
   <string name="ui_update_core">تحديث النواة</string>
   <string name="ui_aspect_ratio">نسبة العرض إلى الارتفاع</string>
+  <string name="ui_auto_crop_black_bars">قص الحواف السوداء تلقائيًا</string>
+  <string name="ui_auto_crop_black_bars_summary">أخذ عينات من عدة إطارات في الخلفية وقص الحواف السوداء الثابتة المضمّنة في الفيديو.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">جارٍ تحليل إطارات الفيديو…</string>
+  <string name="ui_auto_crop_black_bars_applied">تمت إزالة الحواف السوداء من هذا الفيديو.</string>
+  <string name="ui_auto_crop_black_bars_none">لم يتم اكتشاف حواف سوداء ثابتة.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">تعذّر تحليل مصدر الفيديو هذا.</string>
+  <string name="ui_auto_crop_black_bars_failed">فشل تحليل الحواف السوداء.</string>
+  <string name="ui_auto_crop_black_bars_managed">تتم إدارة video-crop بواسطة mpv.conf.</string>
   <string name="ui_presets">الإعدادات المسبقة</string>
   <string name="ui_add_custom_ratio_e_g_16_9">إضافة نسبة مخصّصة (مثل 16:9)</string>
   <string name="ui_width">العرض</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1313,6 +1313,14 @@ Bitte starten Sie die App neu, damit alle Änderungen wirksam werden.</string>
   <string name="ui_install_core">Core installieren</string>
   <string name="ui_update_core">Core aktualisieren</string>
   <string name="ui_aspect_ratio">Seitenverhältnis</string>
+  <string name="ui_auto_crop_black_bars">Schwarze Balken automatisch entfernen</string>
+  <string name="ui_auto_crop_black_bars_summary">Analysiert mehrere Einzelbilder im Hintergrund und entfernt dauerhaft eingebettete schwarze Balken.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">Videobilder werden analysiert…</string>
+  <string name="ui_auto_crop_black_bars_applied">Schwarze Balken wurden für dieses Video entfernt.</string>
+  <string name="ui_auto_crop_black_bars_none">Keine dauerhaften schwarzen Balken erkannt.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">Diese Videoquelle konnte nicht analysiert werden.</string>
+  <string name="ui_auto_crop_black_bars_failed">Analyse der schwarzen Balken fehlgeschlagen.</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop wird von mpv.conf verwaltet.</string>
   <string name="ui_presets">Voreinstellungen</string>
   <string name="ui_add_custom_ratio_e_g_16_9">Benutzerdefiniertes Verhältnis hinzufügen (z. B. 16:9)</string>
   <string name="ui_width">Breite</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1313,6 +1313,14 @@ Reinicia la aplicación para que se apliquen todos los cambios.</string>
   <string name="ui_install_core">Instalar núcleo</string>
   <string name="ui_update_core">Actualizar núcleo</string>
   <string name="ui_aspect_ratio">Relación de aspecto</string>
+  <string name="ui_auto_crop_black_bars">Recortar barras negras automáticamente</string>
+  <string name="ui_auto_crop_black_bars_summary">Analiza varios fotogramas en segundo plano y recorta las barras negras integradas que persisten.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">Analizando fotogramas…</string>
+  <string name="ui_auto_crop_black_bars_applied">Se eliminaron las barras negras de este vídeo.</string>
+  <string name="ui_auto_crop_black_bars_none">No se detectaron barras negras persistentes.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">No se pudo analizar esta fuente de vídeo.</string>
+  <string name="ui_auto_crop_black_bars_failed">Error al analizar las barras negras.</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop está gestionado por mpv.conf.</string>
   <string name="ui_presets">Preajustes</string>
   <string name="ui_add_custom_ratio_e_g_16_9">Añadir relación personalizada (p. ej., 16:9)</string>
   <string name="ui_width">Ancho</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1313,6 +1313,14 @@ Veuillez redémarrer l’application pour appliquer toutes les modifications.</s
   <string name="ui_install_core">Installer le noyau</string>
   <string name="ui_update_core">Mettre à jour le noyau</string>
   <string name="ui_aspect_ratio">Format d’image</string>
+  <string name="ui_auto_crop_black_bars">Rogner automatiquement les bandes noires</string>
+  <string name="ui_auto_crop_black_bars_summary">Analyse plusieurs images en arrière-plan et rogne les bandes noires intégrées persistantes.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">Analyse des images…</string>
+  <string name="ui_auto_crop_black_bars_applied">Bandes noires supprimées pour cette vidéo.</string>
+  <string name="ui_auto_crop_black_bars_none">Aucune bande noire persistante détectée.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">Impossible d’analyser cette source vidéo.</string>
+  <string name="ui_auto_crop_black_bars_failed">Échec de l’analyse des bandes noires.</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop est géré par mpv.conf.</string>
   <string name="ui_presets">Préréglages</string>
   <string name="ui_add_custom_ratio_e_g_16_9">Ajouter un format personnalisé (p. ex. 16:9)</string>
   <string name="ui_width">Largeur</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1249,6 +1249,14 @@
   <string name="ui_install_core">कोर इंस्टॉल करें</string>
   <string name="ui_update_core">कोर अपडेट करें</string>
   <string name="ui_aspect_ratio">आस्पेक्ट रेशियो</string>
+  <string name="ui_auto_crop_black_bars">काली पट्टियाँ अपने आप काटें</string>
+  <string name="ui_auto_crop_black_bars_summary">बैकग्राउंड में कई फ़्रेम का नमूना लेकर वीडियो में स्थायी रूप से जुड़ी काली पट्टियाँ काटता है।</string>
+  <string name="ui_auto_crop_black_bars_analyzing">वीडियो फ़्रेम का विश्लेषण हो रहा है…</string>
+  <string name="ui_auto_crop_black_bars_applied">इस वीडियो से काली पट्टियाँ हटा दी गई हैं।</string>
+  <string name="ui_auto_crop_black_bars_none">कोई स्थायी काली पट्टी नहीं मिली।</string>
+  <string name="ui_auto_crop_black_bars_unsupported">इस वीडियो स्रोत का विश्लेषण नहीं किया जा सका।</string>
+  <string name="ui_auto_crop_black_bars_failed">काली पट्टियों का विश्लेषण विफल रहा।</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop को mpv.conf द्वारा प्रबंधित किया जाता है।</string>
   <string name="ui_presets">प्रीसेट</string>
   <string name="ui_add_custom_ratio_e_g_16_9">कस्टम रेशियो जोड़ें (जैसे 16:9)</string>
   <string name="ui_width">चौड़ाई</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1313,6 +1313,14 @@
   <string name="ui_install_core">コアをインストール</string>
   <string name="ui_update_core">コアを更新</string>
   <string name="ui_aspect_ratio">アスペクト比</string>
+  <string name="ui_auto_crop_black_bars">黒帯を自動クロップ</string>
+  <string name="ui_auto_crop_black_bars_summary">バックグラウンドで複数のフレームを解析し、映像に常時含まれる黒帯をクロップします。</string>
+  <string name="ui_auto_crop_black_bars_analyzing">映像フレームを解析中…</string>
+  <string name="ui_auto_crop_black_bars_applied">この動画の黒帯を除去しました。</string>
+  <string name="ui_auto_crop_black_bars_none">常時表示される黒帯は検出されませんでした。</string>
+  <string name="ui_auto_crop_black_bars_unsupported">この動画ソースは解析できません。</string>
+  <string name="ui_auto_crop_black_bars_failed">黒帯の解析に失敗しました。</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop は mpv.conf で管理されています。</string>
   <string name="ui_presets">プリセット</string>
   <string name="ui_add_custom_ratio_e_g_16_9">カスタム比率を追加（例: 16:9）</string>
   <string name="ui_width">幅</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1313,6 +1313,14 @@ Reinicie o aplicativo para que todas as alterações entrem em vigor.</string>
   <string name="ui_install_core">Instalar núcleo</string>
   <string name="ui_update_core">Atualizar núcleo</string>
   <string name="ui_aspect_ratio">Proporção da tela</string>
+  <string name="ui_auto_crop_black_bars">Recortar barras pretas automaticamente</string>
+  <string name="ui_auto_crop_black_bars_summary">Analisa vários quadros em segundo plano e recorta barras pretas persistentes incorporadas ao vídeo.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">Analisando quadros do vídeo…</string>
+  <string name="ui_auto_crop_black_bars_applied">As barras pretas foram removidas deste vídeo.</string>
+  <string name="ui_auto_crop_black_bars_none">Nenhuma barra preta persistente detectada.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">Não foi possível analisar esta fonte de vídeo.</string>
+  <string name="ui_auto_crop_black_bars_failed">Falha ao analisar as barras pretas.</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop é gerenciado pelo mpv.conf.</string>
   <string name="ui_presets">Predefinições</string>
   <string name="ui_add_custom_ratio_e_g_16_9">Adicionar proporção personalizada (ex.: 16:9)</string>
   <string name="ui_width">Largura</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1313,6 +1313,14 @@
   <string name="ui_install_core">Установить ядро</string>
   <string name="ui_update_core">Обновить ядро</string>
   <string name="ui_aspect_ratio">Соотношение сторон</string>
+  <string name="ui_auto_crop_black_bars">Автоматически обрезать чёрные полосы</string>
+  <string name="ui_auto_crop_black_bars_summary">Анализирует несколько кадров в фоновом режиме и обрезает постоянные чёрные полосы, встроенные в видео.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">Анализ кадров видео…</string>
+  <string name="ui_auto_crop_black_bars_applied">Чёрные полосы удалены для этого видео.</string>
+  <string name="ui_auto_crop_black_bars_none">Постоянные чёрные полосы не обнаружены.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">Не удалось проанализировать этот источник видео.</string>
+  <string name="ui_auto_crop_black_bars_failed">Не удалось проанализировать чёрные полосы.</string>
+  <string name="ui_auto_crop_black_bars_managed">Параметр video-crop управляется через mpv.conf.</string>
   <string name="ui_presets">Предустановки</string>
   <string name="ui_add_custom_ratio_e_g_16_9">Добавить своё соотношение (например, 16:9)</string>
   <string name="ui_width">Ширина</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1315,6 +1315,14 @@
   <string name="ui_install_core">安装核心</string>
   <string name="ui_update_core">更新核心</string>
   <string name="ui_aspect_ratio">宽高比</string>
+  <string name="ui_auto_crop_black_bars">自动去除黑边</string>
+  <string name="ui_auto_crop_black_bars_summary">后台抽取多帧，自动裁掉视频文件中持续存在的黑边。</string>
+  <string name="ui_auto_crop_black_bars_analyzing">正在分析视频帧…</string>
+  <string name="ui_auto_crop_black_bars_applied">已去除当前视频的黑边。</string>
+  <string name="ui_auto_crop_black_bars_none">未检测到持续存在的黑边。</string>
+  <string name="ui_auto_crop_black_bars_unsupported">无法分析当前视频来源。</string>
+  <string name="ui_auto_crop_black_bars_failed">黑边分析失败。</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop 已由 mpv.conf 接管。</string>
   <string name="ui_presets">预设</string>
   <string name="ui_add_custom_ratio_e_g_16_9">添加自定义比例（例如 16:9）</string>
   <string name="ui_width">宽度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1462,6 +1462,14 @@
   <string name="ui_install_core">Install Core</string>
   <string name="ui_update_core">Update Core</string>
   <string name="ui_aspect_ratio">Aspect Ratio</string>
+  <string name="ui_auto_crop_black_bars">Auto crop black bars</string>
+  <string name="ui_auto_crop_black_bars_summary">Sample several frames in the background and crop persistent encoded black bars.</string>
+  <string name="ui_auto_crop_black_bars_analyzing">Analyzing frames…</string>
+  <string name="ui_auto_crop_black_bars_applied">Black bars removed for this video.</string>
+  <string name="ui_auto_crop_black_bars_none">No persistent black bars detected.</string>
+  <string name="ui_auto_crop_black_bars_unsupported">This video source could not be analyzed.</string>
+  <string name="ui_auto_crop_black_bars_failed">Black bar analysis failed.</string>
+  <string name="ui_auto_crop_black_bars_managed">video-crop is managed by mpv.conf.</string>
   <string name="ui_presets">Presets</string>
   <string name="ui_add_custom_ratio_e_g_16_9">Add Custom Ratio (e.g. 16:9)</string>
   <string name="ui_width">Width</string>


### PR DESCRIPTION
## Summary

- add a persistent **Auto crop black bars** toggle to the aspect-ratio sheet
- sample seven frames in the background and conservatively detect persistent encoded bars
- apply the result through mpv's hardware-decoding-compatible `video-crop` property
- cancel stale analysis across media generations and wait for position restoration to reach `READY`
- respect `video-crop` ownership from `mpv.conf` and refresh Ambient geometry after crop changes

## Validation

- `gradlew.bat :app:assembleStandardDebug :app:ktlintCheck --offline --no-daemon --max-workers=2`
- installed the arm64-v8a Standard Debug APK over ADB on a Vivo V2419A
- verified a 1920x1080 letterboxed MKV, including leaving and re-entering the player with saved position restoration
