### PR TITLE
perf(player): reduce playback transition latency

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/App.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/App.kt
@@ -15,6 +15,7 @@ import android.content.ComponentName
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.StrictMode
 import android.util.Log
 import android.view.View
 import androidx.core.view.ViewCompat
@@ -29,6 +30,7 @@ import app.gyrolet.mpvrx.preferences.PlayerPreferences
 import app.gyrolet.mpvrx.presentation.crash.CrashActivity
 import app.gyrolet.mpvrx.presentation.crash.GlobalExceptionHandler
 import app.gyrolet.mpvrx.repository.NetworkRepository
+import app.gyrolet.mpvrx.ui.player.PlaybackPerformanceTrace
 import app.gyrolet.mpvrx.ui.player.PlaybackPhase
 import app.gyrolet.mpvrx.ui.player.PlaybackSession
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
@@ -38,6 +40,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
@@ -66,6 +69,8 @@ class App :
   override fun onCreate() {
     super.onCreate()
 
+    configureDebugStrictMode()
+
     // Initialize Koin
     startKoin {
       androidContext(this@App)
@@ -81,6 +86,8 @@ class App :
       getKoin().get<DecoderPreferences>().useVulkan.set(false)
     }
     registerActivityLifecycleCallbacks(this)
+    PlaybackSession.addObserver(PlaybackPerformanceTrace)
+    startPlaybackPerformanceTracing()
     Thread.setDefaultUncaughtExceptionHandler(GlobalExceptionHandler(applicationContext, CrashActivity::class.java))
     startIdleMpvCoreReaper()
 
@@ -134,6 +141,7 @@ class App :
   }
 
   override fun onActivityStarted(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.mark("PLAYER_ACTIVITY_STARTED")
     if (startedActivityCount++ == 0) {
       getKoin().get<app.gyrolet.mpvrx.domain.syncplay.SyncplayManager>().onAppForegrounded()
       scheduleFastThumbnailWarmupOnce()
@@ -142,6 +150,7 @@ class App :
   }
 
   override fun onActivityStopped(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.mark("PLAYER_ACTIVITY_STOPPED")
     startedActivityCount = (startedActivityCount - 1).coerceAtLeast(0)
     if (startedActivityCount == 0 && !activity.isChangingConfigurations) {
       pauseVideoWhenBackgroundPlaybackDisabled(activity)
@@ -168,10 +177,18 @@ class App :
     Log.d(TAG, "Paused video because video background playback is disabled")
   }
 
+  override fun onActivityPreCreated(
+    activity: Activity,
+    savedInstanceState: Bundle?,
+  ) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.mark("PLAYER_ACTIVITY_CREATE_START")
+  }
+
   override fun onActivityCreated(
     activity: Activity,
     savedInstanceState: Bundle?,
   ) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.mark("PLAYER_ACTIVITY_CREATE_END")
     if (activity.javaClass.name.contains("leakcanary", ignoreCase = true)) {
       val rootView = activity.findViewById<View>(android.R.id.content)
       rootView?.let { view ->
@@ -190,16 +207,55 @@ class App :
     }
   }
 
-  override fun onActivityResumed(activity: Activity) = Unit
+  override fun onActivityResumed(activity: Activity) {
+    when (activity) {
+      is PlayerActivity -> {
+        PlaybackPerformanceTrace.mark("PLAYER_ACTIVITY_RESUMED")
+        activity.window.decorView.postOnAnimation {
+          PlaybackPerformanceTrace.mark("PLAYER_FIRST_FRAME")
+        }
+      }
+      is MainActivity -> {
+        PlaybackPerformanceTrace.mark("MAIN_ACTIVITY_RESUMED")
+        activity.window.decorView.postOnAnimation {
+          PlaybackPerformanceTrace.mark("BROWSER_FIRST_FRAME")
+        }
+      }
+    }
+  }
+
+  override fun onActivityPrePaused(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.begin("ON_PAUSE")
+  }
 
   override fun onActivityPaused(activity: Activity) = Unit
+
+  override fun onActivityPostPaused(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.end("ON_PAUSE")
+  }
+
+  override fun onActivityPreStopped(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.begin("ON_STOP")
+  }
+
+  override fun onActivityPostStopped(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.end("ON_STOP")
+  }
 
   override fun onActivitySaveInstanceState(
     activity: Activity,
     outState: Bundle,
   ) = Unit
 
+  override fun onActivityPreDestroyed(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.begin("ON_DESTROY")
+  }
+
   override fun onActivityDestroyed(activity: Activity) = Unit
+
+  override fun onActivityPostDestroyed(activity: Activity) {
+    if (activity is PlayerActivity) PlaybackPerformanceTrace.end("ON_DESTROY")
+  }
 
   /**
    * Keep libmpv warm for quick navigation/re-entry, but do not pin its native decoder/renderer
@@ -231,6 +287,48 @@ class App :
         }
       }
     }
+  }
+
+  private fun startPlaybackPerformanceTracing() {
+    applicationScope.launch {
+      var previousPhase: PlaybackPhase? = null
+      var previousSurfaceAttached: Boolean? = null
+      var previousGeneration = -1L
+      PlaybackSession.state.collect { state ->
+        if (state.phase != previousPhase) {
+          PlaybackPerformanceTrace.mark("SESSION_PHASE", state.phase.name)
+          previousPhase = state.phase
+        }
+        if (state.surfaceAttached != previousSurfaceAttached) {
+          PlaybackPerformanceTrace.mark(
+            if (state.surfaceAttached) "SURFACE_BOUND" else "SURFACE_UNBOUND",
+            "generation=${state.generation}",
+          )
+          previousSurfaceAttached = state.surfaceAttached
+        }
+        if (state.generation != previousGeneration) {
+          PlaybackPerformanceTrace.mark("SESSION_GENERATION", state.generation.toString())
+          previousGeneration = state.generation
+        }
+      }
+    }
+  }
+
+  private fun configureDebugStrictMode() {
+    if (!BuildConfig.DEBUG) return
+
+    StrictMode.setThreadPolicy(
+      StrictMode.ThreadPolicy.Builder()
+        .detectAll()
+        .penaltyLog()
+        .build(),
+    )
+    StrictMode.setVmPolicy(
+      StrictMode.VmPolicy.Builder()
+        .detectAll()
+        .penaltyLog()
+        .build(),
+    )
   }
 
   private fun scheduleFastThumbnailWarmupOnce() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackPerformanceTrace.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackPerformanceTrace.kt
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package app.gyrolet.mpvrx.ui.player
+
+import android.os.SystemClock
+import android.os.Trace
+import android.util.Log
+import app.gyrolet.mpvrx.BuildConfig
+import `is`.xyz.mpv.MPVLib
+import `is`.xyz.mpv.MPVNode
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Lightweight playback instrumentation intended for Perfetto/system-trace captures.
+ *
+ * Trace slices are emitted in every build and are effectively dormant unless app tracing is
+ * enabled. Human-readable logcat milestones are restricted to debug builds so production playback
+ * does not pay a continuous logging cost.
+ */
+object PlaybackPerformanceTrace : MPVLib.EventObserver {
+  private const val TAG = "PlaybackPerf"
+  private const val TRACE_PREFIX = "mpvRx:"
+  private val sectionStartsNs = ConcurrentHashMap<String, Long>()
+
+  fun mark(
+    name: String,
+    detail: String? = null,
+  ) {
+    val traceName = buildTraceName(name, detail)
+    Trace.beginSection(traceName)
+    Trace.endSection()
+    if (BuildConfig.DEBUG) {
+      Log.d(TAG, "${SystemClock.elapsedRealtimeNanos()} $name${detail?.let { " [$it]" }.orEmpty()}")
+    }
+  }
+
+  fun begin(name: String) {
+    sectionStartsNs[name] = SystemClock.elapsedRealtimeNanos()
+    Trace.beginSection(TRACE_PREFIX + name)
+    if (BuildConfig.DEBUG) Log.d(TAG, "BEGIN $name")
+  }
+
+  fun end(name: String) {
+    Trace.endSection()
+    val startedAt = sectionStartsNs.remove(name)
+    if (BuildConfig.DEBUG) {
+      val durationMs = startedAt?.let { (SystemClock.elapsedRealtimeNanos() - it) / 1_000_000.0 }
+      Log.d(TAG, if (durationMs == null) "END $name" else "END $name durationMs=$durationMs")
+    }
+  }
+
+  override fun eventProperty(property: String) = Unit
+
+  override fun eventProperty(
+    property: String,
+    value: Long,
+  ) = Unit
+
+  override fun eventProperty(
+    property: String,
+    value: Boolean,
+  ) = Unit
+
+  override fun eventProperty(
+    property: String,
+    value: String,
+  ) = Unit
+
+  override fun eventProperty(
+    property: String,
+    value: Double,
+  ) = Unit
+
+  override fun eventProperty(
+    property: String,
+    value: MPVNode,
+  ) = Unit
+
+  override fun event(
+    eventId: Int,
+    data: MPVNode,
+  ) {
+    when (eventId) {
+      MPVLib.MpvEvent.MPV_EVENT_START_FILE -> mark("MPV_START_FILE")
+      MPVLib.MpvEvent.MPV_EVENT_FILE_LOADED -> mark("MPV_FILE_LOADED")
+      MPVLib.MpvEvent.MPV_EVENT_PLAYBACK_RESTART -> mark("MPV_PLAYBACK_RESTART")
+      MPVLib.MpvEvent.MPV_EVENT_END_FILE -> mark("MPV_END_FILE", endFileReason(data))
+    }
+  }
+
+  private fun buildTraceName(
+    name: String,
+    detail: String?,
+  ): String =
+    if (detail.isNullOrBlank()) {
+      (TRACE_PREFIX + name).take(127)
+    } else {
+      "$TRACE_PREFIX$name:$detail".take(127)
+    }
+
+  private fun endFileReason(data: MPVNode): String? {
+    val reason = data["reason"]
+    return reason?.asString() ?: reason?.asInt()?.toString()
+  }
+}

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlaybackSession.kt
@@ -162,6 +162,7 @@ object PlaybackSession : MPVLib.EventObserver {
   private var suspendedVideoTrack: SuspendedVideoTrack? = null
   private var deferredVideoSelectionGeneration: Long? = null
   private var pendingStopClearQueue = false
+  private var supersededStopGeneration = 0L
   private var desiredPaused = true
   private var loadedGeneration = 0L
   private var defaultUserAgent: String? = null
@@ -218,6 +219,7 @@ object PlaybackSession : MPVLib.EventObserver {
         suspendedVideoTrack = null
         deferredVideoSelectionGeneration = null
         pendingStopClearQueue = false
+        supersededStopGeneration = 0L
         desiredPaused = true
         loadedGeneration = 0L
         defaultUserAgent = null
@@ -263,6 +265,7 @@ object PlaybackSession : MPVLib.EventObserver {
           suspendedVideoTrack = null
           deferredVideoSelectionGeneration = null
           pendingStopClearQueue = false
+          supersededStopGeneration = 0L
           desiredPaused = true
           loadedGeneration = 0L
           defaultUserAgent = null
@@ -387,6 +390,7 @@ object PlaybackSession : MPVLib.EventObserver {
       }
 
       val nextGeneration = _state.value.generation + 1L
+      supersededStopGeneration = 0L
       suspendedVideoTrack = null
       deferredVideoSelectionGeneration = null
       desiredPaused = true
@@ -418,6 +422,7 @@ object PlaybackSession : MPVLib.EventObserver {
       }
       propBoolean.emit("pause", true)
       clearTimelinePropertiesLocked()
+      PlaybackPerformanceTrace.mark("MPV_STOP_SENT", "generation=$nextGeneration")
 
       if (previousPhase !in setOf(PlaybackPhase.LOADING, PlaybackPhase.READY, PlaybackPhase.BACKGROUND)) {
         finalizeStopLocked()
@@ -431,16 +436,59 @@ object PlaybackSession : MPVLib.EventObserver {
     }
   }
 
+  /**
+   * Resolves the stop/load race for an incoming media request.
+   *
+   * A genuine session stop still enters [PlaybackPhase.STOPPING] and waits for libmpv to finish.
+   * When a newer direct/local request arrives before that END_FILE, however, there is no app-owned
+   * proxy lifetime that requires the Activity to wait for the event round-trip. In that case the
+   * new generation may supersede the stop and enqueue `loadfile replace` immediately. App-owned
+   * network/HLS/sidecar registrations deliberately retain the conservative wait until their
+   * lifetime can be transferred with equivalent guarantees.
+   */
   suspend fun awaitStopCompletion(timeoutMillis: Long = 3_000L): Boolean {
     if (_state.value.phase != PlaybackPhase.STOPPING) return true
-    return withTimeoutOrNull(timeoutMillis) {
-      state.first { it.phase != PlaybackPhase.STOPPING }
-    } != null
+    if (trySupersedeStopForReplacement()) return true
+
+    val startedAt = android.os.SystemClock.elapsedRealtime()
+    PlaybackPerformanceTrace.mark("WAIT_FOR_STOP_START")
+    val completed =
+      withTimeoutOrNull(timeoutMillis) {
+        state.first { it.phase != PlaybackPhase.STOPPING }
+      } != null
+    PlaybackPerformanceTrace.mark(
+      "WAIT_FOR_STOP_END",
+      "durationMs=${android.os.SystemClock.elapsedRealtime() - startedAt},completed=$completed",
+    )
+    return completed
   }
+
+  private fun trySupersedeStopForReplacement(): Boolean =
+    nativeLock.withLock {
+      val current = _state.value
+      if (current.phase != PlaybackPhase.STOPPING) return@withLock true
+      if (!initialized || activeNetworkStream != null || auxiliaryNetworkStreams.isNotEmpty()) {
+        return@withLock false
+      }
+
+      pendingStopClearQueue = false
+      supersededStopGeneration = current.generation
+      updateState {
+        it.copy(
+          phase = PlaybackPhase.IDLE,
+          activeGeneration = 0L,
+          paused = true,
+          error = null,
+        )
+      }
+      PlaybackPerformanceTrace.mark("WAIT_FOR_STOP_SUPERSEDED", "generation=${current.generation}")
+      true
+    }
 
   private fun finalizeStopLocked() {
     if (pendingStopClearQueue) _queue.value = PlaybackQueueState()
     pendingStopClearQueue = false
+    supersededStopGeneration = 0L
     releaseActiveNetworkStreamLocked()
     releaseAuxiliaryNetworkStreamsLocked()
     updateState {
@@ -455,7 +503,6 @@ object PlaybackSession : MPVLib.EventObserver {
     propBoolean.emit("pause", true)
     clearTimelinePropertiesLocked()
   }
-
 
   /**
     * Destroys a core that must not be reused, including process shutdown and an unrecoverable
@@ -482,6 +529,7 @@ object PlaybackSession : MPVLib.EventObserver {
    * so the output remains muted through destruction.
    */
   fun muteForTeardown() {
+    PlaybackPerformanceTrace.mark("CLOSE_AUDIO_SILENCE")
     withCore(Unit) { beginPlaybackTransitionAudioGuardLocked(canRestore = false) }
   }
 
@@ -496,6 +544,7 @@ object PlaybackSession : MPVLib.EventObserver {
     suspendedVideoTrack = null
     deferredVideoSelectionGeneration = null
     pendingStopClearQueue = false
+    supersededStopGeneration = 0L
     clearSeekAudioGuardLocked(restoreMute = false)
     clearPlaybackTransitionAudioGuardLocked(restoreMute = false)
     runCatching { MPVLib.setPropertyBoolean("mute", true) }
@@ -635,7 +684,17 @@ object PlaybackSession : MPVLib.EventObserver {
     flattenEditions: Boolean = false,
     commit: ((() -> Long) -> Long)? = null,
   ): Long {
-    val resolved = resolvePlayableUri(item)
+    val preparationStartedAt = android.os.SystemClock.elapsedRealtime()
+    PlaybackPerformanceTrace.mark("MEDIA_PREPARATION_START")
+    val resolved =
+      try {
+        resolvePlayableUri(item)
+      } finally {
+        PlaybackPerformanceTrace.mark(
+          "MEDIA_PREPARATION_END",
+          "durationMs=${android.os.SystemClock.elapsedRealtime() - preparationStartedAt}",
+        )
+      }
     return try {
       var previous: NetworkStreamRegistration? = null
       var previousAuxiliary = emptyList<NetworkStreamRegistration>()
@@ -751,6 +810,7 @@ object PlaybackSession : MPVLib.EventObserver {
             add("flatten-editions=yes")
           }
         }.joinToString(",")
+      PlaybackPerformanceTrace.mark("LOADFILE_SENT", "generation=$generation")
       MPVLib.command("loadfile", playableUri, "replace", "-1", loadOptions)
       propBoolean.emit("pause", holdForPositionRestore || desiredPaused)
       generation
@@ -1145,6 +1205,11 @@ object PlaybackSession : MPVLib.EventObserver {
             if (_state.value.phase != PlaybackPhase.STOPPING) {
               updateState { it.copy(phase = PlaybackPhase.LOADING, activeGeneration = it.generation) }
             }
+            if (supersededStopGeneration != 0L && _state.value.generation > supersededStopGeneration) {
+              // libmpv normally delivers the old STOP END_FILE before START_FILE for the replacement.
+              // Once the new file has started, do not let this marker affect a later genuine stop.
+              supersededStopGeneration = 0L
+            }
             true
           }
           MPVLib.MpvEvent.MPV_EVENT_FILE_LOADED -> {
@@ -1153,6 +1218,7 @@ object PlaybackSession : MPVLib.EventObserver {
               runCatching { MPVLib.command("stop") }
               return@withLock true
             }
+            supersededStopGeneration = 0L
             loadedGeneration = current.generation
             val restoringPosition = pendingPositionRestoreGeneration == current.generation
             val appliedPaused = restoringPosition || desiredPaused
@@ -1201,8 +1267,21 @@ object PlaybackSession : MPVLib.EventObserver {
           }
           MPVLib.MpvEvent.MPV_EVENT_END_FILE -> {
             val current = _state.value
+            val reason = parseEndFileReason(data)
+            if (
+              supersededStopGeneration != 0L &&
+              current.activeGeneration == 0L &&
+              reason in setOf(EndFileReason.STOP, EndFileReason.QUIT)
+            ) {
+              PlaybackPerformanceTrace.mark(
+                "SUPERSEDED_STOP_END_FILE",
+                "generation=$supersededStopGeneration,reason=${reason.name}",
+              )
+              supersededStopGeneration = 0L
+              return@withLock false
+            }
             if (current.phase == PlaybackPhase.STOPPING) {
-              if (parseEndFileReason(data) == EndFileReason.REDIRECT) {
+              if (reason == EndFileReason.REDIRECT) {
                 runCatching { MPVLib.command("stop") }
               } else {
                 finalizeStopLocked()
@@ -1210,7 +1289,6 @@ object PlaybackSession : MPVLib.EventObserver {
               return@withLock true
             }
             if (current.activeGeneration == current.generation) {
-              val reason = parseEndFileReason(data)
               if (reason == EndFileReason.REDIRECT && loadedGeneration != current.generation) {
                 // Redirects emit END_FILE before mpv starts the resolved target. Preserve LOADING;
                 // the following START_FILE belongs to the same app-level generation.
@@ -1260,6 +1338,7 @@ object PlaybackSession : MPVLib.EventObserver {
             pendingPositionRestoreOverride = null
             initialPositionGeneration = 0L
             pendingStopClearQueue = false
+            supersededStopGeneration = 0L
             clearSeekAudioGuardLocked(restoreMute = false)
             clearPlaybackTransitionAudioGuardLocked(restoreMute = false)
             resetAmbientShaderTrackingLocked()

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
@@ -20,6 +20,7 @@ import app.gyrolet.mpvrx.domain.media.model.Video
 import app.gyrolet.mpvrx.domain.torrent.isTorrentSource
 import app.gyrolet.mpvrx.ui.player.PlaybackIdentity
 import app.gyrolet.mpvrx.ui.player.PlaybackItem
+import app.gyrolet.mpvrx.ui.player.PlaybackPerformanceTrace
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerLookupHints
 import app.gyrolet.mpvrx.ui.player.PreparedPlaybackLaunchStore
@@ -103,6 +104,7 @@ object MediaUtils {
         putExtra(PlayerActivity.EXTRA_VIDEO_WIDTH, selected.width)
         putExtra(PlayerActivity.EXTRA_VIDEO_HEIGHT, selected.height)
       }
+    PlaybackPerformanceTrace.mark("OPEN_REQUEST", "source=$launchSource queue=${videos.size}")
     context.startActivity(intent)
   }
 
@@ -143,14 +145,20 @@ object MediaUtils {
     val uri =
       when (source) {
         is Video -> {
-          val localPath = source.path.takeIf { File(it).isFile }
+          // Video.path is already MediaStore/library metadata. Avoid a synchronous filesystem
+          // stat on the UI click path before startActivity(); stale media will fail at the same
+          // playback/open stage where the content URI itself is validated.
+          val localPath = source.path.takeIf(String::isNotBlank)
           // Recents stores a durable filesystem path, while normal library playback is usually
           // launched with a MediaStore content:// URI. Playback state is keyed from the launch
           // URI, so reopening the same file as file:// created a different key and restarted at 0.
-          // Resolve the path back to its MediaStore URI for history/quick-play launches so the
-          // existing playback-state key (and therefore the saved position) is reused.
+          // Resolve the path back to its MediaStore URI for history/quick-play launches only when
+          // the Video does not already carry a content URI.
           val playbackUri =
-            if (launchSource.isHistoryResumeLaunch() && localPath != null) {
+            if (launchSource.isHistoryResumeLaunch() &&
+              localPath != null &&
+              !source.uri.scheme.equals("content", ignoreCase = true)
+            ) {
               resolveMediaStoreUri(context, localPath, source.isAudio) ?: source.uri
             } else {
               source.uri
@@ -205,6 +213,7 @@ object MediaUtils {
             isAudio = isAudio,
             playlistDurationsSeconds = playlistDurationsSeconds,
           )
+          PlaybackPerformanceTrace.mark("OPEN_REQUEST", "source=${launchSource ?: "library"} kind=video")
           context.startActivity(intent)
           return
         }
@@ -235,13 +244,15 @@ object MediaUtils {
         }
       }
 
+    // Keep the path handoff syntactic here. File existence is validated by the actual media open;
+    // probing storage before startActivity() adds avoidable main-thread I/O to every local launch.
     val localPath =
       when {
         source is String && source.startsWith("file://", ignoreCase = true) -> source.removePrefix("file://")
         source is String && source.startsWith("/") -> source
         uri.scheme.equals("file", ignoreCase = true) -> uri.path
         else -> null
-      }?.takeIf { File(it).isFile }
+      }?.takeIf(String::isNotBlank)
 
     val playbackUri =
       if (launchSource.isHistoryResumeLaunch() && localPath != null) {
@@ -292,6 +303,7 @@ object MediaUtils {
       isAudio = isAudio,
       playlistDurationsSeconds = playlistDurationsSeconds,
     )
+    PlaybackPerformanceTrace.mark("OPEN_REQUEST", "source=${launchSource ?: "direct"} kind=${uri.scheme ?: "path"}")
     context.startActivity(intent)
   }
 


### PR DESCRIPTION
## Goal
Improve mpvRx playback open/switch/close/reopen responsiveness while preserving the process-wide `PlaybackSession`, background playback, PiP, network/torrent/ytdlp playback, custom mpv configuration, and Surface handoff semantics.

## Pre-edit static audit

| Priority | Finding | Evidence / mechanism | Confidence | Treatment in this PR |
| --- | --- | --- | --- | --- |
| P0 | A new media request inherits `STOPPING` | `issuePlaybackLoad()` waits in `PlaybackSession.awaitStopCompletion()`; active stop finalizes only after libmpv `END_FILE` | CONFIRMED | **Changed for safe outgoing sessions** |
| P0 | Media preparation is globally serialized | `Dispatchers.Default.limitedParallelism(1)` also contains torrent teardown/startup | CONFIRMED | Measured/investigated only; **not** globally parallelized because that would race the torrent engine |
| P1 | Player startup performs cached config/assets checks before session setup | synchronous startup preparation in `setupMPV()` | CONFIRMED | Instrumentation first; no speculative bypass yet |
| P1 | Fair `PlaybackSession` native lock may convoy high-frequency traffic | process-wide `ReentrantLock(true)` | POSSIBLE | No synchronization weakening without device data |
| P1 | Renderer options can affect steady-state pacing | `mediacodec-copy`, `vd-lavc-queue=no`, `framedrop=vo`, `video-sync=audio` are backend/device dependent | POSSIBLE | No option changes without A/B traces |

## Instrumentation

Added `PlaybackPerformanceTrace` and process/session tracing for Perfetto/logcat, including:

- Player Activity create/start/resume/stop/destroy boundaries;
- next rendered player frame and browser frame after resume;
- PlaybackSession phase, generation, Surface bind/unbind;
- media preparation start/end;
- wait-for-stop start/end/supersede;
- `MPV_STOP_SENT` and `LOADFILE_SENT`;
- libmpv `START_FILE`, `FILE_LOADED`, `PLAYBACK_RESTART`, and `END_FILE`;
- debug-only non-fatal StrictMode detection for main-thread/VM violations.

This makes tap/open/stop/native-event/browser-return timing visible in Perfetto without adding production log spam.

## P0 implementation: separate pending stop from replacement

`PlaybackSession.stop()` remains a real session stop and continues to enter `STOPPING` and send libmpv `stop`.

When a newer playback request reaches the existing stop barrier, `PlaybackSession.awaitStopCompletion()` now has a narrowly-scoped fast path:

1. only while the core is already initialized and phase is `STOPPING`;
2. only when the outgoing session has **no app-owned active network/HLS proxy and no auxiliary network sidecars**;
3. cancel the stale pending queue-clear owned by the old Activity;
4. allow the incoming request to proceed to the existing `loadfile ... replace` path immediately;
5. quarantine the superseded stop's late `END_FILE reason=stop/quit` so it cannot reset the new playback generation to `IDLE`.

Outgoing proxy/HLS/sidecar sessions deliberately retain the previous conservative END_FILE wait because their lifetime/cleanup guarantees must not be weakened.

This keeps the process-wide libmpv core intact and does **not** alter Surface handoff, background playback, PiP ownership, decoder selection, renderer selection, mpv.conf handling, or normal genuine-stop semantics.