### PR TITLE
fix(player): avoid stale online auto crop cache

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerViewModel.kt
@@ -4862,7 +4862,11 @@ val isBrightnessSliderShown = MutableStateFlow(false)
     val generation = session.generation
     if (!force && autoCropAnalyzedGeneration == generation) return
     val source = runCatching { host.currentThumbnailSource() }.getOrNull()?.takeIf(String::isNotBlank)
-    val durationSeconds = PlaybackSession.getPropertyDouble("duration") ?: preciseDuration.value.toDouble()
+    val durationSeconds =
+      sequenceOf(
+        PlaybackSession.getPropertyDouble("duration"),
+        preciseDuration.value.toDouble(),
+      ).filterNotNull().firstOrNull { it.isFinite() && it > 0.0 }
     val sourceWidth = PlaybackSession.getPropertyInt("video-params/w") ?: 0
     val sourceHeight = PlaybackSession.getPropertyInt("video-params/h") ?: 0
     val rotation = (PlaybackSession.getPropertyInt("video-params/rotate") ?: 0).mod(360)
@@ -4876,16 +4880,21 @@ val isBrightnessSliderShown = MutableStateFlow(false)
     autoCropJob?.cancel()
     _autoCropState.value = AutoCropState.ANALYZING
     val sourceIdentity = source ?: session.currentItem?.stableId ?: "generation:$generation"
-    val cacheKey = "$sourceIdentity|$sourceWidth|$sourceHeight|${durationSeconds.toLong()}"
+    val androidReadableSource = source?.let(::isAndroidReadableMediaSource) == true
+    // A URL can identify a changing live channel, so only cache results for local/Android media.
+    val cacheKey =
+      durationSeconds?.takeIf { androidReadableSource }?.let { duration ->
+        "$sourceIdentity|$sourceWidth|$sourceHeight|${duration.toLong()}"
+      }
     autoCropJob =
       viewModelScope.launch(Dispatchers.IO) {
         Log.i(TAG, "Auto-crop analyzing generation=$generation source=$sourceIdentity")
         val result =
           try {
-            val cached = autoCropResultCache.get(cacheKey)
+            val cached = cacheKey?.let(autoCropResultCache::get)
             if (cached != null) {
               AutoCropAnalysisResult.Detected(cached)
-            } else if (source != null && durationSeconds > 0.0 && isAndroidReadableMediaSource(source)) {
+            } else if (source != null && durationSeconds != null && androidReadableSource) {
               val positions = autoCropSamplePositions(source, durationSeconds)
               val combined = extractAutoCropSamples(source, positions)
               when {
@@ -4937,7 +4946,7 @@ val isBrightnessSliderShown = MutableStateFlow(false)
             return@withContext
           }
 
-          autoCropResultCache.put(cacheKey, sourceEdges)
+          cacheKey?.let { autoCropResultCache.put(it, sourceEdges) }
           PlaybackSession.setPropertyString("video-crop", cropValue)
           Log.i(TAG, "Auto-crop applied generation=$generation crop=$cropValue edges=$sourceEdges")
           autoCropApplied = true


### PR DESCRIPTION
## Summary

- keep the newly added active-player auto-crop path for online streams
- treat zero, negative, NaN, and infinite durations as unknown so live streams use active playback analysis
- cache auto-crop results only for Android-readable local media, because a live URL can serve changing content

## Root cause

The original online-stream failure came from opening the URL in separate thumbnail players for random seeks. Each sample had to reconnect, recover redirects/headers, buffer, and seek, so fewer than the required frames were often available even while the main player was already rendering video.

Upstream commit `da3fadbc` landed active-player crop detection while this fix was being prepared. This follow-up prevents its online/live results from being cached under a reusable URL and hardens unknown-duration handling.

Reported in https://github.com/Riteshp2001/mpvRx/pull/558#issuecomment-5580153866

## Validation

- `git diff --check` — passed
- Kotlin build was attempted with the workspace JDK and Android SDK, but current `master` is blocked before Kotlin compilation by an unrelated existing invalid Unicode escape in `app/src/main/res/values/strings.xml:1179`
- no device playback test was run

## Screenshots or recordings

N/A — no visible UI changes.

## Checklist

- [x] This PR is focused on the described change, with unrelated edits left out.
- [x] I have recorded validation results and any remaining limitations above.
- [x] User-facing documentation is updated where applicable (not applicable).
- [x] Upstream credits and license notices are preserved for adapted code or assets.
- [x] Logs, screenshots, and code do not expose credentials or private information.
- [x] I have read the [Code of Conduct](https://github.com/Riteshp2001/mpvRx/blob/master/CODE_OF_CONDUCT.md).