### PR TITLE
fix: improve Jellyfin browsing & tracking, music playlist durations, and player gesture UX

### DIFF
--- a/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/data/jellyfin/JellyfinClient.kt
@@ -520,7 +520,7 @@ class JellyfinClient(
         val base = normalizeUrl(serverUrl)
         val urlBuilder =
           StringBuilder(
-            "$base/Users/$userId/Items?Fields=Overview,PrimaryImageAspectRatio,UserData,ChildCount,MediaSources,MediaStreams,ProductionYear,CommunityRating,CriticRating,Genres,OfficialRating,Taglines,SeriesName,SeriesId,SeriesPrimaryImageTag,SeasonName,IndexNumber,ParentIndexNumber,PremiereDate,Status,RemoteTrailers&StartIndex=$startIndex&Limit=$limit&SortBy=${sortBy.apiValue}&SortOrder=${sortOrder.apiValue}",
+            "$base/Users/$userId/Items?Fields=Overview,PrimaryImageAspectRatio,UserData,ChildCount,CumulativeRunTimeTicks,MediaSources,MediaStreams,ProductionYear,CommunityRating,CriticRating,Genres,OfficialRating,Taglines,SeriesName,SeriesId,SeriesPrimaryImageTag,SeasonName,IndexNumber,ParentIndexNumber,PremiereDate,Status,RemoteTrailers&StartIndex=$startIndex&Limit=$limit&SortBy=${sortBy.apiValue}&SortOrder=${sortOrder.apiValue}",
           )
 
         if (!parentId.isNullOrBlank()) {
@@ -953,7 +953,7 @@ class JellyfinClient(
     val type = obj["Type"]?.jsonPrimitive?.content ?: obj["CollectionType"]?.jsonPrimitive?.content ?: "Folder"
     val collectionType = obj["CollectionType"]?.jsonPrimitive?.content
     val overview = obj["Overview"]?.jsonPrimitive?.content
-    val runTimeTicks = obj["RunTimeTicks"]?.jsonPrimitive?.longOrNull
+    val runTimeTicks = obj["RunTimeTicks"]?.jsonPrimitive?.longOrNull ?: obj["CumulativeRunTimeTicks"]?.jsonPrimitive?.longOrNull
     val isFolder = obj["IsFolder"]?.jsonPrimitive?.booleanOrNull ?: (type == "CollectionFolder" || type == "Folder" || type == "Series" || type == "Season")
     val productionYear = obj["ProductionYear"]?.jsonPrimitive?.intOrNull
     val communityRating = obj["CommunityRating"]?.jsonPrimitive?.content?.toDoubleOrNull()

--- a/app/src/main/java/app/gyrolet/mpvrx/preferences/AudioPreferences.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/preferences/AudioPreferences.kt
@@ -26,6 +26,7 @@ class AudioPreferences(
   val backgroundPlayback = preferenceStore.getBoolean("automatic_background_playback", false)
   /** Audio-player-only background playback; video retains [backgroundPlayback]. */
   val audioBackgroundPlayback = preferenceStore.getBoolean("audio_player_background_playback", false)
+  val miniPlayerTrackSwitching = preferenceStore.getBoolean("audio_mini_player_track_switching", false)
   val volumeNormalization = preferenceStore.getBoolean("audio_volume_normalization", false)
   val drcEnabled = preferenceStore.getBoolean("audio_drc_enabled", false)
   val showAudioVisualizer = preferenceStore.getBoolean("show_audio_visualizer", true)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/MainScreen.kt
@@ -462,7 +462,7 @@ object MainScreen : Screen {
                       }
                     } else {
                       LaunchedEffect(jellyfinUiState.libraries) {
-                        jellyfinViewModel.ensureMusicLibraryOpened()
+                        jellyfinViewModel.ensureMusicDataLoaded()
                       }
                       app.gyrolet.mpvrx.ui.browser.jellyfin.JellyfinContent(
                         viewModel = jellyfinViewModel,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/PlaybackQueueActions.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/components/PlaybackQueueActions.kt
@@ -39,6 +39,7 @@ fun addVideosToPlaybackQueue(
             ?.let(PlaybackIdentity::forLocalPath),
         title = video.displayName.ifBlank { video.title },
         mimeType = video.mimeType,
+        durationSeconds = (video.duration / 1000L).toInt().takeIf { it > 0 },
       )
     }
   val added =

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinCards.kt
@@ -1340,8 +1340,6 @@ fun JellyfinLibraryCard(
     modifier =
       modifier
         .width(cardWidth)
-        .tvFocusHighlight(RoundedCornerShape(10.dp), focusedScale = 1.03f)
-        .clip(RoundedCornerShape(10.dp))
         .clickable(onClick = onClick),
   ) {
     Card(
@@ -1349,6 +1347,7 @@ fun JellyfinLibraryCard(
         Modifier
           .fillMaxWidth()
           .aspectRatio(16f / 9f)
+          .tvFocusHighlight(RoundedCornerShape(10.dp), focusedScale = 1.03f)
           .clip(RoundedCornerShape(10.dp)),
       shape = RoundedCornerShape(10.dp),
       colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinContent.kt
@@ -254,7 +254,7 @@ fun JellyfinContent(
   val isBackEnabled =
     if (isMusicOnlyMode) {
       isSearching || selectionManager.isInSelectionMode || uiState.detailItem != null ||
-        (uiState.openLibrary?.isMusic == true && uiState.musicActiveTab != JellyfinMusicTab.HOME) ||
+        uiState.musicActiveTab != JellyfinMusicTab.HOME ||
         (isFabExpanded && !quickPlayFabDirect)
     } else {
       isSeerrRequestsOpen || isSearching || selectionManager.isInSelectionMode ||
@@ -711,7 +711,7 @@ fun JellyfinContent(
             }
 
             // Root / Discovery Home View (Expressive UI)
-            uiState.openLibrary == null && uiState.searchQuery.isBlank() -> {
+            !isMusicOnlyMode && uiState.openLibrary == null && uiState.searchQuery.isBlank() -> {
               val server = uiState.activeServer
 
               if (server != null) {
@@ -905,8 +905,8 @@ fun JellyfinContent(
 
             // Level / Search View: Inside a Library / Folder / Season / Search results
             else -> {
-              val openLib = uiState.openLibrary
-              if (openLib?.isMusic == true && uiState.searchQuery.isBlank() && uiState.activeServer != null) {
+              val openLib = uiState.openLibrary ?: if (isMusicOnlyMode) viewModel.getMusicLibraryView() else null
+              if ((isMusicOnlyMode || openLib?.isMusic == true) && uiState.searchQuery.isBlank() && uiState.activeServer != null) {
                 JellyfinMusicView(
                   uiState = uiState,
                   server = uiState.activeServer!!,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinDetailSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinDetailSheet.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import android.content.Intent
 import android.net.Uri
+import android.text.format.DateUtils
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.gyrolet.mpvrx.R
@@ -162,7 +163,11 @@ fun JellyfinDetailSheet(
         }
         val isArtist = item.type == "MusicArtist" || item.type == "Artist" || item.type == "AlbumArtist"
         val subtitle = if (isArtist) null else (item.seriesName ?: item.overview)?.takeIf { it.isNotBlank() }
-        val itemCountText = if (isArtist) null else "${episodes.size} ${if (item.type == "Playlist") "Items" else "Tracks"}"
+        val totalSec = item.durationSeconds.takeIf { it > 0 }
+          ?: episodes.sumOf { it.durationSeconds }.takeIf { it > 0 }
+        val durationFormatted = totalSec?.let { DateUtils.formatElapsedTime(it) }
+        val countText = if (isArtist) null else "${episodes.size} ${if (item.type == "Playlist") "Items" else "Tracks"}"
+        val itemCountText = listOfNotNull(countText, durationFormatted).joinToString(" • ").takeIf { it.isNotBlank() }
 
         SharedMusicDetailHeader(
           title = item.name,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinMusicView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinMusicView.kt
@@ -438,7 +438,7 @@ fun JellyfinMusicView(
                   }
                   SharedMusicGridCard(
                     title = playlist.name,
-                    subtitle = playlist.childCount?.let { if (it == 1) "1 track" else "$it tracks" } ?: "",
+                    subtitle = formatJellyfinPlaylistSubtitle(playlist),
                     artworkUrl = imageUrl,
                     fallbackIcon = if (playlist.id == "virtual_favorites_playlist" || playlist.id == "favorites") Icons.RoundedFilled.Favorite else Icons.RoundedFilled.QueueMusic,
                     onClick = { onItemClick(playlist) },
@@ -466,6 +466,7 @@ fun JellyfinMusicView(
                   SharedMusicTrackListItem(
                     title = playlist.name,
                     subtitle = playlist.childCount?.let { if (it == 1) "1 track" else "$it tracks" },
+                    durationSeconds = playlist.durationSeconds.takeIf { it > 0 },
                     artworkUrl = imageUrl,
                     fallbackIcon = if (playlist.id == "virtual_favorites_playlist" || playlist.id == "favorites") Icons.RoundedFilled.Favorite else Icons.RoundedFilled.QueueMusic,
                     coverArtSizeDp = coverArtSizeDp,
@@ -596,7 +597,7 @@ fun JellyfinPlaylistsRowSection(
     items = playlists,
     getId = { it.id },
     getTitle = { it.name },
-    getSubtitle = { it.seriesName ?: it.overview ?: "" },
+    getSubtitle = { formatJellyfinPlaylistSubtitle(it) },
     getArtworkUrl = { playlist ->
       if (!playlist.primaryImageTag.isNullOrBlank()) {
         JellyfinClient.getImageUrl(
@@ -706,7 +707,11 @@ fun JellyfinMusicCard(
     )
   }
   val isArtist = item.type == "MusicArtist" || item.type == "Artist" || item.type == "AlbumArtist"
-  val subtitle = if (isArtist) "" else (item.seriesName ?: item.overview ?: "")
+  val subtitle = when {
+    isArtist -> ""
+    item.type == "Playlist" -> formatJellyfinPlaylistSubtitle(item)
+    else -> item.seriesName ?: item.overview ?: ""
+  }
 
   SharedMusicGridCard(
     title = item.name,
@@ -725,3 +730,11 @@ fun JellyfinMusicCard(
     modifier = modifier,
   )
 }
+
+private fun formatJellyfinPlaylistSubtitle(playlist: JellyfinItem): String {
+  val countStr = playlist.childCount?.let { if (it == 1) "1 track" else "$it tracks" }
+  val durationStr = playlist.durationSeconds.takeIf { it > 0 }?.let { DateUtils.formatElapsedTime(it) }
+  val parts = listOfNotNull(countStr, durationStr)
+  return if (parts.isNotEmpty()) parts.joinToString(" • ") else (playlist.seriesName ?: playlist.overview ?: "")
+}
+

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -340,9 +340,10 @@ class JellyfinViewModel(
         val topRatedRaw = topRatedResult.getOrNull()?.items ?: emptyList()
         val musicRaw = musicResult.getOrNull()?.items ?: emptyList()
 
-        // Helper filter to exclude music and folders from general video home sections
+        // Helper filter to exclude music and pure folders from general video home sections
         fun isVideoMedia(item: JellyfinItem): Boolean {
-          if (item.isAudio || item.isFolder || item.type == "Folder" || item.type == "MusicAlbum" || item.type == "Audio" || item.type == "MusicArtist" || item.type == "CollectionFolder") return false
+          if (item.isAudio || item.type == "Folder" || item.type == "MusicAlbum" || item.type == "Audio" || item.type == "MusicArtist" || item.type == "CollectionFolder") return false
+          if (item.isFolder && !item.isSeries && !item.isSeason && item.type != "Series" && item.type != "Season") return false
           return true
         }
 
@@ -359,8 +360,21 @@ class JellyfinViewModel(
               limit = 16,
               groupItems = true,
             )
-            val rawItems = latestItemsResult.getOrDefault(emptyList()).filter { isVideoMedia(it) }
-            val containsShows = rawItems.any { it.isSeries || it.type == "Episode" || it.seriesName != null }
+            var rawItems = latestItemsResult.getOrDefault(emptyList()).filter { isVideoMedia(it) }
+
+            // Fallback: If getLatestMedia with ParentId returned empty, fetch latest items sorted by DateCreated
+            if (rawItems.isEmpty()) {
+              val fallbackItemsResult = jellyfinRepository.getItems(
+                server = server,
+                parentId = lib.id,
+                sortBy = JellyfinSortBy.DATE_ADDED,
+                sortOrder = JellyfinSortOrder.DESCENDING,
+                limit = 16,
+              )
+              rawItems = fallbackItemsResult.getOrNull()?.items.orEmpty().filter { isVideoMedia(it) }
+            }
+
+            val containsShows = rawItems.any { it.isSeries || it.type == "Series" || it.type == "Episode" || it.seriesName != null }
             val isShows = isShowLib || containsShows
 
             val processedItems = if (isShows) {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -47,7 +47,9 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import app.gyrolet.mpvrx.utils.media.PlaybackStateEvents
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -169,6 +171,51 @@ class JellyfinViewModel(
 
   init {
     loadServers()
+    viewModelScope.launch(Dispatchers.IO) {
+      PlaybackStateEvents.changes.collectLatest {
+        refreshPlaybackStateSilently()
+      }
+    }
+  }
+
+  fun refreshPlaybackStateSilently() {
+    val server = _uiState.value.activeServer ?: return
+    viewModelScope.launch(Dispatchers.IO) {
+      delay(400) // Brief delay to ensure Jellyfin server has committed the stop/progress session data
+      val resumeResult = jellyfinRepository.getResumeItems(server, limit = 16).getOrNull()
+      if (resumeResult != null) {
+        _uiState.update { it.copy(resumeItems = resumeResult) }
+      }
+
+      val detail = _uiState.value.detailItem
+      if (detail != null) {
+        val updatedDetail = jellyfinRepository.getItem(server, detail.id).getOrNull()
+        if (updatedDetail != null) {
+          _uiState.update { it.copy(detailItem = updatedDetail) }
+        }
+        val seasonId = _uiState.value.selectedDetailSeasonId
+        if (seasonId != null) {
+          val episodes = jellyfinRepository.getEpisodes(server, detail.id, seasonId).getOrNull()
+          if (episodes != null) {
+            _uiState.update { it.copy(detailEpisodes = episodes) }
+          }
+        }
+      }
+
+      val openLib = _uiState.value.openLibrary
+      if (openLib != null && _uiState.value.currentItems.isNotEmpty()) {
+        val updatedItems = jellyfinRepository.getItems(
+          server = server,
+          parentId = openLib.id,
+          limit = _uiState.value.currentItems.size.coerceAtLeast(50),
+          sortBy = _uiState.value.sortBy,
+          sortOrder = _uiState.value.sortOrder,
+        ).getOrNull()
+        if (updatedItems != null && updatedItems.items.isNotEmpty()) {
+          _uiState.update { it.copy(currentItems = updatedItems.items) }
+        }
+      }
+    }
   }
 
   fun loadServers() {

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -1792,6 +1792,7 @@ class JellyfinViewModel(
       val externalSubs = subsDeferred.await()
 
       var playlistArtists: List<String> = emptyList()
+      var playlistDurations: List<Int> = emptyList()
       val playlistData =
         if (isAudio) {
           val audioSource =
@@ -1833,6 +1834,7 @@ class JellyfinViewModel(
             val titles = ArrayList<String>(audioSource.size)
             val artworks = ArrayList<String>(audioSource.size)
             playlistArtists = audioSource.map { track -> track.seriesName ?: targetItem.seriesName ?: "" }
+            playlistDurations = audioSource.map { it.durationSeconds.toInt() }
             var targetIdx = 0
             audioSource.forEachIndexed { idx, track ->
               if (track.id == targetItem.id) targetIdx = idx
@@ -1855,6 +1857,7 @@ class JellyfinViewModel(
           if (episodesSource.size > 1) {
             val uris = ArrayList<Uri>(episodesSource.size)
             val titles = ArrayList<String>(episodesSource.size)
+            playlistDurations = episodesSource.map { it.durationSeconds.toInt() }
             var targetIdx = 0
             episodesSource.forEachIndexed { index, ep ->
               if (ep.id == targetItem.id) targetIdx = index
@@ -1877,6 +1880,10 @@ class JellyfinViewModel(
 
       val (playlistUris, playlistTitles, playlistIndex) = playlistData.first
       val playlistArtworkUrls = playlistData.second
+
+      if (playlistDurations.isEmpty()) {
+        playlistDurations = listOf(targetItem.durationSeconds.toInt())
+      }
 
       val headers =
         mapOf(
@@ -1901,6 +1908,7 @@ class JellyfinViewModel(
           playlistArtists = playlistArtists,
           playlistArtworkUrls = playlistArtworkUrls,
           isAudio = isAudio,
+          playlistDurationsSeconds = playlistDurations,
         )
       }
     }
@@ -2005,6 +2013,7 @@ class JellyfinViewModel(
           playlistArtists = if (isAudio) playable.map { it.seriesName.orEmpty() } else emptyList(),
           playlistArtworkUrls = playlistArtworks,
           isAudio = isAudio,
+          playlistDurationsSeconds = playable.map { it.durationSeconds.toInt() },
         )
       }
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/jellyfin/JellyfinViewModel.kt
@@ -607,13 +607,27 @@ class JellyfinViewModel(
     }
   }
 
-  fun ensureMusicLibraryOpened() {
+  fun getMusicLibraryView(): JellyfinLibraryView? {
+    val musicItem = _uiState.value.libraries.firstOrNull { isMusicLibrary(it) } ?: return null
+    return JellyfinLibraryView(
+      id = musicItem.id,
+      title = musicItem.name,
+      itemTypes = "Audio",
+      collectionType = musicItem.collectionType,
+      isMusic = true,
+    )
+  }
+
+  fun ensureMusicDataLoaded() {
     val active = _uiState.value.activeServer ?: return
-    if (_uiState.value.openLibrary?.isMusic == true) return
-    val musicLib = _uiState.value.libraries.firstOrNull { isMusicLibrary(it) }
-    if (musicLib != null) {
-      navigateToItem(musicLib)
+    val musicLib = getMusicLibraryView() ?: return
+    if (loadedMusicHomeLibraryId != musicLib.id) {
+      loadMusicHomeDashboard(active, musicLib)
     }
+  }
+
+  fun ensureMusicLibraryOpened() {
+    ensureMusicDataLoaded()
   }
 
   fun setGenreFilter(genre: String?) {
@@ -787,7 +801,7 @@ class JellyfinViewModel(
     if (_uiState.value.musicActiveTab == tab) return
     _uiState.update { it.copy(musicActiveTab = tab) }
     val active = _uiState.value.activeServer ?: return
-    val library = _uiState.value.openLibrary ?: return
+    val library = _uiState.value.openLibrary ?: getMusicLibraryView() ?: return
 
     if (tab == JellyfinMusicTab.HOME) {
       if (loadedMusicHomeLibraryId != library.id) loadMusicHomeDashboard(active, library)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -341,6 +341,12 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
         durationSeconds = (item.duration / 1000L).toInt().takeIf { it > 0 },
       )
     }
+    val isAudio = mediaType == MediaLibraryType.Audio || video.isAudio
+    if (MediaUtils.shouldPlayInMiniPlayerOnly(isAudio)) {
+      MediaUtils.playInMiniPlayer(context, queueItems, index)
+      return
+    }
+
     val launchToken = PreparedPlaybackLaunchStore.stage(
       items = queueItems,
       currentIndex = index,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/medialibrary/MediaLibraryContent.kt
@@ -338,6 +338,7 @@ fun MediaLibraryContent(forceAudio: Boolean = false) {
         stableId = PlaybackIdentity.forLocalPath(item.path),
         title = item.displayName,
         mimeType = item.mimeType,
+        durationSeconds = (item.duration / 1000L).toInt().takeIf { it > 0 },
       )
     }
     val launchToken = PreparedPlaybackLaunchStore.stage(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
@@ -325,6 +325,7 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
         artist = item.artist,
         mimeType = "audio/*",
         artworkUri = item.albumArtUri?.toString(),
+        durationSeconds = (item.durationMs / 1000L).toInt().takeIf { it > 0 },
       )
     }
     val launchToken = PreparedPlaybackLaunchStore.stage(
@@ -360,6 +361,7 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
         artist = item.artist,
         mimeType = "audio/*",
         artworkUri = item.albumArtUri?.toString(),
+        durationSeconds = (item.durationMs / 1000L).toInt().takeIf { it > 0 },
       )
     }
     val launchToken = PreparedPlaybackLaunchStore.stage(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/music/MusicLibraryViewModel.kt
@@ -36,6 +36,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 import app.gyrolet.mpvrx.utils.media.MediaLibraryEvents
+import app.gyrolet.mpvrx.utils.media.MediaUtils
 import kotlinx.coroutines.flow.collectLatest
 
 class MusicLibraryViewModel : ViewModel(), KoinComponent {
@@ -328,6 +329,11 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
         durationSeconds = (item.durationMs / 1000L).toInt().takeIf { it > 0 },
       )
     }
+    if (MediaUtils.shouldPlayInMiniPlayerOnly(isAudio = true)) {
+      MediaUtils.playInMiniPlayer(context, queueItems, index)
+      return
+    }
+
     val launchToken = PreparedPlaybackLaunchStore.stage(
       items = queueItems,
       currentIndex = index,
@@ -364,6 +370,11 @@ class MusicLibraryViewModel : ViewModel(), KoinComponent {
         durationSeconds = (item.durationMs / 1000L).toInt().takeIf { it > 0 },
       )
     }
+    if (MediaUtils.shouldPlayInMiniPlayerOnly(isAudio = true)) {
+      MediaUtils.playInMiniPlayer(context, queueItems, 0)
+      return
+    }
+
     val launchToken = PreparedPlaybackLaunchStore.stage(
       items = queueItems,
       currentIndex = 0,

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/navidrome/NavidromeDetailSheet.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/navidrome/NavidromeDetailSheet.kt
@@ -9,6 +9,7 @@
 
 package app.gyrolet.mpvrx.ui.browser.navidrome
 
+import android.text.format.DateUtils
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -180,10 +181,16 @@ fun NavidromeDetailSheet(
               .fillMaxWidth()
               .padding(horizontal = 16.dp, vertical = 8.dp),
           ) {
+            val playlistDuration = playlist.durationSeconds.takeIf { it > 0 }
+              ?: playlist.songs.sumOf { it.durationSeconds }.takeIf { it > 0 }
+            val playlistDurationFormatted = playlistDuration?.let { DateUtils.formatElapsedTime(it.toLong()) }
+            val countText = if (playlist.songCount == 1) "1 track" else "${playlist.songCount.coerceAtLeast(playlist.songs.size)} tracks"
+            val itemCountText = listOfNotNull(countText, playlistDurationFormatted).joinToString(" • ")
+
             SharedMusicDetailHeader(
               title = playlist.name,
               subtitle = null,
-              itemCountText = "${playlist.songCount} tracks",
+              itemCountText = itemCountText,
               artworkUrl = navidromeRepository.getCoverArtUrl(server, playlist.coverArtId, size = 300),
               fallbackIcon = if (playlist.id == "virtual_favorites_playlist" || playlist.id == "favorites") Icons.RoundedFilled.Favorite else Icons.RoundedFilled.QueueMusic,
               onPlayAll = { viewModel.playAll(context, playlist.songs, 0) },

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/navidrome/NavidromeMusicView.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/navidrome/NavidromeMusicView.kt
@@ -330,7 +330,7 @@ fun NavidromeMusicView(
                 items(sortedPlaylists, key = { it.id }) { playlist ->
                   SharedMusicGridCard(
                     title = playlist.name,
-                    subtitle = "${playlist.songCount} tracks",
+                    subtitle = formatNavidromePlaylistSubtitle(playlist),
                     artworkUrl = navidromeRepository.getCoverArtUrl(server, playlist.coverArtId),
                     fallbackIcon = if (playlist.id == "virtual_favorites_playlist" || playlist.id == "favorites") Icons.RoundedFilled.Favorite else Icons.RoundedFilled.QueueMusic,
                     onClick = { onPlaylistClick(playlist) },
@@ -345,8 +345,8 @@ fun NavidromeMusicView(
                 items(sortedPlaylists, key = { it.id }) { playlist ->
                   SharedMusicTrackListItem(
                     title = playlist.name,
-                    subtitle = "${playlist.songCount} tracks",
-                    durationSeconds = playlist.durationSeconds.toLong(),
+                    subtitle = if (playlist.songCount == 1) "1 track" else "${playlist.songCount} tracks",
+                    durationSeconds = playlist.durationSeconds.takeIf { it > 0 }?.toLong(),
                     artworkUrl = navidromeRepository.getCoverArtUrl(server, playlist.coverArtId),
                     fallbackIcon = if (playlist.id == "virtual_favorites_playlist" || playlist.id == "favorites") Icons.RoundedFilled.Favorite else Icons.RoundedFilled.QueueMusic,
                     coverArtSizeDp = coverArtSizeDp,
@@ -403,7 +403,7 @@ private fun NavidromeHomeContent(
           items = uiState.playlists,
           getId = { it.id },
           getTitle = { it.name },
-          getSubtitle = { "${it.songCount} tracks" },
+          getSubtitle = { formatNavidromePlaylistSubtitle(it) },
           getArtworkUrl = { navidromeRepository.getCoverArtUrl(server, it.coverArtId) },
           fallbackIcon = Icons.RoundedFilled.QueueMusic,
           getFallbackIcon = { if (it.id == "virtual_favorites_playlist" || it.id == "favorites") Icons.RoundedFilled.Favorite else Icons.RoundedFilled.QueueMusic },
@@ -450,4 +450,10 @@ private fun NavidromeHomeContent(
       }
     }
   }
+}
+
+private fun formatNavidromePlaylistSubtitle(playlist: NavidromePlaylist): String {
+  val countStr = if (playlist.songCount == 1) "1 track" else "${playlist.songCount} tracks"
+  val durationStr = playlist.durationSeconds.takeIf { it > 0 }?.let { DateUtils.formatElapsedTime(it.toLong()) }
+  return listOfNotNull(countStr, durationStr).joinToString(" • ")
 }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/navidrome/NavidromeViewModel.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/navidrome/NavidromeViewModel.kt
@@ -322,6 +322,7 @@ class NavidromeViewModel(
       playlistArtists = playlistArtists,
       playlistArtworkUrls = playlistArtworkUrls,
       isAudio = true,
+      playlistDurationsSeconds = songs.map { it.durationSeconds },
     )
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistDetailScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/browser/playlist/PlaylistDetailScreen.kt
@@ -81,6 +81,8 @@ import app.gyrolet.mpvrx.ui.browser.selection.rememberSelectionManager
 import app.gyrolet.mpvrx.ui.components.InlineSearchBar
 import app.gyrolet.mpvrx.ui.icons.Icon
 import app.gyrolet.mpvrx.ui.icons.Icons
+import app.gyrolet.mpvrx.ui.player.PlaybackIdentity
+import app.gyrolet.mpvrx.ui.player.PlaybackItem
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.utils.LocalBackStack
 import app.gyrolet.mpvrx.ui.utils.navigateTo
@@ -247,6 +249,30 @@ data class PlaylistDetailScreen(
       item: PlaylistVideoItem,
       startIndex: Int,
     ) {
+      val isAudio = item.video.isAudio || (playlist?.isAudio == true)
+      if (MediaUtils.shouldPlayInMiniPlayerOnly(isAudio)) {
+        val queueItems =
+          filteredVideoItems.map { playlistEntry ->
+            val fallback = Uri.parse(playlistEntry.video.path)
+            val uri =
+              playlistEntry.video.uri.takeIf { it != Uri.EMPTY && it.toString().isNotBlank() }
+                ?: fallback.takeIf { !it.scheme.isNullOrBlank() }
+                ?: Uri.fromFile(java.io.File(playlistEntry.video.path))
+            val headerExtra = buildM3UHeadersExtra(playlist, playlistEntry.playlistItem)
+            val headersMap = headerExtra?.let { mapOf(it[0] to it[1]) }.orEmpty()
+            PlaybackItem.fromUri(
+              uri = uri.toString(),
+              stableId = playlistEntry.video.path.takeIf(String::isNotBlank)?.let(PlaybackIdentity::forLocalPath),
+              title = playlistEntry.playlistItem.fileName,
+              mimeType = if (isAudio) "audio/*" else playlistEntry.video.mimeType,
+              headers = headersMap,
+              durationSeconds = (playlistEntry.video.duration / 1000L).toInt().takeIf { it > 0 },
+            )
+          }
+        MediaUtils.playInMiniPlayer(context, queueItems, startIndex)
+        return
+      }
+
       val fallbackUri = Uri.parse(item.video.path)
       val playUri =
         item.video.uri.takeIf { it != Uri.EMPTY && it.toString().isNotBlank() }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/PlayerActivity.kt
@@ -3928,8 +3928,12 @@ class PlayerActivity :
     }.onFailure { /* Silently ignore PiP update failures */ }
 
     jellyfinSessionReporter?.let { reporter ->
-      val currentPosMs = (viewModel.pos ?: 0).toLong() * 1000L
-      reporter.reportPlaybackProgress(currentPosMs, isPaused)
+      val currentPosMs = readMpvIntSeconds("time-pos", viewModel.pos ?: 0).toLong() * 1000L
+      reporter.reportPlaybackProgress(
+        positionMs = currentPosMs,
+        isPaused = isPaused,
+        eventName = if (isPaused) "Pause" else "Unpause",
+      )
     }
   }
 
@@ -4277,8 +4281,17 @@ class PlayerActivity :
 
     reportJellyfinStop()
     currentUri?.toString()?.let { url ->
-      jellyfinSessionReporter = JellyfinSessionReporter.create(url, lifecycleScope, networkHttpClient)
-      jellyfinSessionReporter?.reportPlaybackStart((viewModel.pos ?: 0).toLong() * 1000L)
+      val tokenFromHeader =
+        networkPlaylistHeaders.getOrNull(playlistIndex)?.get("X-Emby-Token")
+          ?: intent.getStringArrayExtra("headers")?.let { PlaybackHttpHeaders.fromFlatPairs(it)["X-Emby-Token"] }
+      jellyfinSessionReporter =
+        JellyfinSessionReporter.create(
+          url = url,
+          httpClient = networkHttpClient,
+          fallbackToken = tokenFromHeader,
+        )
+      val initialPosMs = readMpvIntSeconds("time-pos", viewModel.pos ?: 0).toLong() * 1000L
+      jellyfinSessionReporter?.reportPlaybackStart(initialPosMs)
       startJellyfinProgressLoop()
     }
 
@@ -4317,6 +4330,14 @@ class PlayerActivity :
         }
       } finally {
         PlaybackSession.completePositionRestore(loadGeneration)
+        val restoredPosMs = readMpvIntSeconds("time-pos", viewModel.pos ?: 0).toLong() * 1000L
+        if (restoredPosMs > 0) {
+          jellyfinSessionReporter?.reportPlaybackProgress(
+            positionMs = restoredPosMs,
+            isPaused = viewModel.paused ?: false,
+            eventName = "TimeUpdate",
+          )
+        }
       }
     }
 
@@ -4736,9 +4757,13 @@ class PlayerActivity :
         while (isActive) {
           delay(10000) // Report progress every 10 seconds
           val reporter = jellyfinSessionReporter ?: continue
-          val currentPosMs = (viewModel.pos ?: 0).toLong() * 1000L
+          val currentPosMs = readMpvIntSeconds("time-pos", viewModel.pos ?: 0).toLong() * 1000L
           val isPaused = viewModel.paused ?: false
-          reporter.reportPlaybackProgress(currentPosMs, isPaused)
+          reporter.reportPlaybackProgress(
+            positionMs = currentPosMs,
+            isPaused = isPaused,
+            eventName = "TimeUpdate",
+          )
         }
       }
   }
@@ -4747,7 +4772,7 @@ class PlayerActivity :
     jellyfinProgressJob?.cancel()
     jellyfinProgressJob = null
     jellyfinSessionReporter?.let { reporter ->
-      val currentPosMs = (viewModel.pos ?: 0).toLong() * 1000L
+      val currentPosMs = readMpvIntSeconds("time-pos", viewModel.pos ?: 0).toLong() * 1000L
       reporter.reportPlaybackStop(currentPosMs)
       jellyfinSessionReporter = null
     }

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -614,12 +614,40 @@ fun AudioPlayerControls(
   val audioFormat by PlaybackSession.propString["audio-params/format"].collectAsState()
   val bitsPerSample by PlaybackSession.propString["metadata/by-key/BITS_PER_SAMPLE"].collectAsState()
   val bitsPerSampleAlt by PlaybackSession.propString["metadata/by-key/bits_per_sample"].collectAsState()
+  val audioBitrateProp by PlaybackSession.propInt["audio-bitrate"].collectAsState()
+  val generalBitrateProp by PlaybackSession.propInt["bitrate"].collectAsState()
   val playbackSpeed by PlaybackSession.propFloat["speed"].collectAsState()
+
+  val cleanCodecName =
+    remember(audioCodec, mediaPath) {
+      val codec = audioCodec?.lowercase().orEmpty()
+      val rawExt = mediaPath?.fileExtension().orEmpty().lowercase()
+      val ext = if (rawExt in app.gyrolet.mpvrx.utils.storage.FileTypeUtils.AUDIO_EXTENSIONS) rawExt.uppercase() else ""
+      when {
+        codec.contains("flac") -> "FLAC"
+        codec.contains("alac") -> "ALAC"
+        codec.contains("mp3") -> "MP3"
+        codec.contains("aac") -> "AAC"
+        codec.contains("opus") -> "OPUS"
+        codec.contains("vorbis") -> "VORBIS"
+        codec.contains("wavpack") -> "WAVPACK"
+        codec.contains("ape") -> "APE"
+        codec.contains("dsd") -> "DSD"
+        codec.contains("pcm") -> if (ext in setOf("WAV", "AIFF", "AIF")) ext else "PCM"
+        codec.contains("wma") -> "WMA"
+        codec.isNotBlank() && codec.length <= 10 && !codec.contains("/") && !codec.contains(":") -> {
+          codec.replace("float", "").replace("_latm", "").uppercase().trim()
+        }
+        ext.isNotBlank() -> ext
+        else -> ""
+      }
+    }
 
   val isLosslessCodecOrExt =
     remember(audioCodec, mediaPath) {
       val codec = audioCodec?.lowercase().orEmpty()
-      val ext = mediaPath?.fileExtension().orEmpty()
+      val rawExt = mediaPath?.fileExtension().orEmpty().lowercase()
+      val ext = if (rawExt in app.gyrolet.mpvrx.utils.storage.FileTypeUtils.AUDIO_EXTENSIONS) rawExt else ""
       codec.contains("flac") ||
         codec.contains("alac") ||
         codec.contains("pcm") ||
@@ -641,9 +669,28 @@ fun AudioPlayerControls(
     showLosslessDetails = false
   }
 
+  val collapsedAudioBadgeLabel =
+    remember(isHiRes, isLosslessCodecOrExt, cleanCodecName) {
+      when {
+        isHiRes -> "HI-RES LOSSLESS"
+        isLosslessCodecOrExt -> "LOSSLESS"
+        cleanCodecName.isNotBlank() -> cleanCodecName
+        else -> ""
+      }
+    }
+
   val fullLosslessDetailString =
-    remember(isHiRes, sampleRate, audioFormat, bitsPerSample, bitsPerSampleAlt, audioCodec, isLosslessCodecOrExt) {
-      val baseLabel = if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS"
+    remember(
+      isHiRes,
+      isLosslessCodecOrExt,
+      sampleRate,
+      audioFormat,
+      bitsPerSample,
+      bitsPerSampleAlt,
+      audioBitrateProp,
+      generalBitrateProp,
+      cleanCodecName,
+    ) {
       val sr = sampleRate ?: 0
       val khzStr =
         if (sr > 0) {
@@ -652,6 +699,9 @@ fun AudioPlayerControls(
         } else {
           ""
         }
+
+      val bitrateInt = (audioBitrateProp?.takeIf { it > 0 } ?: generalBitrateProp?.takeIf { it > 0 } ?: 0)
+      val kbpsStr = if (bitrateInt > 0) "${bitrateInt / 1000} kbps" else ""
 
       val bps = bitsPerSample?.takeIf { it.isNotBlank() } ?: bitsPerSampleAlt?.takeIf { it.isNotBlank() }
       val bitStr =
@@ -666,22 +716,37 @@ fun AudioPlayerControls(
           else -> ""
         }
 
-      val specsStr =
-        when {
-          bitStr.isNotBlank() && khzStr.isNotBlank() -> "$bitStr/$khzStr"
-          khzStr.isNotBlank() -> khzStr
-          bitStr.isNotBlank() -> bitStr
-          else -> ""
+      if (isLosslessCodecOrExt) {
+        val baseLabel = if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS"
+        val specsCore =
+          when {
+            bitStr.isNotBlank() && khzStr.isNotBlank() -> "$bitStr/$khzStr"
+            khzStr.isNotBlank() -> khzStr
+            bitStr.isNotBlank() -> bitStr
+            else -> ""
+          }
+        buildString {
+          append(baseLabel)
+          if (specsCore.isNotBlank()) {
+            append(" - ").append(specsCore)
+          }
+          if (cleanCodecName.isNotBlank()) {
+            append(" ").append(cleanCodecName)
+          }
         }
-
-      val codecName = audioCodec?.uppercase().orEmpty()
-      buildString {
-        append(baseLabel)
-        if (specsStr.isNotBlank()) {
-          append(" - ").append(specsStr)
-        }
-        if (codecName.isNotBlank()) {
-          append(" ").append(codecName)
+      } else {
+        val baseLabel = cleanCodecName.ifBlank { "AUDIO" }
+        val specs =
+          when {
+            kbpsStr.isNotBlank() && khzStr.isNotBlank() -> "$kbpsStr/$khzStr"
+            kbpsStr.isNotBlank() -> kbpsStr
+            khzStr.isNotBlank() -> khzStr
+            else -> ""
+          }
+        if (specs.isNotBlank()) {
+          "$baseLabel - $specs"
+        } else {
+          baseLabel
         }
       }
     }
@@ -1110,7 +1175,7 @@ fun AudioPlayerControls(
     }
 
     val losslessBadge = @Composable {
-      if (isLosslessCodecOrExt) {
+      if (collapsedAudioBadgeLabel.isNotBlank()) {
         Surface(
           shape = RoundedCornerShape(4.dp),
           color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
@@ -1128,7 +1193,7 @@ fun AudioPlayerControls(
               if (showLosslessDetails && fullLosslessDetailString.isNotBlank()) {
                 fullLosslessDetailString
               } else {
-                if (isHiRes) "HI-RES LOSSLESS" else "LOSSLESS"
+                collapsedAudioBadgeLabel
               },
             style =
               MaterialTheme.typography.labelSmall.copy(

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/AudioPlayerControls.kt
@@ -779,7 +779,14 @@ fun AudioPlayerControls(
   }
 
    val isPlaying = paused == false
-   val currentDurSec = if (preciseDuration > 0f) preciseDuration else duration?.toFloat() ?: 0f
+   val currentDurSec =
+     if (preciseDuration > 0f) {
+       preciseDuration
+     } else if ((duration ?: 0) > 0) {
+       duration!!.toFloat()
+     } else {
+       currentItem?.durationSeconds?.takeIf { it > 0 }?.toFloat() ?: 0f
+     }
    val currentVolumePercent by viewModel.currentVolumePercent.collectAsState()
    val volumeScale = currentVolumePercent / 100f
    val visualizerFeatures = rememberAudioVisualizerFeatures(isPlaying, volumeScale)
@@ -1610,12 +1617,15 @@ fun AudioPlayerControls(
       val precisePosition by viewModel.precisePosition.collectAsStateWithLifecycle()
       val currentPosSec = if (precisePosition > 0f) precisePosition else position?.toFloat() ?: 0f
       val isPaused = paused ?: false
+      val effectiveRemaining =
+        (remaining ?: 0f).takeIf { it > 0f }
+          ?: (currentDurSec - currentPosSec).coerceAtLeast(0f)
 
       SeekbarWithTimers(
         position = currentPosSec,
         committedPosition = currentPosSec,
         duration = currentDurSec.coerceAtLeast(1f),
-        remaining = remaining ?: 0f,
+        remaining = effectiveRemaining,
         onValueChange = { value -> viewModel.seekPreviewTo(value) },
         onValueChangeFinished = { targetPosition -> viewModel.seekTo(targetPosition.toInt(), fast = false) },
         timersInverted = Pair(false, invertDuration),
@@ -2055,7 +2065,7 @@ fun AudioPlayerControls(
             displayName = displayTitle,
             path = mediaPath,
             uri = Uri.parse(mediaPath),
-            duration = duration?.toLong() ?: 0L,
+            duration = duration?.toLong() ?: currentItem?.durationSeconds?.toLong() ?: 0L,
             durationFormatted = "",
             size = 0L,
             sizeFormatted = "",

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/GestureHandler.kt
@@ -1265,9 +1265,6 @@ fun GestureHandler(
                         hasStartedSeeking = true
                         initialVideoPosition = position?.toFloat() ?: 0f
                         pendingSeekPosition = initialVideoPosition
-
-                        // Show seekbar and start seeking mode (same as seekbar scrubbing)
-                        viewModel.showSeekBar()
                         change.consume()
                       }
                     }
@@ -1310,9 +1307,6 @@ fun GestureHandler(
                   hasStartedSeeking = false
                   // Clean up seeking state without showing controls
                   viewModel.playerUpdate.update { PlayerUpdates.None }
-                  if (gestureType == "horizontal_seek") {
-                    viewModel.hideSeekBar()
-                  }
                 }
                 releaseGesture(GestureOwner.HORIZONTAL_SEEK)
                 releaseGesture(GestureOwner.SUBTITLE_SEEK)
@@ -1323,18 +1317,9 @@ fun GestureHandler(
             // Apply the final seek when gesture ends
             if (hasStartedSeeking) {
               pendingSeekPosition?.let { viewModel.seekTo(it.toInt()) }
-              if (gestureType == "subtitle_dialog_seek") {
-                coroutineScope.launch {
-                  delay(300)
-                  viewModel.playerUpdate.update { PlayerUpdates.None }
-                }
-              } else {
-                // Clear the horizontal seek update and hide seekbar after a short delay
-                coroutineScope.launch {
-                  delay(300)
-                  viewModel.playerUpdate.update { PlayerUpdates.None }
-                  viewModel.hideSeekBar()
-                }
+              coroutineScope.launch {
+                delay(300)
+                viewModel.playerUpdate.update { PlayerUpdates.None }
               }
             }
             releaseGesture(GestureOwner.HORIZONTAL_SEEK)

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/player/controls/PlayerControls.kt
@@ -230,9 +230,17 @@ fun PlayerControls(
   val preciseDuration by viewModel.preciseDuration.collectAsState()
   val scopeAudioTracks by viewModel.audioTracks.collectAsState(persistentListOf())
   val mediaScopesState by viewModel.mediaScopesUiState.collectAsState()
+  val currentQueueItem = playbackSessionState.currentItem ?: playbackQueue.currentItem
   val demuxerCacheTime by PlaybackSession.propDouble["demuxer-cache-time"].collectAsState()
   val playbackSpeed by PlaybackSession.propFloat["speed"].collectAsState()
-  val seekbarDuration = if (preciseDuration > 0) preciseDuration else duration?.toFloat() ?: 0f
+  val seekbarDuration =
+    if (preciseDuration > 0) {
+      preciseDuration
+    } else if ((duration ?: 0) > 0) {
+      duration!!.toFloat()
+    } else {
+      currentQueueItem?.durationSeconds?.takeIf { it > 0 }?.toFloat() ?: 0f
+    }
   val seekState by viewModel.seekState.collectAsState()
   val brightness by viewModel.currentBrightness.collectAsState()
   val doubleTapSeekAmount = seekState.amount
@@ -1704,11 +1712,15 @@ is PlayerUpdates.FrameInfo -> {
               }
             val skipSegmentsImmutable = remember(skipSegments) { skipSegments.toImmutableList() }
 
+            val effectiveRemaining =
+              (remaining ?: 0f).takeIf { it > 0f }
+                ?: (seekbarDuration - displayedSeekbarPosition).coerceAtLeast(0f)
+
             SeekbarWithTimers(
               position = displayedSeekbarPosition,
               committedPosition = precisePosition,
-              duration = if (preciseDuration > 0) preciseDuration else duration?.toFloat() ?: 0f,
-              remaining = remaining ?: 0f,
+              duration = seekbarDuration,
+              remaining = effectiveRemaining,
               onValueChange = {
                 isSeeking = true
                 resetControlsTimestamp = System.currentTimeMillis()

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AudioPreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/AudioPreferencesScreen.kt
@@ -520,6 +520,21 @@ object AudioPreferencesScreen : Screen {
               )
 
               PreferenceDivider()
+              val miniPlayerTrackSwitching by preferences.miniPlayerTrackSwitching.collectAsState()
+              SwitchPreference(
+                modifier = Modifier.settingsSearchTarget(R.string.pref_audio_mini_player_track_switching_title),
+                value = miniPlayerTrackSwitching,
+                onValueChange = preferences.miniPlayerTrackSwitching::set,
+                title = { Text(stringResource(R.string.pref_audio_mini_player_track_switching_title)) },
+                summary = {
+                  Text(
+                    stringResource(R.string.pref_audio_mini_player_track_switching_summary),
+                    color = MaterialTheme.colorScheme.outline,
+                  )
+                },
+              )
+
+              PreferenceDivider()
               val autoplayNextAudio by playerPreferences.autoplayNextAudio.collectAsState()
               SwitchPreference(
                 modifier = Modifier.settingsSearchTarget(R.string.pref_autoplay_next_audio_title),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/PlayerPreferencesScreen.kt
@@ -260,26 +260,6 @@ val savePositionOnQuit by preferences.savePositionOnQuit.collectAsState()
 
               PreferenceDivider()
 
-              val autoplayNextAudio by preferences.autoplayNextAudio.collectAsState()
-              SwitchPreference(
-                modifier = Modifier.settingsSearchTarget(R.string.pref_autoplay_next_audio_title),
-                value = autoplayNextAudio,
-                onValueChange = preferences.autoplayNextAudio::set,
-                title = { Text(stringResource(R.string.pref_autoplay_next_audio_title)) },
-                summary = {
-                  Text(
-                    if (autoplayNextAudio) {
-                      stringResource(R.string.pref_autoplay_next_audio_summary)
-                    } else {
-                      stringResource(R.string.pref_autoplay_next_audio_summary_disabled)
-                    },
-                    color = MaterialTheme.colorScheme.outline,
-                  )
-                },
-              )
-
-              PreferenceDivider()
-
               val playlistMode by preferences.playlistMode.collectAsState()
               SwitchPreference(
                 modifier = Modifier.settingsSearchTarget(R.string.pref_playlist_mode_title),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SearchablePreference.kt
@@ -945,6 +945,15 @@ object SearchablePreferences {
       )
       add(
         SearchablePreference(
+          titleRes = R.string.pref_audio_mini_player_track_switching_title,
+          summaryRes = R.string.pref_audio_mini_player_track_switching_summary,
+          keywords = listOf("mini player", "background", "switch", "song", "audio", "music", "change"),
+          category = "Audio",
+          screen = AudioPreferencesScreen,
+        ),
+      )
+      add(
+        SearchablePreference(
           titleRes = R.string.pref_autoplay_next_audio_title,
           summaryRes = R.string.pref_autoplay_next_audio_summary,
           keywords = listOf("autoplay", "next", "audio", "music", "advance", "continuous"),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SearchablePreference.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SearchablePreference.kt
@@ -945,6 +945,15 @@ object SearchablePreferences {
       )
       add(
         SearchablePreference(
+          titleRes = R.string.pref_autoplay_next_audio_title,
+          summaryRes = R.string.pref_autoplay_next_audio_summary,
+          keywords = listOf("autoplay", "next", "audio", "music", "advance", "continuous"),
+          category = "Audio",
+          screen = AudioPreferencesScreen,
+        ),
+      )
+      add(
+        SearchablePreference(
           titleRes = R.string.pref_video_background_playback_title,
           summaryRes = R.string.pref_video_background_playback_summary,
           keywords = listOf("background", "playback", "video", "service", "media"),
@@ -1332,7 +1341,6 @@ object SearchablePreferences {
         category = "Player",
         screen = PlayerPreferencesScreen,
         anchorItemIndex = 1,
-        SearchEntrySpec(R.string.pref_autoplay_next_audio_title, listOf("autoplay", "next", "audio", "music")),
         SearchEntrySpec(R.string.pref_playlist_mode_title, listOf("playlist", "next", "previous", "navigation", "queue")),
         SearchEntrySpec(R.string.pref_enable_video_mini_player_title, listOf("mini player", "video", "background", "continue")),
         SearchEntrySpec(R.string.ui_show_media_info_in_chooser, listOf("media info", "chooser", "open with", "system")),
@@ -1442,6 +1450,7 @@ object SearchablePreferences {
         category = "Audio",
         screen = AudioPreferencesScreen,
         anchorItemIndex = 5,
+        SearchEntrySpec(R.string.pref_autoplay_next_audio_title, listOf("autoplay", "next", "audio", "music")),
         SearchEntrySpec(R.string.pref_audio_drc_title, listOf("audio", "dynamic range", "compression", "drc", "loudness")),
         SearchEntrySpec(R.string.pref_lyrics_auto_translate, listOf("lyrics", "translation", "automatic", "language")),
         SearchEntrySpec(R.string.pref_lyrics_target_language, listOf("lyrics", "translation", "target", "language")),

--- a/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SettingsSearchNavigation.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/ui/preferences/SettingsSearchNavigation.kt
@@ -152,6 +152,7 @@ private val settingsSearchListAnchors: Map<Screen, List<SettingsSearchListAnchor
         SettingsSearchListAnchor(titleRes = R.string.pref_audio_pitch_correction_title, itemIndex = 5),
         SettingsSearchListAnchor(titleRes = R.string.pref_audio_volume_normalization_title, itemIndex = 5),
         SettingsSearchListAnchor(titleRes = R.string.pref_audio_background_playback_title, itemIndex = 5),
+        SettingsSearchListAnchor(titleRes = R.string.pref_autoplay_next_audio_title, itemIndex = 5),
         SettingsSearchListAnchor(titleRes = R.string.pref_audio_channels, itemIndex = 5),
         SettingsSearchListAnchor(titleRes = R.string.pref_audio_volume_boost_cap, itemIndex = 5),
       ),

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/JellyfinSessionReporter.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/JellyfinSessionReporter.kt
@@ -11,12 +11,16 @@ package app.gyrolet.mpvrx.utils.media
 
 import android.net.Uri
 import android.util.Log
+import app.gyrolet.mpvrx.data.jellyfin.JellyfinClient
+import app.gyrolet.mpvrx.data.jellyfin.JellyfinClient.Companion.addJellyfinHeaders
 import app.gyrolet.mpvrx.network.SharedHttpClient
 import app.gyrolet.mpvrx.network.awaitResponse
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -24,23 +28,34 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class JellyfinSessionReporter(
   private val baseUrl: String,
   private val itemId: String,
   private val apiKey: String,
-  private val playSessionId: String?,
-  private val mediaSourceId: String?,
-  private val coroutineScope: CoroutineScope,
+  private val playSessionId: String,
+  private val mediaSourceId: String,
   private val httpClient: OkHttpClient = defaultHttpClient,
 ) {
+  private val reporterScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
   companion object {
     private const val TAG = "JellyfinSessionReporter"
 
     // Ticks per millisecond in Jellyfin (1 tick = 100 nanoseconds = 10,000 ticks per millisecond)
     private const val TICKS_PER_MILLISECOND = 10000L
     private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private val json =
+      Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+        explicitNulls = false
+      }
 
     private val defaultHttpClient by lazy {
       SharedHttpClient.derive {
@@ -51,8 +66,8 @@ class JellyfinSessionReporter(
 
     fun create(
       url: String,
-      coroutineScope: CoroutineScope,
       httpClient: OkHttpClient? = null,
+      fallbackToken: String? = null,
     ): JellyfinSessionReporter? {
       try {
         val uri = Uri.parse(url)
@@ -66,9 +81,16 @@ class JellyfinSessionReporter(
           return null
         }
         val itemId = pathSegments[mediaIndex + 1]
-        val apiKey = uri.getQueryParameter("api_key") ?: uri.getQueryParameter("ApiKey") ?: return null
-        val playSessionId = uri.getQueryParameter("playSessionId") ?: uri.getQueryParameter("PlaySessionId")
-        val mediaSourceId = uri.getQueryParameter("mediaSourceId") ?: uri.getQueryParameter("MediaSourceId")
+        val apiKey = uri.getQueryParameter("api_key")
+          ?: uri.getQueryParameter("ApiKey")
+          ?: fallbackToken
+          ?: return null
+        val playSessionId = uri.getQueryParameter("playSessionId")
+          ?: uri.getQueryParameter("PlaySessionId")
+          ?: UUID.randomUUID().toString().replace("-", "")
+        val mediaSourceId = uri.getQueryParameter("mediaSourceId")
+          ?: uri.getQueryParameter("MediaSourceId")
+          ?: itemId
 
         val scheme = uri.scheme ?: "http"
         val authority = uri.encodedAuthority ?: return null
@@ -90,7 +112,6 @@ class JellyfinSessionReporter(
           apiKey = apiKey,
           playSessionId = playSessionId,
           mediaSourceId = mediaSourceId,
-          coroutineScope = coroutineScope,
           httpClient = httpClient ?: defaultHttpClient,
         )
       } catch (e: Exception) {
@@ -109,6 +130,7 @@ class JellyfinSessionReporter(
     val CanSeek: Boolean = true,
     val IsPaused: Boolean = false,
     val IsMuted: Boolean = false,
+    val PlayMethod: String = "DirectPlay",
   )
 
   @Serializable
@@ -120,6 +142,8 @@ class JellyfinSessionReporter(
     val CanSeek: Boolean = true,
     val IsPaused: Boolean = false,
     val IsMuted: Boolean = false,
+    val PlayMethod: String = "DirectPlay",
+    val EventName: String? = null,
   )
 
   @Serializable
@@ -131,16 +155,17 @@ class JellyfinSessionReporter(
   )
 
   fun reportPlaybackStart(positionMs: Long) {
-    coroutineScope.launch(Dispatchers.IO) {
+    reporterScope.launch {
       val urlString = "$baseUrl/Sessions/Playing?api_key=$apiKey"
       val info =
         PlaybackStartInfo(
           ItemId = itemId,
           PlaySessionId = playSessionId,
           MediaSourceId = mediaSourceId,
-          PositionTicks = positionMs * TICKS_PER_MILLISECOND,
+          PositionTicks = (positionMs.coerceAtLeast(0L)) * TICKS_PER_MILLISECOND,
+          PlayMethod = "DirectPlay",
         )
-      val jsonBody = Json.encodeToString(info)
+      val jsonBody = json.encodeToString(info)
       sendPostRequest(urlString, jsonBody)
     }
   }
@@ -148,33 +173,36 @@ class JellyfinSessionReporter(
   fun reportPlaybackProgress(
     positionMs: Long,
     isPaused: Boolean,
+    eventName: String? = null,
   ) {
-    coroutineScope.launch(Dispatchers.IO) {
+    reporterScope.launch {
       val urlString = "$baseUrl/Sessions/Playing/Progress?api_key=$apiKey"
       val info =
         PlaybackProgressInfo(
           ItemId = itemId,
           PlaySessionId = playSessionId,
           MediaSourceId = mediaSourceId,
-          PositionTicks = positionMs * TICKS_PER_MILLISECOND,
+          PositionTicks = (positionMs.coerceAtLeast(0L)) * TICKS_PER_MILLISECOND,
           IsPaused = isPaused,
+          PlayMethod = "DirectPlay",
+          EventName = eventName,
         )
-      val jsonBody = Json.encodeToString(info)
+      val jsonBody = json.encodeToString(info)
       sendPostRequest(urlString, jsonBody)
     }
   }
 
   fun reportPlaybackStop(positionMs: Long) {
-    coroutineScope.launch(Dispatchers.IO) {
+    reporterScope.launch {
       val urlString = "$baseUrl/Sessions/Playing/Stopped?api_key=$apiKey"
       val info =
         PlaybackStopInfo(
           ItemId = itemId,
           PlaySessionId = playSessionId,
           MediaSourceId = mediaSourceId,
-          PositionTicks = positionMs * TICKS_PER_MILLISECOND,
+          PositionTicks = (positionMs.coerceAtLeast(0L)) * TICKS_PER_MILLISECOND,
         )
-      val jsonBody = Json.encodeToString(info)
+      val jsonBody = json.encodeToString(info)
       sendPostRequest(urlString, jsonBody)
     }
   }
@@ -187,17 +215,17 @@ class JellyfinSessionReporter(
       val request =
         Request.Builder()
           .url(urlString)
+          .addJellyfinHeaders(apiKey)
           .header("Content-Type", "application/json")
-          .header("X-Emby-Token", apiKey)
-          .header("User-Agent", "mpvRx/1.0")
+          .header("User-Agent", "mpvRx/${JellyfinClient.VERSION}")
           .post(jsonBody.toRequestBody(JSON_MEDIA_TYPE))
           .build()
 
       httpClient.newCall(request).awaitResponse().use { response ->
         if (response.isSuccessful) {
-          Log.d(TAG, "Successfully reported status to Jellyfin: $urlString")
+          Log.d(TAG, "Successfully reported status to Jellyfin ($urlString): ${response.code}")
         } else {
-          Log.e(TAG, "Failed to report status to Jellyfin: $urlString, response code: ${response.code}")
+          Log.e(TAG, "Failed to report status to Jellyfin ($urlString): ${response.code} ${response.message}")
         }
       }
     } catch (cancellation: CancellationException) {
@@ -207,3 +235,4 @@ class JellyfinSessionReporter(
     }
   }
 }
+

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaPathUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaPathUtils.kt
@@ -24,11 +24,16 @@ import app.gyrolet.mpvrx.ui.player.PlaybackSession
  * "content://media/123".fileExtension() == ""
  * ```
  */
-fun String.fileExtension(): String =
-  substringBefore('?')
-    .substringBefore('#')
-    .substringAfterLast('.', "")
-    .lowercase()
+fun String.fileExtension(): String {
+  val cleanPath = substringBefore('?').substringBefore('#')
+  val lastSlash = cleanPath.lastIndexOf('/')
+  val lastDot = cleanPath.lastIndexOf('.')
+  return if (lastDot > lastSlash && lastDot != -1 && lastDot < cleanPath.length - 1) {
+    cleanPath.substring(lastDot + 1).lowercase()
+  } else {
+    ""
+  }
+}
 
 /**
  * Returns the MPV seek mode string based on the user's precise-seeking preference

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
@@ -14,13 +14,18 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.MediaStore
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import app.gyrolet.mpvrx.domain.media.model.Video
 import app.gyrolet.mpvrx.domain.torrent.isTorrentSource
+import app.gyrolet.mpvrx.ui.browser.NavigationBarState
+import app.gyrolet.mpvrx.ui.player.MediaPlaybackService
 import app.gyrolet.mpvrx.ui.player.PlaybackIdentity
 import app.gyrolet.mpvrx.ui.player.PlaybackItem
 import app.gyrolet.mpvrx.ui.player.PlaybackPerformanceTrace
+import app.gyrolet.mpvrx.ui.player.PlaybackPhase
+import app.gyrolet.mpvrx.ui.player.PlaybackSession
 import app.gyrolet.mpvrx.ui.player.PlayerActivity
 import app.gyrolet.mpvrx.ui.player.PlayerLookupHints
 import app.gyrolet.mpvrx.ui.player.PreparedPlaybackLaunchStore
@@ -60,6 +65,48 @@ data class PlaybackSubtitleTrack(
  * bypassing MediaUtils.
  */
 object MediaUtils {
+  fun shouldPlayInMiniPlayerOnly(isAudio: Boolean): Boolean {
+    if (!isAudio) return false
+    val audioPreferences =
+      runCatching { org.koin.core.context.GlobalContext.get().get<app.gyrolet.mpvrx.preferences.AudioPreferences>() }.getOrNull()
+    if (audioPreferences?.miniPlayerTrackSwitching?.get() != true) return false
+    val sessionState = PlaybackSession.state.value
+    val isServiceActive = MediaPlaybackService.isForegroundActive()
+    val isMiniPlayerVisible = NavigationBarState.isMiniPlayerVisible
+    val isSessionActive =
+      sessionState.phase == PlaybackPhase.READY ||
+        sessionState.phase == PlaybackPhase.BACKGROUND
+    return isServiceActive || isMiniPlayerVisible || isSessionActive
+  }
+
+  fun playInMiniPlayer(
+    context: Context,
+    queueItems: List<PlaybackItem>,
+    startIndex: Int = 0,
+  ) {
+    if (queueItems.isEmpty()) return
+    val selectedIndex = startIndex.coerceIn(queueItems.indices)
+    PlaybackSession.replaceQueue(queueItems, selectedIndex, isExplicitQueue = true)
+    val item = queueItems[selectedIndex]
+    PlaybackSession.load(item)
+    PlaybackSession.setPropertyBoolean("pause", false)
+    PlaybackSession.markBackground()
+    NavigationBarState.isMiniPlayerVisible = true
+
+    val serviceIntent =
+      Intent(context, MediaPlaybackService::class.java).apply {
+        putExtra("media_title", item.title)
+        putExtra("media_artist", item.artist)
+        putExtra("media_uri", item.originalUri)
+        putExtra("media_identifier", item.stableId)
+        putExtra("audio_background_playback", true)
+        putExtra("is_audio", true)
+      }
+    runCatching {
+      ContextCompat.startForegroundService(context, serviceIntent)
+    }
+  }
+
   fun playFiles(
     videos: List<Video>,
     context: Context,
@@ -73,23 +120,31 @@ object MediaUtils {
       return
     }
 
+    val selected = videos[selectedIndex]
+    val isAudioMedia = selected.isAudio || videos.all { it.isAudio }
+
     val queueItems =
       videos.map { video ->
         PlaybackItem.fromUri(
           uri = video.uri.toString(),
           stableId = video.path.takeIf(String::isNotBlank)?.let(PlaybackIdentity::forLocalPath),
           title = video.displayName,
-          mimeType = video.mimeType,
+          mimeType = if (video.isAudio) "audio/*" else video.mimeType,
           durationSeconds = (video.duration / 1000L).toInt().takeIf { it > 0 },
         )
       }
+
+    if (shouldPlayInMiniPlayerOnly(isAudioMedia)) {
+      playInMiniPlayer(context, queueItems, selectedIndex)
+      return
+    }
+
     val launchToken =
       PreparedPlaybackLaunchStore.stage(
         items = queueItems,
         currentIndex = selectedIndex,
         isExplicitQueue = true,
       )
-    val selected = videos[selectedIndex]
     val intent =
       Intent(Intent.ACTION_VIEW, selected.uri).apply {
         setClass(context, PlayerActivity::class.java)
@@ -143,135 +198,95 @@ object MediaUtils {
     isAudio: Boolean = false,
     playlistDurationsSeconds: List<Int> = emptyList(),
   ) {
-    val uri =
-      when (source) {
-        is Video -> {
-          // Video.path is already MediaStore/library metadata. Avoid a synchronous filesystem
-          // stat on the UI click path before startActivity(); stale media will fail at the same
-          // playback/open stage where the content URI itself is validated.
-          val localPath = source.path.takeIf(String::isNotBlank)
-          // Recents stores a durable filesystem path, while normal library playback is usually
-          // launched with a MediaStore content:// URI. Playback state is keyed from the launch
-          // URI, so reopening the same file as file:// created a different key and restarted at 0.
-          // Resolve the path back to its MediaStore URI for history/quick-play launches only when
-          // the Video does not already carry a content URI.
-          val playbackUri =
-            if (launchSource.isHistoryResumeLaunch() &&
-              localPath != null &&
-              !source.uri.scheme.equals("content", ignoreCase = true)
-            ) {
-              resolveMediaStoreUri(context, localPath, source.isAudio) ?: source.uri
-            } else {
-              source.uri
-            }
-          val intent = Intent(Intent.ACTION_VIEW, playbackUri)
-          val torrentSource = playbackUri.toString().takeIf { isTorrentSource(it, source.mimeType) }
-          intent.setClass(
-            context,
-            if (torrentSource != null && torrentFileIndex == null && torrentPreparationId == null) {
-              TorrentSelectionActivity::class.java
-            } else {
-              PlayerActivity::class.java
-            },
-          )
-          intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-          intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-          intent.putExtra("internal_launch", true) // Enables subtitle autoload
-          localPath?.let { intent.putExtra("local_media_path", it) }
-          intent.putExtra("is_audio", source.isAudio)
-          intent.putExtra(PlayerActivity.EXTRA_VIDEO_WIDTH, source.width)
-          intent.putExtra(PlayerActivity.EXTRA_VIDEO_HEIGHT, source.height)
-          applyPlaybackExtras(
-            intent = intent,
-            launchSource = launchSource,
-            title =
-              title
-                ?: source.title.takeIf { shouldForwardVideoTitle(source) && it.isNotBlank() }
-                ?: source.displayName.takeIf { shouldForwardVideoTitle(source) && it.isNotBlank() }
-                ?: if (launchSource != null &&
-                  (launchSource.contains("playlist") || launchSource == "m3u_playlist")
-                ) {
-                  source.displayName
-                } else {
-                  null
-                },
-            headers = headers,
-            subtitles = subtitles,
-            enabledSubtitles = enabledSubtitles,
-            subtitleTracks = subtitleTracks,
-            lookupHints = lookupHints,
-            torrentFileIndex = torrentFileIndex,
-            torrentPreparationId = torrentPreparationId,
-            torrentSource = torrentSource,
-            mediaDescription = mediaDescription,
-            posterUrl = posterUrl,
-            backdropUrl = backdropUrl,
-            playlist = playlist,
-            playlistIndex = playlistIndex,
-            playlistTitles = playlistTitles,
-            playlistArtists = playlistArtists,
-            playlistArtworkUrls = playlistArtworkUrls,
-            isAudio = isAudio,
-            playlistDurationsSeconds = playlistDurationsSeconds.ifEmpty {
-              listOf((source.duration / 1000L).toInt().takeIf { it > 0 } ?: 0)
-            },
-          )
-          PlaybackPerformanceTrace.mark("OPEN_REQUEST", "source=${launchSource ?: "library"} kind=video")
-          context.startActivity(intent)
-          return
-        }
+    val videoSource = source as? Video
+    val localPath =
+      when {
+        videoSource != null -> videoSource.path.takeIf(String::isNotBlank)
+        source is String && source.startsWith("file://", ignoreCase = true) -> source.removePrefix("file://")
+        source is String && source.startsWith("/") -> source
+        source is Uri && source.scheme.equals("file", ignoreCase = true) -> source.path
+        else -> null
+      }?.takeIf(String::isNotBlank)
 
-        is String -> {
-          if (source.isBlank()) return
-          // Handle file paths with # characters properly
-          if (source.startsWith("/") || source.startsWith("file://")) {
-            // It's a local file path - create URI safely
-            val filePath =
-              if (source.startsWith("file://")) {
-                source.removePrefix("file://")
-              } else {
-                source
-              }
-            Uri.fromFile(java.io.File(filePath))
+    val playbackUri: Uri =
+      when {
+        videoSource != null -> {
+          if (launchSource.isHistoryResumeLaunch() &&
+            localPath != null &&
+            !videoSource.uri.scheme.equals("content", ignoreCase = true)
+          ) {
+            resolveMediaStoreUri(context, localPath, videoSource.isAudio) ?: videoSource.uri
           } else {
-            // It's likely a network URI - parse normally
+            videoSource.uri
+          }
+        }
+        source is String -> {
+          if (source.isBlank()) return
+          if (source.startsWith("/") || source.startsWith("file://")) {
+            val filePath = if (source.startsWith("file://")) source.removePrefix("file://") else source
+            Uri.fromFile(File(filePath))
+          } else {
             val parsedUri = source.toUri()
             parsedUri.scheme?.let { parsedUri } ?: "file://$source".toUri()
           }
         }
-
-        is android.net.Uri -> source
+        source is Uri -> source
         else -> {
           android.util.Log.e("MediaUtils", "Unsupported source type: ${source::class.java}")
           return
         }
       }
 
-    // Keep the path handoff syntactic here. File existence is validated by the actual media open;
-    // probing storage before startActivity() adds avoidable main-thread I/O to every local launch.
-    val localPath =
-      when {
-        source is String && source.startsWith("file://", ignoreCase = true) -> source.removePrefix("file://")
-        source is String && source.startsWith("/") -> source
-        uri.scheme.equals("file", ignoreCase = true) -> uri.path
-        else -> null
-      }?.takeIf(String::isNotBlank)
+    val isAudioMedia =
+      isAudio ||
+        videoSource?.isAudio == true ||
+        (localPath?.let { File(it).extension.lowercase() in FileTypeUtils.AUDIO_EXTENSIONS } ?: false)
 
-    val playbackUri =
-      if (launchSource.isHistoryResumeLaunch() && localPath != null) {
-        val isAudio = File(localPath).extension.lowercase() in FileTypeUtils.AUDIO_EXTENSIONS
-        resolveMediaStoreUri(context, localPath, isAudio) ?: uri
-      } else {
-        uri
-      }
+    if (shouldPlayInMiniPlayerOnly(isAudioMedia)) {
+      val queueItems =
+        if (playlist.isNotEmpty()) {
+          val selIndex = playlistIndex.coerceIn(playlist.indices)
+          playlist.mapIndexed { idx, pUri ->
+            PlaybackItem.fromUri(
+              uri = pUri.toString(),
+              title = playlistTitles.getOrNull(idx) ?: title,
+              artist = playlistArtists.getOrNull(idx),
+              mimeType = "audio/*",
+              headers = headers.orEmpty(),
+              artworkUri =
+                playlistArtworkUrls.getOrNull(idx)?.takeIf(String::isNotBlank)
+                  ?: posterUrl?.takeIf { idx == selIndex },
+              durationSeconds = playlistDurationsSeconds.getOrNull(idx)?.takeIf { it > 0 },
+            )
+          }
+        } else {
+          val durSec =
+            playlistDurationsSeconds.firstOrNull()?.takeIf { it > 0 }
+              ?: videoSource?.let { (it.duration / 1000L).toInt().takeIf { d -> d > 0 } }
+          listOf(
+            PlaybackItem.fromUri(
+              uri = playbackUri.toString(),
+              stableId = localPath?.let(PlaybackIdentity::forLocalPath),
+              title = title ?: videoSource?.displayName,
+              artist = playlistArtists.firstOrNull(),
+              mimeType = "audio/*",
+              headers = headers.orEmpty(),
+              artworkUri = posterUrl ?: playlistArtworkUrls.firstOrNull(),
+              durationSeconds = durSec,
+            ),
+          )
+        }
+      playInMiniPlayer(context, queueItems, playlistIndex)
+      return
+    }
 
     val intent = Intent(Intent.ACTION_VIEW, playbackUri)
     val torrentSource =
       when (source) {
         is String -> source.trim()
         is Uri -> source.toString()
-        else -> playbackUri.toString()
-      }.takeIf { isTorrentSource(it) }
+        else -> playbackUri.toString().takeIf { videoSource != null && isTorrentSource(it, videoSource.mimeType) }
+      }?.takeIf { isTorrentSource(it) }
     intent.setClass(
       context,
       if (torrentSource != null && torrentFileIndex == null && torrentPreparationId == null) {
@@ -282,11 +297,27 @@ object MediaUtils {
     )
     intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    intent.putExtra("internal_launch", true)
     localPath?.let { intent.putExtra("local_media_path", it) }
+    if (videoSource != null) {
+      intent.putExtra("is_audio", videoSource.isAudio)
+      intent.putExtra(PlayerActivity.EXTRA_VIDEO_WIDTH, videoSource.width)
+      intent.putExtra(PlayerActivity.EXTRA_VIDEO_HEIGHT, videoSource.height)
+    }
     applyPlaybackExtras(
       intent = intent,
       launchSource = launchSource,
-      title = title,
+      title =
+        title
+          ?: videoSource?.title?.takeIf { shouldForwardVideoTitle(videoSource) && it.isNotBlank() }
+          ?: videoSource?.displayName?.takeIf { shouldForwardVideoTitle(videoSource) && it.isNotBlank() }
+          ?: if (launchSource != null &&
+            (launchSource.contains("playlist") || launchSource == "m3u_playlist")
+          ) {
+            videoSource?.displayName
+          } else {
+            null
+          },
       headers = headers,
       subtitles = subtitles,
       enabledSubtitles = enabledSubtitles,
@@ -303,10 +334,15 @@ object MediaUtils {
       playlistTitles = playlistTitles,
       playlistArtists = playlistArtists,
       playlistArtworkUrls = playlistArtworkUrls,
-      isAudio = isAudio,
-      playlistDurationsSeconds = playlistDurationsSeconds,
+      isAudio = isAudioMedia,
+      playlistDurationsSeconds = playlistDurationsSeconds.ifEmpty {
+        videoSource?.let { listOf((it.duration / 1000L).toInt().takeIf { d -> d > 0 } ?: 0) } ?: emptyList()
+      },
     )
-    PlaybackPerformanceTrace.mark("OPEN_REQUEST", "source=${launchSource ?: "direct"} kind=${uri.scheme ?: "path"}")
+    PlaybackPerformanceTrace.mark(
+      "OPEN_REQUEST",
+      "source=${launchSource ?: (if (videoSource != null) "library" else "direct")} kind=${if (videoSource != null) "video" else (playbackUri.scheme ?: "path")}",
+    )
     context.startActivity(intent)
   }
 

--- a/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
+++ b/app/src/main/java/app/gyrolet/mpvrx/utils/media/MediaUtils.kt
@@ -80,6 +80,7 @@ object MediaUtils {
           stableId = video.path.takeIf(String::isNotBlank)?.let(PlaybackIdentity::forLocalPath),
           title = video.displayName,
           mimeType = video.mimeType,
+          durationSeconds = (video.duration / 1000L).toInt().takeIf { it > 0 },
         )
       }
     val launchToken =
@@ -211,7 +212,9 @@ object MediaUtils {
             playlistArtists = playlistArtists,
             playlistArtworkUrls = playlistArtworkUrls,
             isAudio = isAudio,
-            playlistDurationsSeconds = playlistDurationsSeconds,
+            playlistDurationsSeconds = playlistDurationsSeconds.ifEmpty {
+              listOf((source.duration / 1000L).toInt().takeIf { it > 0 } ?: 0)
+            },
           )
           PlaybackPerformanceTrace.mark("OPEN_REQUEST", "source=${launchSource ?: "library"} kind=video")
           context.startActivity(intent)
@@ -397,6 +400,10 @@ object MediaUtils {
       intent.putExtra(PlayerActivity.EXTRA_PREPARED_PLAYBACK_TOKEN, launchToken)
       intent.putExtra("playlistIndex", selectedIndex)
       intent.putExtra("playlist_index", selectedIndex)
+    }
+    val selectedDuration = playlistDurationsSeconds.getOrNull(if (playlist.isNotEmpty()) playlistIndex else 0)?.takeIf { it > 0 }
+    if (selectedDuration != null) {
+      intent.putExtra("duration", selectedDuration)
     }
     launchSource?.let { intent.putExtra("launch_source", it) }
     title?.let {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -487,6 +487,8 @@
   <string name="background_playback_title">التشغيل في الخلفية</string>
   <string name="pref_audio_background_playback_title">التشغيل في الخلفية (مشغل الصوت)</string>
   <string name="pref_audio_background_playback_summary">مواصلة تشغيل الصوت عند مغادرة مشغل الصوت أو إيقاف الشاشة</string>
+  <string name="pref_audio_mini_player_track_switching_title">تغيير الأغاني في المشغل المصغر</string>
+  <string name="pref_audio_mini_player_track_switching_summary">عندما يكون المشغل المصغر أو التشغيل في الخلفية نشطًا، يؤدي اختيار أغنية أخرى إلى تحديث المشغل المصغر دون فتح المشغل الكامل</string>
   <string name="pref_video_background_playback_title">التشغيل في الخلفية (مشغل الفيديو)</string>
   <string name="pref_video_background_playback_summary">مواصلة تشغيل صوت الفيديو عند مغادرة مشغل الفيديو أو إيقاف الشاشة</string>
   <string name="deselect_all">إلغاء تحديد الكل</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -487,6 +487,8 @@ Weiter: NEXT</string>
   <string name="background_playback_title">Hintergrundwiedergabe</string>
   <string name="pref_audio_background_playback_title">Hintergrundwiedergabe (Audio-Player)</string>
   <string name="pref_audio_background_playback_summary">Audio beim Verlassen des Audio-Players oder Ausschalten des Bildschirms weiterspielen</string>
+  <string name="pref_audio_mini_player_track_switching_title">Titel im Mini-Player wechseln</string>
+  <string name="pref_audio_mini_player_track_switching_summary">Wenn der Mini-Player oder die Hintergrundwiedergabe aktiv ist, wechselt die Titelauswahl das Lied im Mini-Player, ohne den Vollbild-Player zu öffnen</string>
   <string name="pref_video_background_playback_title">Hintergrundwiedergabe (Video-Player)</string>
   <string name="pref_video_background_playback_summary">Video-Audio beim Verlassen des Video-Players oder Ausschalten des Bildschirms weiterspielen</string>
   <string name="deselect_all">Auswahl aufheben</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -487,6 +487,8 @@ Siguiente: NEXT</string>
   <string name="background_playback_title">Reproducción en segundo plano</string>
   <string name="pref_audio_background_playback_title">Reproducción en segundo plano (Reproductor de Audio)</string>
   <string name="pref_audio_background_playback_summary">Mantener la reproducción al salir del reproductor de audio o apagar la pantalla</string>
+  <string name="pref_audio_mini_player_track_switching_title">Cambiar canciones en el mini reproductor</string>
+  <string name="pref_audio_mini_player_track_switching_summary">Cuando el mini reproductor o la reproducción en segundo plano estén activos, seleccionar otra canción actualiza el mini reproductor sin abrir el reproductor completo</string>
   <string name="pref_video_background_playback_title">Reproducción en segundo plano (Reproductor de Video)</string>
   <string name="pref_video_background_playback_summary">Mantener el audio del video al salir del reproductor de video o apagar la pantalla</string>
   <string name="deselect_all">Deseleccionar todo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -487,6 +487,8 @@ Suivant : NEXT</string>
   <string name="background_playback_title">Lecture en arrière-plan</string>
   <string name="pref_audio_background_playback_title">Lecture en arrière-plan (Lecteur Audio)</string>
   <string name="pref_audio_background_playback_summary">Continuer la lecture audio en quittant le lecteur audio ou en éteignant l\’écran</string>
+  <string name="pref_audio_mini_player_track_switching_title">Changer de morceau dans le mini-lecteur</string>
+  <string name="pref_audio_mini_player_track_switching_summary">Lorsque le mini-lecteur ou la lecture en arrière-plan est active, sélectionner un autre morceau met à jour le mini-lecteur sans ouvrir le lecteur complet</string>
   <string name="pref_video_background_playback_title">Lecture en arrière-plan (Lecteur Vidéo)</string>
   <string name="pref_video_background_playback_summary">Continuer la lecture du son de la vidéo en quittant le lecteur vidéo ou en éteignant l\’écran</string>
   <string name="deselect_all">Tout désélectionner</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -486,6 +486,8 @@
   <string name="background_playback_title">बैकग्राउंड प्लेबैक</string>
   <string name="pref_audio_background_playback_title">ऑडियो प्लेयर बैकग्राउंड प्लेबैक</string>
   <string name="pref_audio_background_playback_summary">ऑडियो प्लेयर से बाहर जाने या स्क्रीन बंद करने पर ऑडियो चलता रखें</string>
+  <string name="pref_audio_mini_player_track_switching_title">मिनी प्लेयर में गाने बदलें</string>
+  <string name="pref_audio_mini_player_track_switching_summary">जब मिनी प्लेयर या बैकग्राउंड प्लेबैक सक्रिय हो, तो दूसरा गाना चुनने पर पूरा प्लेयर खोले बिना मिनी प्लेयर में गाना बदल जाता है</string>
   <string name="pref_video_background_playback_title">वीडियो प्लेयर बैकग्राउंड प्लेबैक</string>
   <string name="pref_video_background_playback_summary">वीडियो प्लेयर से बाहर जाने या स्क्रीन बंद करने पर वीडियो का ऑडियो चलता रखें</string>
   <string name="deselect_all">सभी अनसिलेक्ट करें</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -487,6 +487,8 @@
   <string name="background_playback_title">バックグラウンド再生</string>
   <string name="pref_audio_background_playback_title">バックグラウンド再生（オーディオプレイヤー）</string>
   <string name="pref_audio_background_playback_summary">オーディオプレイヤーを離れたり画面をオフにしても音声を再生し続ける</string>
+  <string name="pref_audio_mini_player_track_switching_title">ミニプレイヤーで曲を切り替える</string>
+  <string name="pref_audio_mini_player_track_switching_summary">ミニプレイヤーまたはバックグラウンド再生が有効な場合、別の曲を選択しても全画面プレイヤーを開かずにミニプレイヤーで切り替えます</string>
   <string name="pref_video_background_playback_title">バックグラウンド再生（ビデオプレイヤー）</string>
   <string name="pref_video_background_playback_summary">ビデオプレイヤーを離れたり画面をオフにしても動画の音声を再生し続ける</string>
   <string name="deselect_all">すべて選択解除</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -487,6 +487,8 @@ Próximo: NEXT</string>
   <string name="background_playback_title">Reprodução em segundo plano</string>
   <string name="pref_audio_background_playback_title">Reprodução em segundo plano (Reprodutor de Áudio)</string>
   <string name="pref_audio_background_playback_summary">Manter o áudio tocando ao sair do reprodutor de áudio ou desligar a tela</string>
+  <string name="pref_audio_mini_player_track_switching_title">Trocar músicas no mini player</string>
+  <string name="pref_audio_mini_player_track_switching_summary">Quando o mini player ou a reprodução em segundo plano estiver ativa, selecionar outra música atualiza o mini player sem abrir o player completo</string>
   <string name="pref_video_background_playback_title">Reprodução em segundo plano (Reprodutor de Vídeo)</string>
   <string name="pref_video_background_playback_summary">Manter o áudio do vídeo tocando ao sair do reprodutor de vídeo ou desligar a tela</string>
   <string name="deselect_all">Desmarcar tudo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -487,6 +487,8 @@
   <string name="background_playback_title">Фоновое воспроизведение</string>
   <string name="pref_audio_background_playback_title">Фоновое воспроизведение (Аудиоплеер)</string>
   <string name="pref_audio_background_playback_summary">Продолжать воспроизведение аудио при выходе из аудиоплеера или выключении экрана</string>
+  <string name="pref_audio_mini_player_track_switching_title">Переключать треки в мини-плеере</string>
+  <string name="pref_audio_mini_player_track_switching_summary">Когда мини-плеер или фоновое воспроизведение активны, выбор другого трека обновляет мини-плеер без открытия полноэкранного плеера</string>
   <string name="pref_video_background_playback_title">Фоновое воспроизведение (Видеоплеер)</string>
   <string name="pref_video_background_playback_summary">Продолжать воспроизведение звука видео при выходе из видеоплеера или выключении экрана</string>
   <string name="deselect_all">Снять выделение</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -487,6 +487,8 @@
   <string name="background_playback_title">后台播放</string>
   <string name="pref_audio_background_playback_title">后台播放（音频播放器）</string>
   <string name="pref_audio_background_playback_summary">在离开音频播放器或关闭屏幕时保持音频播放</string>
+  <string name="pref_audio_mini_player_track_switching_title">在迷你播放器中切歌</string>
+  <string name="pref_audio_mini_player_track_switching_summary">当迷你播放器或后台播放处于活动状态时，选择另一首歌曲将直接在迷你播放器中切换，而无需打开完整播放器</string>
   <string name="pref_video_background_playback_title">后台播放（视频播放器）</string>
   <string name="pref_video_background_playback_summary">在离开视频播放器或关闭屏幕时保持视频音频播放</string>
   <string name="deselect_all">取消全选</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -570,6 +570,8 @@
   <string name="background_playback_title">Background playback</string>
   <string name="pref_audio_background_playback_title">Audio Player Background Playback</string>
   <string name="pref_audio_background_playback_summary">Keep audio playing when leaving the audio player or turning off screen</string>
+  <string name="pref_audio_mini_player_track_switching_title">Switch songs in mini player</string>
+  <string name="pref_audio_mini_player_track_switching_summary">When mini player or background playback is active, selecting another song updates the mini player without opening the full player</string>
   <string name="pref_video_background_playback_title">Video Player Background Playback</string>
   <string name="pref_video_background_playback_summary">Keep video audio playing when leaving the video player or turning off screen</string>
   <string name="deselect_all">Deselect All</string>


### PR DESCRIPTION
## Summary

This PR groups several UX, UI, and playback fixes across Jellyfin browsing/session tracking, Music playback, and Player gesture interactions:

**1. Jellyfin Playback & Session Tracking:**

    - Fixed playback reporting sync and timestamp drift when communicating session updates to Jellyfin servers.
    - Ensured proper session ID refresh and session state transitions.

**2. Jellyfin Navigation & Library Display:**

    - Fixed navigation handling so switching to/from the Music tab does not hijack the Jellyfin browser tab state.
    - Fixed library card styling so that corner rounding applies only to the poster thumbnail rather than clipping the library title text.
    - Fixed TV Series & Season filtering logic (isVideoMedia) in Jellyfin library queries and added a fallback query to ensure all library "Latest" sections (such as Latest Series) populate correctly even if /Items/Latest returns empty.

**3. Music Duration Handling (Jellyfin & Navidrome):**

    - Added total playlist duration calculation and display across playlist grid cards, list items, carousels, and detail bottom sheets.
    - Resolved the issue in the audio player where the total track length initially showed 00:00 before updating by forwarding known track durations upfront and falling back cleanly.

**4. Player Gesture Seeking:**

    - When all OSDs/controls are hidden, horizontal swipe-seeking now only displays the top relative timestamp indicator (+/- seek time), hiding the bottom seekbar popup to keep the screen uncluttered.

