### PR TITLE
fix: address playback and network navigation regressions

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/NetworkConnectionCard.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/cards/NetworkConnectionCard.kt
@@ -195,7 +195,7 @@ fun NetworkConnectionCard(
           Modifier
             .fillMaxWidth()
             .padding(top = 12.dp),
-        horizontalArrangement = Arrangement.End,
+        horizontalArrangement = Arrangement.Start,
       ) {
         when {
           isConnecting -> {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -766,7 +766,7 @@ private fun LocalNetworkContent(
   val navBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current.takeIf { it > 0.dp } ?: 88.dp
   LazyColumn(
     modifier = Modifier.fillMaxSize(),
-    contentPadding = PaddingValues(start = 16.dp, top = 12.dp, end = 16.dp, bottom = navBarHeight + 16.dp),
+    contentPadding = PaddingValues(start = 16.dp, top = 12.dp, end = 16.dp, bottom = navBarHeight + 88.dp),
     verticalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     // 1. Stream Link Section (URL input & recent streams with Save to Media action)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/networkstreaming/NetworkStreamingScreen.kt
@@ -766,7 +766,7 @@ private fun LocalNetworkContent(
   val navBarHeight = app.gyrolet.mpvrx.ui.browser.LocalNavigationBarHeight.current.takeIf { it > 0.dp } ?: 88.dp
   LazyColumn(
     modifier = Modifier.fillMaxSize(),
-    contentPadding = PaddingValues(start = 16.dp, top = 12.dp, end = 16.dp, bottom = navBarHeight + 88.dp),
+    contentPadding = PaddingValues(start = 16.dp, top = 12.dp, end = 16.dp, bottom = navBarHeight + 16.dp),
     verticalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     // 1. Stream Link Section (URL input & recent streams with Save to Media action)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -1101,10 +1101,10 @@ class PlayerActivity :
     val videoHeight: Int
     if (containerAspect > videoAspect) {
       videoHeight = containerHeight
-      videoWidth = (videoHeight * videoAspect).roundToInt().coerceAtLeast(1)
+      videoWidth = centeredFittedDimension((videoHeight * videoAspect).roundToInt(), containerWidth)
     } else {
       videoWidth = containerWidth
-      videoHeight = (videoWidth / videoAspect).roundToInt().coerceAtLeast(1)
+      videoHeight = centeredFittedDimension((videoWidth / videoAspect).roundToInt(), containerHeight)
     }
 
     val params = binding.player.layoutParams as ConstraintLayout.LayoutParams
@@ -1116,6 +1116,16 @@ class PlayerActivity :
     params.topToTop = ConstraintLayout.LayoutParams.PARENT_ID
     params.bottomToBottom = ConstraintLayout.LayoutParams.PARENT_ID
     binding.player.layoutParams = params
+  }
+
+  private fun centeredFittedDimension(
+    requested: Int,
+    container: Int,
+  ): Int {
+    val fitted = requested.coerceIn(1, container)
+    // An odd remainder cannot be split equally by ConstraintLayout. Prefer one pixel less video
+    // over visibly placing the extra ambient/letterbox pixel on only one side.
+    return if (fitted > 1 && (container - fitted) % 2 != 0) fitted - 1 else fitted
   }
 
   private fun restoreFullSizePlayerBounds() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -783,8 +783,11 @@ class PlayerActivity :
       setOrientation()
     }
 
-    // Apply persisted shuffle state after playlist is loaded
-    viewModel.applyPersistedShuffleState()
+    if (attachedToCurrentSession) {
+      viewModel.syncShuffleStateFromSession()
+    } else {
+      viewModel.resetShuffleForNewPlayback()
+    }
 
     // Observe selected Lua scripts for runtime loading
     lifecycleScope.launch {
@@ -5139,6 +5142,7 @@ private suspend fun restorePlaybackPosition(state: PlaybackStateEntity?) {
         isBackgroundPlaybackSessionActive = false
         pendingBackgroundTransition = false
         if (attachToCurrentPlaybackSessionIfRequested(intent)) {
+          viewModel.syncShuffleStateFromSession()
           PlaybackSession.markForeground()
           isReady = PlaybackSession.state.value.phase == PlaybackPhase.READY
           if (isReady) viewModel.onVideoLoadCompleted()
@@ -5186,6 +5190,7 @@ private suspend fun restorePlaybackPosition(state: PlaybackStateEntity?) {
     val previouslyLoadedTorrentFileIndex = this.intent.getIntExtra("torrent_file_index", -1)
     val previousItemWasReady = isReady
 
+    viewModel.resetShuffleForNewPlayback()
     setIntent(intent)
     applyInitialVideoOrientation(intent)
     applyPlaybackBrightnessPolicy(isAudio = isCurrentMediaKnownAudio())

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -6005,12 +6005,47 @@ private suspend fun restorePlaybackPosition(state: PlaybackStateEntity?) {
   private fun applyInitialVideoOrientation(sourceIntent: Intent) {
     if (playerPreferences.orientation.get() != PlayerOrientation.Video || isKnownAudioLaunch(sourceIntent)) return
 
-    val width = sourceIntent.getIntExtra(EXTRA_VIDEO_WIDTH, 0)
-    val height = sourceIntent.getIntExtra(EXTRA_VIDEO_HEIGHT, 0)
+    var width = sourceIntent.getIntExtra(EXTRA_VIDEO_WIDTH, 0)
+    var height = sourceIntent.getIntExtra(EXTRA_VIDEO_HEIGHT, 0)
+    var rotation = 0
+
+    extractUriFromIntent(sourceIntent)
+      ?.takeIf { uri -> uri.scheme.equals("content", true) || uri.scheme.equals("file", true) }
+      ?.let { uri ->
+        runCatching {
+          val retriever = android.media.MediaMetadataRetriever()
+          try {
+            retriever.setDataSource(this, uri)
+            if (width <= 0) {
+              width =
+                retriever
+                  .extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                  ?.toIntOrNull()
+                  ?: 0
+            }
+            if (height <= 0) {
+              height =
+                retriever
+                  .extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                  ?.toIntOrNull()
+                  ?: 0
+            }
+            rotation =
+              retriever
+                .extractMetadata(android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+                ?.toIntOrNull()
+                ?: 0
+          } finally {
+            retriever.release()
+          }
+        }
+      }
     if (width <= 0 || height <= 0) return
 
+    val normalizedRotation = ((rotation % 360) + 360) % 360
+    val swapsDimensions = normalizedRotation == 90 || normalizedRotation == 270
     val initialOrientation =
-      if (width > height) {
+      if ((width > height) != swapsDimensions) {
         ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
       } else {
         ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -4249,13 +4249,11 @@ val isBrightnessSliderShown = MutableStateFlow(false)
             return@launch
           }
 
-          // A backward keyframe seek can expose pre-target video while audio still starts at the
-          // requested timestamp. Exact seeking decodes through that gap and keeps A/V aligned.
-          // A clamped forward seek uses an absolute target, but non-precise mode must still let
-          // MPV choose a safe keyframe instead of HR-seeking into the EOF boundary.
+          // Keep non-precise double-taps on MPV's fast keyframe path in both directions. Only a
+          // boundary-clamped seek needs an absolute target; it can still remain keyframe-based.
           val targetWasClamped = targetPosition != null && targetPosition < requestedTarget
-          val useRelativeKeyframeSeek = !preciseSeeking && toApply > 0 && !targetWasClamped
-          val useExactSeeking = toApply < 0 || preciseSeeking
+          val useRelativeKeyframeSeek = !preciseSeeking && !targetWasClamped
+          val useExactSeeking = preciseSeeking
           val seekMode =
             if (useRelativeKeyframeSeek) {
               "relative+keyframes"

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -1873,11 +1873,9 @@ val isBrightnessSliderShown = MutableStateFlow(false)
 
     // Track selection is now handled by TrackSelector in PlayerActivity
 
-    // Restore repeat mode and shuffle state from preferences
+    // Repeat mode remains a player preference; shuffle belongs to the active queue only.
     _repeatMode.value = playerPreferences.repeatMode.get()
-    _shuffleEnabled.value = playerPreferences.shuffleEnabled.get()
     PlaybackSession.setRepeatMode(_repeatMode.value)
-    PlaybackSession.setShuffleEnabled(_shuffleEnabled.value)
 
     // Observe volume boost cap changes to enforce limits dynamically (in PiP)
     viewModelScope.launch(playbackStateDispatcher) {
@@ -5748,11 +5746,13 @@ val isBrightnessSliderShown = MutableStateFlow(false)
 
   // ==================== Repeat and Shuffle ====================
 
-  fun applyPersistedShuffleState() {
-    PlaybackSession.setShuffleEnabled(_shuffleEnabled.value)
-    if (_shuffleEnabled.value) {
-      host.onQueueShuffleChanged(true)
-    }
+  fun syncShuffleStateFromSession() {
+    _shuffleEnabled.value = PlaybackSession.queue.value.shuffleEnabled
+  }
+
+  fun resetShuffleForNewPlayback() {
+    _shuffleEnabled.value = false
+    PlaybackSession.setShuffleEnabled(false)
   }
 
   fun cycleRepeatMode() {
@@ -5776,8 +5776,6 @@ val isBrightnessSliderShown = MutableStateFlow(false)
   fun toggleShuffle() {
     _shuffleEnabled.value = !_shuffleEnabled.value
 
-    // Persist the shuffle state
-    playerPreferences.shuffleEnabled.set(_shuffleEnabled.value)
     PlaybackSession.setShuffleEnabled(_shuffleEnabled.value)
 
     // Notify activity to handle shuffle state change


### PR DESCRIPTION
## Summary

- keep odd-sized portrait video surfaces pixel-centered in YouTube ambience mode (`Refs #605`)
- left-align network connection actions so the right-side Add Connection FAB cannot cover them (`Refs #606`)
- keep non-precise double-tap seeking on MPV's fast keyframe path in both directions (`Refs #610`)
- make shuffle queue-scoped so every newly opened folder, M3U playlist, network queue, or music queue starts in its visible sequential order (`Refs #611`)
- read local rotation metadata before attaching the player view so 90°/270° videos open in the correct orientation from the first frame (`Refs #612`)